### PR TITLE
Fix TestJetStreamClusterLeafnodePlusDaisyChainSetup

### DIFF
--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -4605,9 +4605,11 @@ func TestJetStreamClusterLeafnodePlusDaisyChainSetup(t *testing.T) {
 	})
 	require_NoError(t, err)
 
-	checkFor(t, time.Second, 200*time.Millisecond, func() error {
-		si, err := js.StreamInfo("M")
-		require_NoError(t, err)
+	checkFor(t, 10*time.Second, 200*time.Millisecond, func() error {
+		si, err := js.StreamInfo("M", nats.MaxWait(2*time.Second))
+		if err != nil {
+			return err
+		}
 		if si.State.Msgs == 100 {
 			return nil
 		}


### PR DESCRIPTION
Let it retry on sporadic timeout on slower CI runners.

Signed-off-by: Waldemar Quevedo <wally@nats.io>