### PR TITLE
(2.15) NRG: Don't campaign as managed node outside the peer set

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -12797,7 +12797,11 @@ func (js *jetStream) clusterInfo(rg *raftGroup) *ClusterInfo {
 		if peer == id || slices.ContainsFunc(ci.Replicas, func(info *PeerInfo) bool { return info.Peer == peer }) {
 			continue
 		}
-		ci.Replicas = append(ci.Replicas, generatePeer(peer))
+		pi := generatePeer(peer)
+		// We know the peer is part of the assignment, but if we have a Raft node it
+		// wasn't reported as one of its peers, so it hasn't joined the group (yet).
+		pi.Pending = n != nil
+		ci.Replicas = append(ci.Replicas, pi)
 	}
 	// Order the result based on the name so that we get something consistent
 	// when doing repeated stream info in the CLI, etc...

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -7432,6 +7432,7 @@ func TestJetStreamClusterStreamScaleDownChangesRaftGroup(t *testing.T) {
 	cfg.Replicas = 3
 	_, err = js.UpdateStream(cfg)
 	require_NoError(t, err)
+	c.waitOnStreamLeader(globalAccountName, "TEST")
 
 	// Wait for some time to let the servers catch each other up. Can't use equality checks here.
 	time.Sleep(500 * time.Millisecond)

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -14142,6 +14142,53 @@ func TestJetStreamClusterMetaReplicasInJsz(t *testing.T) {
 	})
 }
 
+func TestJetStreamClusterPendingPeersReportedInClusterInfo(t *testing.T) {
+	js := &jetStream{srv: &Server{}}
+
+	peerInfo := func(ci *ClusterInfo, peer string) *PeerInfo {
+		t.Helper()
+		for _, pi := range ci.Replicas {
+			if pi.Peer == peer {
+				return pi
+			}
+		}
+		t.Fatalf("peer %q not reported in cluster info", peer)
+		return nil
+	}
+
+	// The assignment has scaled up to three peers, but only "a" has joined the
+	// Raft group so far. The peers that are only known from the assignment must
+	// be distinguishable from the one that's an actual peer of the group.
+	rg := &raftGroup{
+		Name:  "test",
+		Peers: []string{"a", "b", "c"},
+		node:  &raft{peers: map[string]*lps{"a": {}}},
+	}
+	ci := js.clusterInfo(rg)
+	require_Len(t, len(ci.Replicas), 3)
+	require_False(t, peerInfo(ci, "a").Pending)
+	require_True(t, peerInfo(ci, "b").Pending)
+	require_True(t, peerInfo(ci, "c").Pending)
+
+	// Once they've all joined the group nothing is pending anymore.
+	rg.node = &raft{peers: map[string]*lps{"a": {}, "b": {}, "c": {}}}
+	ci = js.clusterInfo(rg)
+	require_Len(t, len(ci.Replicas), 3)
+	for _, pi := range ci.Replicas {
+		require_False(t, pi.Pending)
+	}
+
+	// Without a Raft node we have no knowledge of group membership, so we can't
+	// claim any of the assigned peers are pending.
+	rg.node = nil
+	rg.Desired = &desiredRaftGroup{ID: "id", Cluster: "C1", Peers: []string{"a", "b", "c"}}
+	ci = js.clusterInfo(rg)
+	require_Len(t, len(ci.Replicas), 3)
+	for _, pi := range ci.Replicas {
+		require_False(t, pi.Pending)
+	}
+}
+
 func TestJetStreamClusterMigrationStatusReportedInClusterInfo(t *testing.T) {
 	js := &jetStream{srv: &Server{}}
 

--- a/server/raft.go
+++ b/server/raft.go
@@ -5759,6 +5759,14 @@ func (n *raft) switchToCandidate() {
 		return
 	}
 
+	// For managed groups the meta layer can assign us before the group leader has
+	// added us to the peer set. Do not campaign while we're not a member ourselves.
+	if n.managed && n.peers[n.id] == nil {
+		n.updateLeader(noLeader)
+		n.resetElect(minElectionTimeout)
+		return
+	}
+
 	if n.State() != Candidate {
 		n.debug("Switching to candidate")
 	} else {

--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -3759,6 +3759,39 @@ func TestNRGTrackPeerObserved(t *testing.T) {
 	require_True(t, n.LastHeardFromPeer("C").IsZero())
 }
 
+func TestNRGTrackPeerAutoAddOnlyUnmanaged(t *testing.T) {
+	n, cleanup := initSingleMemRaftNode(t)
+	defer cleanup()
+
+	nats0 := "S1Nunr6R" // "nats-0"
+	nats1 := "yrzKKRBu" // "nats-1"
+
+	n.state.Store(int32(Leader))
+	require_Equal(t, n.prop.len(), 0)
+
+	// As leader of an unmanaged group, hearing from an unknown peer
+	// proposes adding it to the group automatically.
+	require_NoError(t, n.trackPeer(nats0))
+	require_Equal(t, n.prop.len(), 1)
+	pe, ok := n.prop.popOne()
+	require_True(t, ok)
+	require_Equal(t, pe.Type, EntryAddPeer)
+	require_Equal(t, string(pe.Data), nats0)
+	// Unmanaged groups don't track observed peers.
+	require_Len(t, len(n.observed), 0)
+
+	// As leader of a managed group, the meta layer owns membership.
+	// Hearing from an unknown peer must not propose adding it, only
+	// record it as observed.
+	n.Lock()
+	n.managed = true
+	n.Unlock()
+	require_NoError(t, n.trackPeer(nats1))
+	require_Equal(t, n.prop.len(), 0)
+	require_Len(t, len(n.observed), 1)
+	require_False(t, n.LastHeardFromPeer(nats1).IsZero())
+}
+
 func TestNRGInitializeAndScaleUp(t *testing.T) {
 	n, cleanup := initSingleMemRaftNode(t)
 	defer cleanup()

--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -6781,6 +6781,51 @@ func TestNRGDontSwitchToCandidateWithInflightSelfMembershipChange(t *testing.T) 
 	require_Equal(t, n.State(), Candidate)
 }
 
+func TestNRGDontSwitchToCandidateAsManagedNodeOutsidePeerSet(t *testing.T) {
+	n, cleanup := initSingleMemRaftNode(t)
+	defer cleanup()
+
+	nats0 := "S1Nunr6R" // "nats-0"
+
+	// The meta layer can assign us to a group before the group leader has added
+	// us to the peer set. Simulate the leader's peer state overwriting our
+	// bootstrap peer set with a committed membership that excludes us.
+	n.Lock()
+	n.managed = true
+	n.processPeerState(&peerState{[]string{nats0}, 1, n.extSt})
+	n.Unlock()
+	_, ok := n.peers[n.id]
+	require_False(t, ok)
+
+	// We must not become a candidate while we're not in our own peer set, otherwise
+	// we could become leader outside the peer set and stall membership changes.
+	n.switchToCandidate()
+	require_Equal(t, n.State(), Follower)
+
+	// Receive the leader's peer state that adds us as a committed member.
+	n.Lock()
+	n.processPeerState(&peerState{[]string{nats0, n.id}, 2, n.extSt})
+	n.Unlock()
+	_, ok = n.peers[n.id]
+	require_True(t, ok)
+
+	// Now that we're a member, we can campaign.
+	n.switchToCandidate()
+	require_Equal(t, n.State(), Candidate)
+
+	// An unmanaged group doesn't have meta-assigned members, a node outside
+	// the peer set must still be able to campaign there.
+	n.switchToFollower(noLeader)
+	n.Lock()
+	n.managed = false
+	n.processPeerState(&peerState{[]string{nats0}, 1, n.extSt})
+	n.Unlock()
+	_, ok = n.peers[n.id]
+	require_False(t, ok)
+	n.switchToCandidate()
+	require_Equal(t, n.State(), Candidate)
+}
+
 func TestNRGTrackPeerLag(t *testing.T) {
 	c := createJetStreamClusterExplicit(t, "R3S", 3)
 	defer c.shutdown()

--- a/server/stream.go
+++ b/server/stream.go
@@ -456,6 +456,7 @@ type PeerInfo struct {
 	Active  time.Duration `json:"active"`            // Active is the timestamp it was last active
 	Lag     uint64        `json:"lag,omitempty"`     // Lag is how many operations behind it is
 	Peer    string        `json:"peer"`              // Peer is the unique ID for the peer
+	Pending bool          `json:"pending,omitempty"` // Pending indicates the peer is part of the assignment, but is not a peer of the Raft group (yet)
 	// For migrations.
 	cluster string
 }


### PR DESCRIPTION
If a server was added in the assignment but was not added as a peer in the Raft group yet, it could still campaign and try to become leader. This PR fixes that by not allowing a peer of a managed group, that is not in the peer set, to try to campaign for leadership.

This was the original reason for `TestJetStreamClusterStreamScaleDownChangesRaftGroup` flaking. Since that's not what the test is meant to cover, a simple `c.waitOnStreamLeader` after the scale up was added to ensure the scale up completes and all peers are added, a small NRG change with a test to cover that was made instead.

Also added a test covering the `n.managed` interaction in `n.trackPeer`, which was technically already covered by the high-level tests, but good to have as a simpler Raft-level one too. Finally, added `PeerInfo.Pending` to expose whether any peers exist in the assignment but are not part of the Raft group yet.