### PR TITLE
(2.15) [FIXED] prepareForWALReplay failed to Truncate deleted sequence

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -11228,17 +11228,15 @@ func (fs *fileStore) Truncate(seq uint64) (rerr error) {
 
 	var hasLsm bool
 	var lastTime int64
+	var lsm StoreMsg
 	smb := fs.selectMsgBlock(seq)
 	if smb != nil {
-		smb.mu.Lock()
-		lsm, _, err := smb.fetchMsgNoCopyLocked(seq, nil)
-		if lsm != nil {
+		_, _, err := smb.prevMatching(fwcs, true, seq, &lsm)
+		if err == nil && lsm.seq == seq {
 			hasLsm = true
 			lastTime = lsm.ts
 		}
-		smb.finishedWithCache()
-		smb.mu.Unlock()
-		if err != nil && err != ErrStoreMsgNotFound && err != errDeletedMsg {
+		if err != nil && err != ErrStoreMsgNotFound {
 			fs.mu.Unlock()
 			return err
 		}
@@ -11358,7 +11356,7 @@ func (fs *fileStore) Truncate(seq uint64) (rerr error) {
 		}
 
 		// Truncate our selected message block.
-		nmsgs, nbytes, err := smb.truncate(seq, lastTime)
+		nmsgs, nbytes, err := smb.truncate(lsm.seq, lsm.ts)
 		if err != nil {
 			smb.mu.Unlock()
 			fs.mu.Unlock()

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -1144,6 +1144,113 @@ func TestFileStoreStreamTruncate(t *testing.T) {
 	})
 }
 
+func TestFileStoreStreamTruncateDeletedSequence(t *testing.T) {
+	testFileStoreAllPermutations(t, func(t *testing.T, fcfg FileStoreConfig) {
+		// Place sequences 1-10 in the first block and 11-12 in the next.
+		fcfg.BlockSize = 350
+		cfg := StreamConfig{Name: "zzz", Subjects: []string{"foo"}, Storage: FileStorage}
+		created := time.Now()
+
+		fs, err := newFileStoreWithCreated(fcfg, cfg, created, prf(&fcfg), nil)
+		require_NoError(t, err)
+		defer fs.Stop()
+
+		for range 12 {
+			_, _, err := fs.StoreMsg("foo", nil, []byte("ok"), 0)
+			require_NoError(t, err)
+		}
+
+		// Delete and compact the truncation point
+		for _, seq := range []uint64{4, 5} {
+			removed, err := fs.RemoveMsg(seq)
+			require_NoError(t, err)
+			require_True(t, removed)
+		}
+		const truncateSeq = uint64(5)
+		smb := fs.selectMsgBlock(truncateSeq)
+		require_NotNil(t, smb)
+		require_True(t, smb != fs.lmb)
+		smb.mu.Lock()
+		require_NoError(t, smb.compact())
+		smb.finishedWithCache()
+		smb.mu.Unlock()
+
+		// Preserve the deleted truncation point as the logical LastSeq.
+		require_NoError(t, fs.Truncate(truncateSeq))
+		expected := fs.State()
+		require_Equal(t, expected.Msgs, 3)
+		require_Equal(t, expected.FirstSeq, 1)
+		require_Equal(t, expected.LastSeq, truncateSeq)
+		require_True(t, reflect.DeepEqual(expected.Deleted, []uint64{4, 5}))
+
+		for seq := uint64(1); seq <= 3; seq++ {
+			_, err := fs.LoadMsg(seq, nil)
+			require_NoError(t, err)
+		}
+		for seq := uint64(4); seq <= 5; seq++ {
+			_, err := fs.LoadMsg(seq, nil)
+			require_Error(t, err, ErrStoreMsgNotFound, errDeletedMsg)
+		}
+		for seq := uint64(6); seq <= 12; seq++ {
+			_, err := fs.LoadMsg(seq, nil)
+			require_Error(t, err, ErrStoreEOF)
+		}
+
+		// Recover without index.db to verify that blocks are complete.
+		require_NoError(t, fs.Stop())
+		require_NoError(t, os.Remove(filepath.Join(fcfg.StoreDir, msgDir, streamStreamStateFile)))
+		fs, err = newFileStoreWithCreated(fcfg, cfg, created, prf(&fcfg), nil)
+		require_NoError(t, err)
+		defer fs.Stop()
+		require_True(t, reflect.DeepEqual(fs.State(), expected))
+	})
+}
+
+func TestFileStoreStreamTruncateDeletedWithCompactedPrefix(t *testing.T) {
+	testFileStoreAllPermutations(t, func(t *testing.T, fcfg FileStoreConfig) {
+		fcfg.BlockSize = 120
+		cfg := StreamConfig{Name: "zzz", Subjects: []string{"foo"}, Storage: FileStorage}
+
+		fs, err := newFileStoreWithCreated(fcfg, cfg, time.Now(), prf(&fcfg), nil)
+		require_NoError(t, err)
+		defer fs.Stop()
+
+		// Store 9 messages, creating 3 blocks
+		// [1,2,3], [4,5,6], [7,8,9]
+		for range 9 {
+			_, _, err := fs.StoreMsg("foo", nil, []byte("ok"), 0)
+			require_NoError(t, err)
+		}
+
+		// Remove messages 4 and 5, and compact
+		for _, seq := range []uint64{4, 5} {
+			removed, err := fs.RemoveMsg(seq)
+			require_NoError(t, err)
+			require_True(t, removed)
+		}
+
+		smb := fs.selectMsgBlock(4)
+		require_NotNil(t, smb)
+		smb.mu.Lock()
+		require_NoError(t, smb.compact())
+		smb.mu.Unlock()
+
+		// With no prior message in the selected block, Truncate(5) removes the block.
+		const truncateSeq = uint64(5)
+		require_NoError(t, fs.Truncate(truncateSeq))
+		fs.mu.RLock()
+		removed := !slices.Contains(fs.blks, smb)
+		fs.mu.RUnlock()
+		require_True(t, removed)
+
+		state := fs.State()
+		require_Equal(t, state.Msgs, 3)
+		require_Equal(t, state.FirstSeq, uint64(1))
+		require_Equal(t, state.LastSeq, truncateSeq)
+		require_True(t, reflect.DeepEqual(state.Deleted, []uint64{4, 5}))
+	})
+}
+
 func TestFileStoreRemovePartialRecovery(t *testing.T) {
 	testFileStoreAllPermutations(t, func(t *testing.T, fcfg FileStoreConfig) {
 		cfg := StreamConfig{Name: "zzz", Subjects: []string{"foo"}, Storage: FileStorage}

--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -12059,6 +12059,112 @@ func TestJetStreamClusterPrepareForWALReplayTruncatesStore(t *testing.T) {
 	require_Equal(t, mset.lastSeq(), 2)
 }
 
+func TestJetStreamClusterWALReplayTruncatesDeletedSnapshotSequence(t *testing.T) {
+	const (
+		snapshotLastSeq = uint64(5)
+		finalLastSeq    = uint64(12)
+	)
+
+	// SyncAlways is relaxed to SyncOnFlush for replicated streams, enabling
+	// recovery from the stream snapshot and its retained Raft WAL tail.
+	c := createJetStreamClusterWithTemplate(t, jsClusterSyncAlwaysTempl, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Storage:  nats.FileStorage,
+		Replicas: 3,
+	})
+	require_NoError(t, err)
+
+	sl := c.streamLeader(globalAccountName, "TEST")
+	mset, err := sl.globalAccount().lookupStream("TEST")
+	require_NoError(t, err)
+	fs := mset.store.(*fileStore)
+	require_True(t, mset.shouldReplayFromWAL())
+
+	// Ten of these messages fit in 350 bytes, placing sequences 1-10 in the
+	// first block and 11-12 in the next. This leaves sequence 5 as an interior
+	// message in a non-last block that can be compacted safely.
+	fs.mu.Lock()
+	fs.fcfg.BlockSize = 350
+	fs.mu.Unlock()
+
+	for range snapshotLastSeq {
+		_, err = js.Publish("foo", []byte("ok"))
+		require_NoError(t, err)
+	}
+
+	rn := mset.raftNode().(*raft)
+	// Recovery will restore this snapshot and truncate the filestore to its
+	// LastSeq before replaying the operations retained after it.
+	require_NoError(t, rn.InstallSnapshot(mset.stateSnapshot(), false))
+
+	// Delete the snapshot boundary itself, then append later messages so the
+	// retained WAL has a tail to replay after truncation.
+	for _, seq := range []uint64{snapshotLastSeq - 1, snapshotLastSeq} {
+		require_NoError(t, js.DeleteMsg("TEST", seq))
+	}
+	for range finalLastSeq - snapshotLastSeq {
+		_, err = js.Publish("foo", []byte("ok"))
+		require_NoError(t, err)
+	}
+
+	state := mset.state()
+	require_Equal(t, state.Msgs, 10)
+	require_Equal(t, state.LastSeq, finalLastSeq)
+	require_NoError(t, fs.FlushAllPending())
+
+	// Rewrite the first block without its deleted records, leaving sequence 5
+	// represented only by a delete marker.
+	smb := fs.selectMsgBlock(snapshotLastSeq)
+	require_NotNil(t, smb)
+	require_True(t, smb != fs.lmb)
+	smb.mu.Lock()
+	err = smb.compact()
+	smb.mu.Unlock()
+	require_NoError(t, err)
+
+	snapIndex, snapData, err := rn.LoadLastSnapshot()
+	require_NoError(t, err)
+	snap, err := decodeStreamSnapshot(snapData)
+	require_NoError(t, err)
+	require_Equal(t, snap.LastSeq, snapshotLastSeq)
+	index, _, _ := rn.Progress()
+	require_True(t, index > snapIndex)
+
+	// Stop the Raft group before the server so shutdown cannot replace the old
+	// snapshot. Restart must truncate the store and replay the retained WAL tail.
+	rn.Stop()
+	rn.WaitForStop()
+	sl.Shutdown()
+	sl.WaitForShutdown()
+	sl = c.restartServer(sl)
+	c.waitOnStreamCurrent(sl, globalAccountName, "TEST")
+
+	mset, err = sl.globalAccount().lookupStream("TEST")
+	require_NoError(t, err)
+	// Wait for the expected final last sequence.
+	checkFor(t, 5*time.Second, 100*time.Millisecond, func() error {
+		state = mset.store.State()
+		if state.LastSeq != finalLastSeq {
+			return fmt.Errorf("stream replay at sequence %d", state.LastSeq)
+		}
+		return nil
+	})
+	require_Equal(t, state.Msgs, 10)
+	require_Equal(t, state.FirstSeq, 1)
+	require_Equal(t, state.LastSeq, finalLastSeq)
+	require_Len(t, len(state.Deleted), 2)
+	require_Equal(t, state.Deleted[0], snapshotLastSeq-1)
+	require_Equal(t, state.Deleted[1], snapshotLastSeq)
+	require_True(t, mset.isMonitorRunning())
+}
+
 func TestJetStreamClusterAsyncFlushFileStoreFlushOnSnapshot(t *testing.T) {
 	c := createJetStreamClusterExplicit(t, "R3S", 3)
 	defer c.shutdown()


### PR DESCRIPTION
When WAL recovery truncated a filestore to a deleted and compacted snapshot sequence, Truncate failed with errDeletedMsg. The fix is to truncate the selected block at the preceding stored message, if any.