### PR TITLE
(2.15) [FIXED] Preserve FirstSeq during WAL replay

### DIFF
--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -11900,6 +11900,78 @@ func TestJetStreamClusterPrepareForWALReplayDoesNotAdvanceStore(t *testing.T) {
 	require_Equal(t, mset.lastSeq(), 1)
 }
 
+func TestJetStreamClusterWALReplayPreservesFirstSeq(t *testing.T) {
+	c := createJetStreamClusterWithTemplate(t, jsClusterSyncAlwaysTempl, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	const firstSeq = 1000
+	si, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Storage:  nats.FileStorage,
+		Replicas: 3,
+		FirstSeq: firstSeq,
+	})
+	require_NoError(t, err)
+	require_Equal(t, si.State.FirstSeq, firstSeq)
+	require_Equal(t, si.State.LastSeq, firstSeq-1)
+	c.waitOnStreamLeader(globalAccountName, "TEST")
+
+	// Restart a follower without allowing server shutdown to create its first
+	// snapshot. Its filestore must therefore be recovered from the complete WAL.
+	restartWithoutSnapshot := func(rs *Server) *Server {
+		t.Helper()
+		mset, err := rs.globalAccount().lookupStream("TEST")
+		require_NoError(t, err)
+		rn := mset.raftNode()
+		require_True(t, mset.shouldReplayFromWAL())
+		_, _, err = rn.LoadLastSnapshot()
+		require_Error(t, err, errNoSnapAvailable)
+
+		rn.Stop()
+		rn.WaitForStop()
+		rs.Shutdown()
+		rs.WaitForShutdown()
+		rs = c.restartServer(rs)
+		c.waitOnStreamCurrent(rs, globalAccountName, "TEST")
+		return rs
+	}
+
+	rs := c.randomNonStreamLeader(globalAccountName, "TEST")
+	require_NotNil(t, rs)
+	rs = restartWithoutSnapshot(rs)
+
+	// An empty stream has no WAL entry recording FirstSeq, so make sure recovery preserves it.
+	mset, err := rs.globalAccount().lookupStream("TEST")
+	require_NoError(t, err)
+	require_Equal(t, mset.state().Msgs, 0)
+	require_Equal(t, mset.state().FirstSeq, firstSeq)
+	require_Equal(t, mset.state().LastSeq, firstSeq-1)
+
+	// Repeat with an existing publish to exercise replay at FirstSeq as well.
+	pa, err := js.Publish("foo", []byte("one"))
+	require_NoError(t, err)
+	require_Equal(t, pa.Sequence, firstSeq)
+	checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+		return checkState(t, c, globalAccountName, "TEST")
+	})
+
+	rs = restartWithoutSnapshot(rs)
+	mset, err = rs.globalAccount().lookupStream("TEST")
+	require_NoError(t, err)
+	require_Equal(t, mset.state().Msgs, 1)
+	require_Equal(t, mset.state().FirstSeq, firstSeq)
+	require_Equal(t, mset.state().LastSeq, firstSeq)
+
+	// The next publish must continue from the configured first sequence.
+	pa, err = js.Publish("foo", []byte("two"))
+	require_NoError(t, err)
+	require_Equal(t, pa.Sequence, firstSeq+1)
+}
+
 type snapshotlessRaftNode struct {
 	RaftNode
 	id string

--- a/server/jetstream_helpers_test.go
+++ b/server/jetstream_helpers_test.go
@@ -183,6 +183,25 @@ var jsClusterTempl = `
 	accounts { $SYS { users = [ { user: "admin", pass: "s3cr3t!" } ] } }
 `
 
+var jsClusterSyncAlwaysTempl = `
+	listen: 127.0.0.1:-1
+	server_name: %s
+	jetstream: {max_mem_store: 2GB, max_file_store: 2GB, store_dir: '%s', sync_interval: always}
+
+	leaf {
+		listen: 127.0.0.1:-1
+	}
+
+	cluster {
+		name: %s
+		listen: 127.0.0.1:%d
+		routes = [%s]
+	}
+
+	# For access to system account.
+	accounts { $SYS { users = [ { user: "admin", pass: "s3cr3t!" } ] } }
+`
+
 var jsClusterEncryptedTempl = `
 	listen: 127.0.0.1:-1
 	server_name: %s

--- a/server/stream.go
+++ b/server/stream.go
@@ -1646,6 +1646,8 @@ func (mset *stream) prepareForWALReplay(snap *StreamReplicatedState) error {
 	if snap != nil {
 		snapSeq = snap.LastSeq
 		clfs = snap.Failed
+	} else if mset.cfg.FirstSeq > 0 {
+		snapSeq = mset.cfg.FirstSeq - 1
 	}
 
 	var state StreamState


### PR DESCRIPTION
If replicated SyncAlways stream is restarted before its first Raft snapshot, 
WAL replay would reset the stream store to sequence zero, ignoring FirstSeq.