### PR TITLE
[FIXED] Rejected consumer create destroys existing consumer state

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -1271,16 +1271,6 @@ func (mset *stream) addConsumerWithAssignmentAndMode(config *ConsumerConfig, ona
 			config.Name = o.name
 		}
 	}
-	// Create ackMsgs queue now that we have a consumer name
-	o.ackMsgs = newIPQueue[*jsAckMsg](s, fmt.Sprintf("[ACC:%s] consumer '%s' on stream '%s' ackMsgs", accName, o.name, cfg.Name))
-
-	// Create our request waiting queue.
-	if o.isPullMode() {
-		o.waiting = newWaitQueue(config.MaxWaiting)
-		// Create our internal queue for next msg requests.
-		o.nextMsgReqs = newIPQueue[*nextMsgReq](s, fmt.Sprintf("[ACC:%s] consumer '%s' on stream '%s' pull requests", accName, o.name, cfg.Name))
-	}
-
 	// already under lock, mset.Name() would deadlock
 	o.stream = cfg.Name
 	o.ackEventT = JSMetricConsumerAckPre + "." + o.stream + "." + o.name
@@ -1415,6 +1405,15 @@ func (mset *stream) addConsumerWithAssignmentAndMode(config *ConsumerConfig, ona
 			_ = o.stop()
 			return nil, err
 		}
+	}
+
+	// Create ackMsgs queue now that we have a consumer name
+	o.ackMsgs = newIPQueue[*jsAckMsg](s, fmt.Sprintf("[ACC:%s] consumer '%s' on stream '%s' ackMsgs", accName, o.name, cfg.Name))
+
+	// Create our request waiting queue.
+	if o.isPullMode() {
+		o.waiting = newWaitQueue(config.MaxWaiting)
+		o.nextMsgReqs = newIPQueue[*nextMsgReq](s, fmt.Sprintf("[ACC:%s] consumer '%s' on stream '%s' pull requests", accName, o.name, cfg.Name))
 	}
 
 	// Set up the ack subscription for this consumer. Will use wildcard for all acks.

--- a/server/consumer.go
+++ b/server/consumer.go
@@ -1250,7 +1250,8 @@ func (mset *stream) addConsumerWithAssignmentAndMode(config *ConsumerConfig, ona
 	if isDurableConsumer(config) {
 		if len(config.Durable) > JSMaxNameLen {
 			mset.mu.Unlock()
-			o.deleteWithoutAdvisory()
+			// Release the temporary consumer we built; it was never registered.
+			_ = o.stop()
 			return nil, NewJSConsumerNameTooLongError(JSMaxNameLen)
 		}
 		o.name = config.Durable
@@ -1288,7 +1289,8 @@ func (mset *stream) addConsumerWithAssignmentAndMode(config *ConsumerConfig, ona
 
 	if !isValidAssetName(o.name) {
 		mset.mu.Unlock()
-		o.deleteWithoutAdvisory()
+		// Release the temporary consumer we built; it was never registered.
+		_ = o.stop()
 		return nil, NewJSConsumerBadDurableNameError()
 	}
 
@@ -1312,6 +1314,8 @@ func (mset *stream) addConsumerWithAssignmentAndMode(config *ConsumerConfig, ona
 		}
 		// Once we are here we have a replacement push-based durable.
 		eo.updateDeliverSubject(o.cfg.DeliverSubject)
+		// Release the temporary consumer we built; it was never registered.
+		_ = o.stop()
 		return eo, nil
 	}
 
@@ -1320,7 +1324,8 @@ func (mset *stream) addConsumerWithAssignmentAndMode(config *ConsumerConfig, ona
 		store, err := mset.store.ConsumerStore(o.name, o.created, config)
 		if err != nil {
 			mset.mu.Unlock()
-			o.deleteWithoutAdvisory()
+			// Store creation failed, so just cleanup.
+			_ = o.stop()
 			return nil, NewJSConsumerStoreFailedError(err)
 		}
 		o.store = store
@@ -1390,6 +1395,8 @@ func (mset *stream) addConsumerWithAssignmentAndMode(config *ConsumerConfig, ona
 			if err != nil {
 				s.Errorf("JetStream consumer '%s > %s > %s' errored while updating state: %v", o.acc.Name, o.stream, o.name, err)
 				mset.mu.Unlock()
+				// Release the temporary consumer we built; it was never registered.
+				_ = o.stop()
 				return nil, NewJSConsumerStoreFailedError(err)
 			}
 		}
@@ -1397,8 +1404,15 @@ func (mset *stream) addConsumerWithAssignmentAndMode(config *ConsumerConfig, ona
 		// Clustered non-direct consumers defer this to setLeader so the
 		// expensive store scans don't block the meta apply goroutine.
 		if err := o.selectStartingSeqNo(); err != nil {
+			// Delete our store while holding the stream lock, so a concurrent create
+			// for the same name cannot have registered and be sharing this on-disk
+			// directory. Then release the rest of the consumer non-destructively.
+			if o.store != nil {
+				_ = o.store.Delete()
+				o.store = nil
+			}
 			mset.mu.Unlock()
-			o.deleteWithoutAdvisory()
+			_ = o.stop()
 			return nil, err
 		}
 	}

--- a/server/consumer.go
+++ b/server/consumer.go
@@ -1385,20 +1385,17 @@ func (mset *stream) addConsumerWithAssignmentAndMode(config *ConsumerConfig, ona
 	if eo, ok := mset.consumers[o.name]; ok {
 		mset.mu.Unlock()
 		if !o.isDurable() || !o.isPushMode() {
-			o.name = _EMPTY_ // Prevent removal since same name.
 			o.deleteWithoutAdvisory()
 			return nil, NewJSConsumerNameExistError()
 		}
 		// If we are here we have already registered this durable. If it is still active that is an error.
 		if eo.isActive() {
-			o.name = _EMPTY_ // Prevent removal since same name.
 			o.deleteWithoutAdvisory()
 			return nil, NewJSConsumerExistingActiveError()
 		}
 		// Since we are here this means we have a potentially new durable so we should update here.
 		// Check that configs are the same.
 		if !configsEqualSansDelivery(o.cfg, eo.cfg) {
-			o.name = _EMPTY_ // Prevent removal since same name.
 			o.deleteWithoutAdvisory()
 			return nil, NewJSConsumerReplacementWithDifferentNameError()
 		}

--- a/server/consumer.go
+++ b/server/consumer.go
@@ -1292,6 +1292,29 @@ func (mset *stream) addConsumerWithAssignmentAndMode(config *ConsumerConfig, ona
 		return nil, NewJSConsumerBadDurableNameError()
 	}
 
+	// Check if we already have this one registered.
+	if eo, ok := mset.consumers[o.name]; ok {
+		mset.mu.Unlock()
+		if !o.isDurable() || !o.isPushMode() {
+			_ = o.stop()
+			return nil, NewJSConsumerNameExistError()
+		}
+		// If we are here we have already registered this durable. If it is still active that is an error.
+		if eo.isActive() {
+			_ = o.stop()
+			return nil, NewJSConsumerExistingActiveError()
+		}
+		// Since we are here this means we have a potentially new durable so we should update here.
+		// Check that configs are the same.
+		if !configsEqualSansDelivery(o.cfg, eo.cfg) {
+			_ = o.stop()
+			return nil, NewJSConsumerReplacementWithDifferentNameError()
+		}
+		// Once we are here we have a replacement push-based durable.
+		eo.updateDeliverSubject(o.cfg.DeliverSubject)
+		return eo, nil
+	}
+
 	// Setup our storage if not a direct consumer.
 	if !config.Direct {
 		store, err := mset.store.ConsumerStore(o.name, o.created, config)
@@ -1378,30 +1401,6 @@ func (mset *stream) addConsumerWithAssignmentAndMode(config *ConsumerConfig, ona
 			o.deleteWithoutAdvisory()
 			return nil, err
 		}
-	}
-
-	// Now register with mset and create the ack subscription.
-	// Check if we already have this one registered.
-	if eo, ok := mset.consumers[o.name]; ok {
-		mset.mu.Unlock()
-		if !o.isDurable() || !o.isPushMode() {
-			o.deleteWithoutAdvisory()
-			return nil, NewJSConsumerNameExistError()
-		}
-		// If we are here we have already registered this durable. If it is still active that is an error.
-		if eo.isActive() {
-			o.deleteWithoutAdvisory()
-			return nil, NewJSConsumerExistingActiveError()
-		}
-		// Since we are here this means we have a potentially new durable so we should update here.
-		// Check that configs are the same.
-		if !configsEqualSansDelivery(o.cfg, eo.cfg) {
-			o.deleteWithoutAdvisory()
-			return nil, NewJSConsumerReplacementWithDifferentNameError()
-		}
-		// Once we are here we have a replacement push-based durable.
-		eo.updateDeliverSubject(o.cfg.DeliverSubject)
-		return eo, nil
 	}
 
 	// Set up the ack subscription for this consumer. Will use wildcard for all acks.

--- a/server/jetstream_consumer_test.go
+++ b/server/jetstream_consumer_test.go
@@ -13276,3 +13276,84 @@ func TestJetStreamConsumerCreateCollisionPreservesExistingConsumerStore(t *testi
 	_, err = os.Stat(odir)
 	require_NoError(t, err)
 }
+
+func TestJetStreamConsumerFailedRecoverStateDoesNotLeakInternalClients(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	acc := s.GlobalAccount()
+	sys := s.SystemAccount()
+
+	// Stream stays empty, so its last sequence is 0 while the recovered consumer below
+	// has a much higher delivered sequence: this drives the reconcile path.
+	mset, err := acc.addStream(&StreamConfig{Name: "TEST", Subjects: []string{"foo"}, Storage: FileStorage})
+	require_NoError(t, err)
+
+	// Set up a consumer store whose delivered sequence is far ahead of the stream.
+	cfg := &ConsumerConfig{Durable: "dur", AckPolicy: AckExplicit}
+	cs, err := mset.store.ConsumerStore("dur", time.Now().UTC(), cfg)
+	require_NoError(t, err)
+	odir := cs.(*consumerFileStore).odir // Capture before stop.
+	require_NoError(t, cs.ForceUpdate(&ConsumerState{
+		Delivered: SequencePair{Consumer: 100, Stream: 100},
+		AckFloor:  SequencePair{Consumer: 100, Stream: 100},
+	}))
+	require_NoError(t, cs.Stop())
+
+	// Make the store directory read-only so the reconcile fails.
+	require_NoError(t, os.Chmod(odir, 0o500))
+	defer os.Chmod(odir, 0o700) // restore before Shutdown cleans up
+
+	numClients := func(a *Account) int {
+		a.mu.RLock()
+		defer a.mu.RUnlock()
+		return len(a.clients)
+	}
+	accBefore, sysBefore := numClients(acc), numClients(sys)
+
+	// Trigger recovery multiple times to exploit if internal clients are leaked.
+	const iters = 20
+	for range iters {
+		_, err = mset.addConsumerWithAssignment(cfg, _EMPTY_, nil, true, ActionCreateOrUpdate, false)
+		require_Error(t, err)
+		require_Contains(t, err.Error(), "error creating store for consumer")
+	}
+
+	// Validate that no internal clients were leaked.
+	const tolerance = 5
+	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+		if d := numClients(acc) - accBefore; d > tolerance {
+			return fmt.Errorf("account leaked ~%d internal clients over %d failed recovery creates", d, iters)
+		}
+		if d := numClients(sys) - sysBefore; d > tolerance {
+			return fmt.Errorf("system account leaked ~%d internal clients over %d failed recovery creates", d, iters)
+		}
+		return nil
+	})
+}
+
+func TestJetStreamConsumerCreateNameTooLongDoesNotDeleteObsStream(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	// A stream literally named "obs".
+	acc := s.globalAccount()
+	obs, err := acc.addStream(&StreamConfig{Name: "obs", Subjects: []string{"obs.>"}, Storage: FileStorage})
+	require_NoError(t, err)
+	fs, ok := obs.store.(*fileStore)
+	require_True(t, ok)
+	obsDir := fs.fcfg.StoreDir
+	_, err = os.Stat(obsDir)
+	require_NoError(t, err)
+
+	mset, err := acc.addStream(&StreamConfig{Name: "TEST", Subjects: []string{"foo"}, Storage: FileStorage})
+	require_NoError(t, err)
+
+	// Durable name longer than the limit: rejected before the consumer is registered.
+	_, err = mset.addConsumer(&ConsumerConfig{Durable: strings.Repeat("a", JSMaxNameLen+1), AckPolicy: AckExplicit})
+	require_Error(t, err)
+
+	// The unrelated "obs" stream's directory must still exist.
+	_, err = os.Stat(obsDir)
+	require_NoError(t, err)
+}

--- a/server/jetstream_consumer_test.go
+++ b/server/jetstream_consumer_test.go
@@ -7809,10 +7809,10 @@ func TestJetStreamConsumerFilterUpdate(t *testing.T) {
 	checkNumFilter := func(expected int) {
 		t.Helper()
 		mset.mu.RLock()
-		nf := mset.numFilter
+		nf := int(mset.csl.Count())
 		mset.mu.RUnlock()
 		if nf != expected {
-			t.Fatalf("Expected stream's numFilter to be %d, got %d", expected, nf)
+			t.Fatalf("Expected stream's filters to be %d, got %d", expected, nf)
 		}
 	}
 
@@ -7826,7 +7826,7 @@ func TestJetStreamConsumerFilterUpdate(t *testing.T) {
 	})
 	require_NoError(t, err)
 
-	// and expect that numFilter reports correctly.
+	// and expect that it reports correctly.
 	checkNumFilter(0)
 }
 

--- a/server/jetstream_consumer_test.go
+++ b/server/jetstream_consumer_test.go
@@ -13239,3 +13239,40 @@ func TestJetStreamConsumerFlowControlResetOnLeaderChange(t *testing.T) {
 		return nil
 	})
 }
+
+func TestJetStreamConsumerCreateCollisionPreservesExistingConsumerStore(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	mset, err := s.globalAccount().addStream(&StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Storage:  FileStorage,
+	})
+	require_NoError(t, err)
+
+	// Existing durable consumer registered under "dur" with an on-disk store.
+	o, err := mset.addConsumer(&ConsumerConfig{Durable: "dur", AckPolicy: AckExplicit})
+	require_NoError(t, err)
+
+	cfs, ok := o.store.(*consumerFileStore)
+	require_True(t, ok)
+	odir := cfs.odir
+	require_NotEqual(t, odir, _EMPTY_)
+
+	// Sanity: the existing consumer's store directory exists.
+	_, err = os.Stat(odir)
+	require_NoError(t, err)
+
+	// Trigger the collision path. Since the consumer already exists, this should error.
+	_, err = mset.addConsumerWithAssignment(
+		&ConsumerConfig{AckPolicy: AckExplicit},
+		"dur", nil, false, ActionCreateOrUpdate, false,
+	)
+	require_Error(t, err, NewJSConsumerNameExistError())
+
+	// The existing consumer should still be registered, and its store directory intact.
+	require_Equal(t, mset.lookupConsumer("dur"), o)
+	_, err = os.Stat(odir)
+	require_NoError(t, err)
+}

--- a/server/jetstream_consumer_test.go
+++ b/server/jetstream_consumer_test.go
@@ -13357,3 +13357,33 @@ func TestJetStreamConsumerCreateNameTooLongDoesNotDeleteObsStream(t *testing.T) 
 	_, err = os.Stat(obsDir)
 	require_NoError(t, err)
 }
+
+func TestJetStreamConsumerCreateCollisionPreservesExistingConsumerQueues(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	mset, err := s.globalAccount().addStream(&StreamConfig{Name: "TEST", Subjects: []string{"foo"}, Storage: FileStorage})
+	require_NoError(t, err)
+	o, err := mset.addConsumer(&ConsumerConfig{Durable: "dur", AckPolicy: AckExplicit})
+	require_NoError(t, err)
+
+	// A pull consumer registers two queues in the server's ipQueues map.
+	ackKey, reqKey := o.ackMsgs.name, o.nextMsgReqs.name
+	if _, ok := s.ipQueues.Load(ackKey); !ok {
+		t.Fatal("precondition: existing consumer ackMsgs queue not registered")
+	}
+
+	// Trigger the name collision path.
+	_, err = mset.addConsumerWithAssignment(
+		&ConsumerConfig{AckPolicy: AckExplicit}, "dur", nil, false, ActionCreateOrUpdate, false,
+	)
+	require_Error(t, err)
+
+	// The existing registry entries must still be present and still point at its queues.
+	v, ok := s.ipQueues.Load(ackKey)
+	require_True(t, ok)
+	require_Equal(t, v.(*ipQueue[*jsAckMsg]), o.ackMsgs)
+	v, ok = s.ipQueues.Load(reqKey)
+	require_True(t, ok)
+	require_Equal(t, v.(*ipQueue[*nextMsgReq]), o.nextMsgReqs)
+}

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -26589,3 +26589,51 @@ func TestJetStreamSourceHeaderNotAllowedIfNotSourced(t *testing.T) {
 	t.Run("R1", func(t *testing.T) { test(t, 1) })
 	t.Run("R3", func(t *testing.T) { test(t, 3) })
 }
+
+func TestJetStreamSetConsumerIgnoresDuplicateName(t *testing.T) {
+	mset := &stream{consumers: make(map[string]*consumer)}
+
+	first := &consumer{name: "dur", subjf: []*subjectFilter{{subject: "foo"}}}
+	first.cfg.FilterSubject = "foo"
+	mset.setConsumer(first)
+	require_Equal(t, mset.consumers["dur"], first)
+	require_Equal(t, mset.csl.Count(), 1)
+	require_Len(t, len(mset.cList), 1)
+
+	// A different object trying to register under the same name must be ignored.
+	dup := &consumer{name: "dur", subjf: []*subjectFilter{{subject: "foo"}}}
+	dup.cfg.FilterSubject = "foo"
+	mset.setConsumer(dup)
+
+	require_Equal(t, mset.consumers["dur"], first) // not overwritten
+	require_Equal(t, mset.csl.Count(), 1)          // not double-counted
+	require_Len(t, len(mset.cList), 1)             // no duplicate entry
+	require_Equal(t, mset.cList[0], first)
+}
+
+func TestJetStreamRemoveConsumerOnlyRemovesMatchingInstance(t *testing.T) {
+	mset := &stream{consumers: make(map[string]*consumer)}
+
+	good := &consumer{name: "dur", subjf: []*subjectFilter{{subject: "foo"}}}
+	good.cfg.FilterSubject = "foo"
+	mset.setConsumer(good)
+	require_Equal(t, mset.csl.Count(), 1)
+	require_Len(t, len(mset.cList), 1)
+
+	// A stale object left over from a failed create: same name, different identity.
+	stale := &consumer{name: "dur"}
+	stale.cfg.FilterSubject = "foo"
+	mset.removeConsumer(stale)
+
+	require_Equal(t, mset.consumers["dur"], good) // valid consumer survives
+	require_Equal(t, mset.csl.Count(), 1)
+	require_Len(t, len(mset.cList), 1)
+	require_Equal(t, mset.cList[0], good)
+
+	// Removing the registered consumer must still work.
+	mset.removeConsumer(good)
+	_, ok := mset.consumers["dur"]
+	require_True(t, !ok)
+	require_Equal(t, mset.csl.Count(), 0)
+	require_Len(t, len(mset.cList), 0)
+}

--- a/server/stream.go
+++ b/server/stream.go
@@ -9045,6 +9045,9 @@ func (mset *stream) numConsumers() int {
 
 // Lock should be held.
 func (mset *stream) setConsumer(o *consumer) {
+	if _, ok := mset.consumers[o.name]; ok {
+		return
+	}
 	mset.consumers[o.name] = o
 	if len(o.subjf) > 0 {
 		mset.numFilter++
@@ -9066,32 +9069,33 @@ func (mset *stream) setConsumer(o *consumer) {
 
 // Lock should be held.
 func (mset *stream) removeConsumer(o *consumer) {
-	if _, ok := mset.consumers[o.name]; ok {
-		delete(mset.consumers, o.name)
-
-		if o.cfg.FilterSubject != _EMPTY_ && mset.numFilter > 0 {
-			mset.numFilter--
-		}
-		if (o.direct || o.sourcing) && mset.sourcingConsumers > 0 {
-			mset.sourcingConsumers--
-		}
-
-		// Now update consumers list as well
-		mset.clsMu.Lock()
-		for i, ol := range mset.cList {
-			if ol == o {
-				mset.cList = append(mset.cList[:i], mset.cList[i+1:]...)
-				break
-			}
-		}
-		// Always remove from the leader sublist.
-		if mset.csl != nil {
-			for _, sub := range o.signalSubs() {
-				mset.csl.Remove(sub, o)
-			}
-		}
-		mset.clsMu.Unlock()
+	if c, ok := mset.consumers[o.name]; !ok || c != o {
+		return
 	}
+	delete(mset.consumers, o.name)
+
+	if o.cfg.FilterSubject != _EMPTY_ && mset.numFilter > 0 {
+		mset.numFilter--
+	}
+	if (o.direct || o.sourcing) && mset.sourcingConsumers > 0 {
+		mset.sourcingConsumers--
+	}
+
+	// Now update consumers list as well
+	mset.clsMu.Lock()
+	for i, ol := range mset.cList {
+		if ol == o {
+			mset.cList = append(mset.cList[:i], mset.cList[i+1:]...)
+			break
+		}
+	}
+	// Always remove from the leader sublist.
+	if mset.csl != nil {
+		for _, sub := range o.signalSubs() {
+			mset.csl.Remove(sub, o)
+		}
+	}
+	mset.clsMu.Unlock()
 }
 
 // swapSigSubs will update signal Subs for a new subject filter.

--- a/server/stream.go
+++ b/server/stream.go
@@ -570,7 +570,6 @@ type stream struct {
 	term      uint64                  // Raft term, used to determine if we are still the leader for the current term (if applicable, 0 otherwise).
 	lmsgId    string                  // The de-duplication message ID of the last message stored in the stream.
 	consumers map[string]*consumer    // The consumers for this stream.
-	numFilter int                     // The number of filtered consumers.
 	cfg       StreamConfig            // The stream's config.
 	cfgMu     sync.RWMutex            // Config mutex used to solve some races with consumer code
 	created   time.Time               // Time the stream was created.
@@ -9049,9 +9048,6 @@ func (mset *stream) setConsumer(o *consumer) {
 		return
 	}
 	mset.consumers[o.name] = o
-	if len(o.subjf) > 0 {
-		mset.numFilter++
-	}
 	if o.direct || o.sourcing {
 		mset.sourcingConsumers++
 	}
@@ -9074,9 +9070,6 @@ func (mset *stream) removeConsumer(o *consumer) {
 	}
 	delete(mset.consumers, o.name)
 
-	if o.cfg.FilterSubject != _EMPTY_ && mset.numFilter > 0 {
-		mset.numFilter--
-	}
 	if (o.direct || o.sourcing) && mset.sourcingConsumers > 0 {
 		mset.sourcingConsumers--
 	}
@@ -9135,16 +9128,6 @@ func (mset *stream) swapSigSubs(o *consumer, newFilters []string) {
 	}
 	o.mu.Unlock()
 	mset.clsMu.Unlock()
-
-	mset.mu.Lock()
-	defer mset.mu.Unlock()
-
-	if mset.numFilter > 0 && len(o.subjf) > 0 {
-		mset.numFilter--
-	}
-	if len(newFilters) > 0 {
-		mset.numFilter++
-	}
 }
 
 // lookupConsumer will retrieve a consumer by name.


### PR DESCRIPTION
This PR fixes a number of issues relating to errors on consumer create:
- `setConsumer` no longer overwrites an existing consumer and `removeConsumer` only unregisters when the entry is the same instance that is passed, so a stale consumer with the same name can't evict the live consumer from `mset.consumers`, `cList` and `csl`.
- The name-exists check now runs before `mset.store.ConsumerStore(o.name, ...)`, which opened the existing consumer's on-disk directory and then deleted it when the rejected create tore itself down.
- Error paths release the temporary consumer with `o.stop()` instead of `o.deleteWithoutAdvisory()`, which on the early name checks could `os.RemoveAll` an unrelated stream named `obs` (unlikely but fixed anyhow).
- The `ackMsgs`/`nextMsgReqs` ipQueues are created after the name-exists check, since they key `s.ipQueues` by consumer name and the rejected create overwrote and then unregistered the live consumer's entries.
- `mset.numFilter` is removed, as it was maintained in three places, never read, and miscounted consumers using `FilterSubjects`.

In practice the name-exists paths above only apply to single/standalone servers, since clustered paths perform this check elsewhere and would prevent it.