### PR TITLE
(2.14) [FIXED] Catchup stall, overrun/cached bytes limit, and stale group state

### DIFF
--- a/server/jetstream_batching_test.go
+++ b/server/jetstream_batching_test.go
@@ -3153,7 +3153,7 @@ func TestJetStreamAtomicBatchPublishPartialBatchInSharedAppendEntry(t *testing.T
 			newEntry(EntryNormal, esm2),
 		})
 		batch := &batchApply{}
-		_, err = js.applyStreamEntries(mset, ce, false, batch)
+		_, err = js.applyStreamEntries(mset, mset.raftNode(), ce, false, batch)
 		require_NoError(t, err)
 		entryStart, maxApplied := batch.entryStart, batch.maxApplied
 
@@ -3207,7 +3207,7 @@ func TestJetStreamAtomicBatchPublishCatchupMarkerMidBatch(t *testing.T) {
 	esm1 := encodeStreamMsgAllowCompressAndBatch("foo", _EMPTY_, hdr1, []byte("hello"), 0, ts, false, "uuid", 1, false)
 	ce1 := newCommittedEntry(1, []*Entry{newEntry(EntryNormal, esm1)})
 	batch := &batchApply{}
-	_, err = js.applyStreamEntries(mset, ce1, false, batch)
+	_, err = js.applyStreamEntries(mset, mset.raftNode(), ce1, false, batch)
 	require_NoError(t, err)
 
 	// Confirm the batch is in progress.
@@ -3217,7 +3217,7 @@ func TestJetStreamAtomicBatchPublishCatchupMarkerMidBatch(t *testing.T) {
 	//    Type==EntryCatchup and Data==nil (see raft.sendCatchupSignal). The
 	//    in-progress batch must remain intact and buffer this marker.
 	catchupCE := newCommittedEntry(0, []*Entry{{EntryCatchup, nil}})
-	_, err = js.applyStreamEntries(mset, catchupCE, false, batch)
+	_, err = js.applyStreamEntries(mset, mset.raftNode(), catchupCE, false, batch)
 	require_NoError(t, err)
 
 	// 3) Apply the batch commit (seq 2). The replay loop must skip the buffered
@@ -3233,7 +3233,7 @@ func TestJetStreamAtomicBatchPublishCatchupMarkerMidBatch(t *testing.T) {
 	var panicked any
 	func() {
 		defer func() { panicked = recover() }()
-		_, err = js.applyStreamEntries(mset, ce2, false, batch)
+		_, err = js.applyStreamEntries(mset, mset.raftNode(), ce2, false, batch)
 	}()
 	if panicked != nil {
 		mset.mu.Unlock()

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -4087,7 +4087,7 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 				}
 
 				// Apply our entries.
-				if maxApplied, err := js.applyStreamEntries(mset, ce, isRecovering, batch); err == nil {
+				if maxApplied, err := js.applyStreamEntries(mset, n, ce, isRecovering, batch); err == nil {
 					// Update our applied.
 					if maxApplied > 0 {
 						// Indicate we've processed (but not applied) everything up to this point.
@@ -4115,12 +4115,20 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 						// instead of fully resetting the state. Resetting the clustered state may result in
 						// race conditions and should only be used as a last effort attempt.
 						if errors.Is(err, errCatchupAbortedNoLeader) || err == errCatchupTooManyRetries || err == errAlreadyLeader {
-							if node := mset.raftNode(); node != nil && node.DrainAndReplaySnapshot() {
+							if n.DrainAndReplaySnapshot() {
 								break
+							} else if n.IsDeleted() {
+								// The only reason we can't replay is our node being deleted, which
+								// means the meta layer is deliberately tearing this monitor down.
+								// Don't fall through to a reset, that would resurrect this group.
+								s.Warnf("Will not reset stream '%s > %s', raft group %q was removed",
+									accName, sa.Config.Name, n.Group())
+								aq.recycle(&ces)
+								return
 							}
 						}
 						// We will attempt to reset our cluster state.
-						if mset.resetClusteredState(err) {
+						if mset.resetClusteredState(n, err) {
 							aq.recycle(&ces)
 							return
 						}
@@ -4749,7 +4757,7 @@ func (mset *stream) isMigrating() bool {
 }
 
 // resetClusteredState is called when a clustered stream had an error (e.g sequence mismatch, bad snapshot) and needs to be reset.
-func (mset *stream) resetClusteredState(err error) bool {
+func (mset *stream) resetClusteredState(n RaftNode, err error) bool {
 	mset.mu.RLock()
 	s, js, jsa, sa, acc, node, name := mset.srv, mset.js, mset.jsa, mset.sa, mset.acc, mset.node, mset.nameLocked(false)
 	stype, tierName, replicas := mset.cfg.Storage, mset.tier, mset.cfg.Replicas
@@ -4757,8 +4765,20 @@ func (mset *stream) resetClusteredState(err error) bool {
 
 	// The stream might already be deleted and not assigned to us anymore.
 	// In any case, don't revive the stream if it's already closed.
-	if mset.closed.Load() || (node != nil && node.IsDeleted()) {
+	// A nil node means it was removed out from underneath us, which only happens
+	// when the meta layer is deliberately tearing this monitor down.
+	if mset.closed.Load() || node == nil || node.IsDeleted() {
 		s.Warnf("Will not reset stream '%s > %s', stream is closed", acc, mset.name())
+		// Explicitly returning true here, we want the outside to break out of the monitoring loop as well.
+		return true
+	}
+
+	// The node we were monitoring is no longer this stream's node. The meta layer has
+	// remapped us into a different group and is tearing this monitor down, so resetting
+	// here would resurrect a group that has already been replaced.
+	if n != nil && n != node {
+		s.Warnf("Will not reset stream '%s > %s', raft group %q was replaced by %q",
+			acc, mset.name(), n.Group(), node.Group())
 		// Explicitly returning true here, we want the outside to break out of the monitoring loop as well.
 		return true
 	}
@@ -4770,9 +4790,7 @@ func (mset *stream) resetClusteredState(err error) bool {
 	})
 
 	// Stepdown regardless if we are the leader here.
-	if node != nil {
-		node.StepDown()
-	}
+	node.StepDown()
 
 	// If we detect we are shutting down just return.
 	if js != nil && js.isShuttingDown() {
@@ -4792,14 +4810,12 @@ func (mset *stream) resetClusteredState(err error) bool {
 		return false
 	}
 
-	if node != nil {
-		if errors.Is(err, errCatchupAbortedNoLeader) || err == errCatchupTooManyRetries {
-			// Don't delete all state, could've just been temporarily unable to reach the leader.
-			node.Stop()
-		} else {
-			// We delete our raft state. Will recreate.
-			node.Delete()
-		}
+	if errors.Is(err, errCatchupAbortedNoLeader) || err == errCatchupTooManyRetries {
+		// Don't delete all state, could've just been temporarily unable to reach the leader.
+		node.Stop()
+	} else {
+		// We delete our raft state. Will recreate.
+		node.Delete()
 	}
 
 	// Preserve our current state and messages unless we have a first sequence mismatch.
@@ -4859,7 +4875,7 @@ func isControlHdr(hdr []byte) bool {
 
 // Apply our stream entries.
 // Return maximum allowed applied value, if currently inside a batch, zero otherwise.
-func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isRecovering bool, batch *batchApply) (uint64, error) {
+func (js *jetStream) applyStreamEntries(mset *stream, n RaftNode, ce *CommittedEntry, isRecovering bool, batch *batchApply) (uint64, error) {
 	for i, e := range ce.Entries {
 		// Ignore if lower-level catchup is started.
 		// We don't need to optimize during this, all entries are handled as normal.
@@ -5199,7 +5215,7 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 					s, accName, streamName := mset.srv, mset.acc.GetName(), mset.cfg.Name
 					mset.mu.RUnlock()
 					s.Warnf("Detected bad stream state, resetting '%s > %s'", accName, streamName)
-					mset.resetClusteredState(err)
+					mset.resetClusteredState(n, err)
 				}
 			}
 

--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -11604,7 +11604,7 @@ func TestJetStreamClusterDontReviveRemovedStream(t *testing.T) {
 	})
 
 	// Simulating the stream was catching up and is resetting after timing out.
-	require_True(t, mset.resetClusteredState(nil))
+	require_True(t, mset.resetClusteredState(mset.raftNode(), nil))
 
 	// Allow for some time here, mset.resetClusteredState might
 	// spin up a goroutine if it's resetting the stream.

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -5276,7 +5276,7 @@ func TestJetStreamClusterAccountUsageDrifts(t *testing.T) {
 	mset, err := acc.lookupStream("TEST1")
 	require_NoError(t, err)
 	// NRG only
-	mset.resetClusteredState(nil)
+	mset.resetClusteredState(mset.raftNode(), nil)
 	checkAccount(sir1.State.Bytes, sir3.State.Bytes)
 	// Need to re-lookup this stream since we will recreate from reset above.
 	checkFor(t, 5*time.Second, 200*time.Millisecond, func() error {
@@ -5284,7 +5284,7 @@ func TestJetStreamClusterAccountUsageDrifts(t *testing.T) {
 		return err
 	})
 	// Now NRG and Stream state itself.
-	mset.resetClusteredState(errFirstSequenceMismatch)
+	mset.resetClusteredState(mset.raftNode(), errFirstSequenceMismatch)
 	checkAccount(sir1.State.Bytes, sir3.State.Bytes)
 
 	// Now test server restart
@@ -5351,7 +5351,7 @@ func TestJetStreamClusterStreamFailTracking(t *testing.T) {
 	mset, err := nl.GlobalAccount().lookupStream("TEST")
 	require_NoError(t, err)
 	// Reset raft
-	mset.resetClusteredState(nil)
+	mset.resetClusteredState(mset.raftNode(), nil)
 	time.Sleep(100 * time.Millisecond)
 
 	nl.Shutdown()
@@ -10931,7 +10931,7 @@ func TestJetStreamClusterApplyDeleteRangeOpIdempotent(t *testing.T) {
 		newEntry(EntryNormal, encodeDeleteRange(&DeleteRange{First: 100, Num: 401})),
 	})
 	batch := &batchApply{}
-	_, err = sjs.applyStreamEntries(mset, replay, false, batch)
+	_, err = sjs.applyStreamEntries(mset, mset.raftNode(), replay, false, batch)
 	require_NoError(t, err)
 	require_Equal(t, mset.lastSeq(), 1000)
 
@@ -10945,7 +10945,7 @@ func TestJetStreamClusterApplyDeleteRangeOpIdempotent(t *testing.T) {
 	dr := newCommittedEntry(2, []*Entry{
 		newEntry(EntryNormal, encodeDeleteRange(&DeleteRange{First: 1001, Num: 1000})),
 	})
-	_, err = sjs.applyStreamEntries(mset, dr, false, batch)
+	_, err = sjs.applyStreamEntries(mset, mset.raftNode(), dr, false, batch)
 	require_NoError(t, err)
 	require_Equal(t, mset.lastSeq(), 2000)
 	mset.store.FastState(&after)
@@ -10955,7 +10955,7 @@ func TestJetStreamClusterApplyDeleteRangeOpIdempotent(t *testing.T) {
 	dr = newCommittedEntry(3, []*Entry{
 		newEntry(EntryNormal, encodeDeleteRange(&DeleteRange{First: 1501, Num: 1000})),
 	})
-	_, err = sjs.applyStreamEntries(mset, dr, false, batch)
+	_, err = sjs.applyStreamEntries(mset, mset.raftNode(), dr, false, batch)
 	require_NoError(t, err)
 	require_Equal(t, mset.lastSeq(), 2500)
 	mset.store.FastState(&after)
@@ -14375,4 +14375,77 @@ func TestJetStreamClusterSourcesStateSnapshot(t *testing.T) {
 			}
 		})
 	}
+}
+
+// A stream that gets remapped into a new Raft group has its old node removed out from
+// underneath the running monitor. A monitor parked in catchup only surfaces the resulting
+// error afterwards, and must not reset the stream: the meta layer has already moved us to
+// a new group, so a reset would tear the stream down and resurrect the replaced group.
+func TestJetStreamClusterNoResetClusteredStateAfterStreamRemap(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	for _, name := range []string{"TEST", "OTHER"} {
+		_, err := js.AddStream(&nats.StreamConfig{
+			Name:     name,
+			Subjects: []string{name + ".foo"},
+			Replicas: 3,
+		})
+		require_NoError(t, err)
+	}
+
+	// Use a follower so we don't disturb the stream leader.
+	s := c.randomNonStreamLeader(globalAccountName, "TEST")
+	mset, err := s.globalAccount().lookupStream("TEST")
+	require_NoError(t, err)
+
+	// The node this monitor generation owns.
+	n := mset.raftNode()
+	require_NotNil(t, n)
+
+	t.Run("NodeRemoved", func(t *testing.T) {
+		// Simulate processClusterUpdateStream detecting a stream remap: the node is removed
+		// and the monitor is torn down, both while the monitor is parked in catchup.
+		mset.removeNode()
+		mset.stopMonitoring()
+		require_True(t, mset.raftNode() == nil)
+
+		// This is what the parked monitor does once its catchup finally aborts.
+		require_True(t, mset.resetClusteredState(n, errCatchupAbortedNoLeader))
+
+		// The stream must be left intact for the meta layer to converge on, not stopped
+		// and recreated from the now stale stream assignment.
+		time.Sleep(500 * time.Millisecond)
+		require_False(t, mset.closed.Load())
+		nmset, err := s.globalAccount().lookupStream("TEST")
+		require_NoError(t, err)
+		require_True(t, nmset == mset)
+	})
+
+	t.Run("NodeReplaced", func(t *testing.T) {
+		// Same remap, but caught after a different node has already been linked in. The
+		// monitor is still stopped from the subtest above, so nothing races us here.
+		other, err := s.globalAccount().lookupStream("OTHER")
+		require_NoError(t, err)
+		replacement := other.raftNode()
+		require_NotNil(t, replacement)
+
+		mset.mu.Lock()
+		mset.node = replacement
+		mset.mu.Unlock()
+
+		// Our generation's node is no longer the stream's node, so we must not reset.
+		require_True(t, mset.resetClusteredState(n, errCatchupAbortedNoLeader))
+
+		time.Sleep(500 * time.Millisecond)
+		require_False(t, mset.closed.Load())
+		require_False(t, other.closed.Load())
+
+		mset.mu.Lock()
+		mset.node = nil
+		mset.mu.Unlock()
+	})
 }

--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -3526,7 +3526,7 @@ func TestJetStreamClusterDesyncAfterErrorDuringCatchup(t *testing.T) {
 				// Too many retries while processing snapshot is considered a cluster reset.
 				// If a leader is temporarily unavailable we shouldn't blow away our state.
 				require_True(t, isClusterResetErr(errCatchupTooManyRetries))
-				mset.resetClusteredState(errCatchupTooManyRetries)
+				mset.resetClusteredState(mset.raftNode(), errCatchupTooManyRetries)
 			},
 		},
 		{
@@ -3549,7 +3549,7 @@ func TestJetStreamClusterDesyncAfterErrorDuringCatchup(t *testing.T) {
 				err := mset.processSnapshot(&snap, appliedIndex)
 				require_True(t, errors.Is(err, errCatchupAbortedNoLeader))
 				require_True(t, isClusterResetErr(err))
-				mset.resetClusteredState(err)
+				mset.resetClusteredState(mset.raftNode(), err)
 			},
 		},
 	}
@@ -3709,7 +3709,7 @@ func TestJetStreamClusterConsumerDesyncAfterErrorDuringStreamCatchup(t *testing.
 	require_NoError(t, err)
 
 	// Run error condition.
-	mset.resetClusteredState(nil)
+	mset.resetClusteredState(mset.raftNode(), nil)
 
 	// Consumer leader stays offline, we only start the server with missing stream/consumer data.
 	// We expect that the reset server must not allow the outdated server to become leader, as that would result in desync.
@@ -3870,7 +3870,7 @@ func TestJetStreamClusterReservedResourcesAccountingAfterClusterReset(t *testing
 			require_NotNil(t, sa)
 			require_Equal(t, rn, saGroupNode)
 
-			require_True(t, mset.resetClusteredState(clusterResetErr))
+			require_True(t, mset.resetClusteredState(mset.raftNode(), clusterResetErr))
 
 			checkFor(t, 5*time.Second, 500*time.Millisecond, func() error {
 				sjs.mu.RLock()
@@ -8739,7 +8739,7 @@ func TestJetStreamClusterApplyEntriesRejectEmptyNormal(t *testing.T) {
 		t.Fatalf("expected errBadEntryOp from applyMetaEntries, got %v", err)
 	}
 	ce := &CommittedEntry{Entries: empty}
-	if _, err := js.applyStreamEntries(&stream{}, ce, false, nil); err != errBadEntryOp {
+	if _, err := js.applyStreamEntries(&stream{}, nil, ce, false, nil); err != errBadEntryOp {
 		t.Fatalf("expected errBadEntryOp from applyStreamEntries, got %v", err)
 	}
 	if err := js.applyConsumerEntries(&consumer{}, ce, false); err != errBadEntryOp {

--- a/server/norace_1_test.go
+++ b/server/norace_1_test.go
@@ -3837,7 +3837,7 @@ func TestNoRaceJetStreamClusterStreamReset(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 	// Do a hard reset here by hand.
-	mset.resetClusteredState(nil)
+	mset.resetClusteredState(mset.raftNode(), nil)
 
 	// Wait til we have the consumer leader re-elected.
 	c.waitOnConsumerLeader("$G", "TEST", "d1")

--- a/server/raft.go
+++ b/server/raft.go
@@ -189,6 +189,7 @@ type raft struct {
 	observed map[string]time.Time           // Peers not in our peer set that we've heard from, only for managed groups
 	acks     map[uint64]map[string]struct{} // Append entry responses/acks, map of entry index -> peer ID
 	pae      map[uint64]*appendEntry        // Pending append entries
+	paeBytes uint64                         // Total byte size of the pending append entries in pae
 
 	rescue *time.Timer // Non-nil while an unsafe quorum rescue is active (see RescueQuorum)
 	elect  *time.Timer // Election timer, normally accessed via electTimer
@@ -1049,10 +1050,28 @@ func (n *raft) isLeaderOverrun() bool {
 	// We only do this past a high threshold to protect ourselves.
 	// Worst-case we'll have 2x the threshold, once in uncommitted and once in unapplied entries.
 	// Either the number of uncommitted entries is over the threshold: we're not getting quorum from our followers.
-	uncommittedThreshold := n.pindex > commit && n.pindex-commit > pauseQuorumThreshold
+	uncommittedThreshold := n.pindex > commit && n.overrun(n.pindex-commit, pauseQuorumThreshold, pauseQuorumBytes)
 	// Or, the number of in-memory committed but not yet applied entries is over the threshold: we're slow to apply.
-	unappliedThreshold := commit > applied && commit-applied > pauseQuorumThreshold
+	unappliedThreshold := commit > applied && n.overrun(commit-applied, pauseQuorumThreshold, pauseQuorumBytes)
 	return uncommittedThreshold || unappliedThreshold
+}
+
+// entryBytes estimates the byte size of the given number of entries, based on the
+// average size of the entries we are currently holding in our WAL.
+// Lock should be held.
+func (n *raft) entryBytes(entries uint64) uint64 {
+	msgs := n.pindex - n.papplied
+	if msgs == 0 || n.bytes == 0 {
+		return 0
+	}
+	return entries * n.bytes / msgs
+}
+
+// overrun returns whether the given number of entries is over either the entry count
+// threshold or the estimated byte threshold.
+// Lock should be held.
+func (n *raft) overrun(entries, maxEntries, maxBytes uint64) bool {
+	return entries > maxEntries || n.entryBytes(entries) > maxBytes
 }
 
 // ForwardProposal will forward the proposal to the leader if known.
@@ -1627,8 +1646,8 @@ func (n *raft) installSnapshot(snap *snapshot) error {
 	}
 
 	// If installing a snapshot past our commits, clear the cache.
-	if snap.lastIndex > n.commit && len(n.pae) > 0 {
-		n.pae = make(map[uint64]*appendEntry)
+	if snap.lastIndex > n.commit {
+		n.resetPendingEntries()
 	}
 
 	var state StreamState
@@ -3821,7 +3840,14 @@ func (n *raft) applyCommit(index uint64) error {
 			return errEntryLoadFailed
 		}
 	} else {
-		defer delete(n.pae, index)
+		// Size it now, the buffer is cleared below.
+		sz := n.entryStoreSize(ae)
+		defer func() {
+			if _, ok := n.pae[index]; ok {
+				n.paeBytes -= sz
+				delete(n.pae, index)
+			}
+		}()
 	}
 
 	n.commit = index
@@ -4312,12 +4338,11 @@ func (n *raft) truncateWAL(term, index uint64) {
 
 	// Invalidate cached entries the WAL no longer has.
 	if index == 0 {
-		if len(n.pae) > 0 {
-			n.pae = make(map[uint64]*appendEntry)
-		}
+		n.resetPendingEntries()
 	} else {
-		for k := range n.pae {
+		for k, ae := range n.pae {
 			if k > index {
+				n.paeBytes -= n.entryStoreSize(ae)
 				delete(n.pae, k)
 			}
 		}
@@ -4569,7 +4594,7 @@ func (n *raft) processAppendEntry(ae *appendEntry, sub *subscription) {
 	if sub != nil && (commit > applied || n.quorumPaused) {
 		diff := commit - applied
 		if n.quorumPaused {
-			if diff > paeWarnThreshold {
+			if n.overrun(diff, paeWarnThreshold, paeWarnBytes) {
 				if catchingUp {
 					n.cancelCatchup()
 				}
@@ -4582,7 +4607,7 @@ func (n *raft) processAppendEntry(ae *appendEntry, sub *subscription) {
 			var state StreamState
 			n.wal.FastState(&state)
 			n.warn("Quorum resumed: commit %d, applied %d, WAL size %s", commit, applied, friendlyBytes(state.Bytes))
-		} else if diff > pauseQuorumThreshold {
+		} else if n.overrun(diff, pauseQuorumThreshold, pauseQuorumBytes) {
 			// It takes a while until we reach the pause threshold, but once we do we enter a "cooldown period".
 			n.quorumPaused = true
 			n.overrunCount++
@@ -5013,13 +5038,7 @@ func (n *raft) storeToWAL(ae *appendEntry) error {
 		return errEntryStoreFailed
 	}
 
-	var sz uint64
-	if n.wtype == FileStorage {
-		sz = fileStoreMsgSize(_EMPTY_, nil, ae.buf)
-	} else {
-		sz = memStoreMsgSize(_EMPTY_, nil, ae.buf)
-	}
-	n.bytes += sz
+	n.bytes += n.entryStoreSize(ae)
 	n.pterm = ae.term
 	n.pindex = seq
 	return nil
@@ -5027,9 +5046,15 @@ func (n *raft) storeToWAL(ae *appendEntry) error {
 
 const (
 	pauseQuorumThreshold = 100_000
-	paeDropThreshold     = 20_000
-	paeWarnThreshold     = 10_000
-	paeWarnModulo        = 5_000
+	pauseQuorumBytes     = 1 * 1024 * 1024 * 1024 // 1GB
+
+	paeDropThreshold = 20_000
+	paeDropBytes     = 256 * 1024 * 1024 // 256MB
+
+	paeWarnThreshold   = 10_000
+	paeWarnModulo      = 5_000
+	paeWarnBytes       = 128 * 1024 * 1024 // 128MB
+	paeWarnBytesModulo = 32 * 1024 * 1024  // 32MB
 )
 
 func (n *raft) sendAppendEntry(entries []*Entry) {
@@ -5089,16 +5114,46 @@ func (n *raft) sendAppendEntryLocked(entries []*Entry, checkLeader bool) error {
 // cachePendingEntry saves append entries in memory for faster processing during applyCommit.
 // Only save so many however to avoid memory bloat.
 func (n *raft) cachePendingEntry(ae *appendEntry) {
-	if l := len(n.pae); l < paeDropThreshold {
-		n.pae[n.pindex], l = ae, l+1
-		if l >= paeWarnThreshold && l%paeWarnModulo == 0 {
-			n.warn("%d append entries pending", len(n.pae))
-		}
-	} else {
-		// Invalidate cache entry at this index, we might have
-		// stored it previously with a different value.
+	// Invalidate any cache entry at this index, we might have
+	// stored it previously with a different value.
+	if pae, ok := n.pae[n.pindex]; ok {
+		n.paeBytes -= n.entryStoreSize(pae)
 		delete(n.pae, n.pindex)
 	}
+	if l := uint64(len(n.pae)); l < paeDropThreshold && n.paeBytes < paeDropBytes {
+		prev := n.paeBytes
+		n.pae[n.pindex], l = ae, l+1
+		n.paeBytes += n.entryStoreSize(ae)
+		if l >= paeWarnThreshold && l%paeWarnModulo == 0 {
+			n.warn("%d append entries pending", len(n.pae))
+		} else if b := n.paeBytes; b >= paeWarnBytes {
+			// Only log on transition past another paeWarnBytesModulo.
+			if b/paeWarnBytesModulo != prev/paeWarnBytesModulo {
+				n.warn("%d append entries pending, %s", l, friendlyBytes(b))
+			}
+		}
+	}
+}
+
+// entryStoreSize returns the byte size of the given append entry as stored in our WAL.
+// Lock should be held.
+func (n *raft) entryStoreSize(ae *appendEntry) uint64 {
+	if ae == nil || ae.buf == nil {
+		return 0
+	}
+	if n.wtype == FileStorage {
+		return fileStoreMsgSize(_EMPTY_, nil, ae.buf)
+	}
+	return memStoreMsgSize(_EMPTY_, nil, ae.buf)
+}
+
+// resetPendingEntries clears our append entry cache.
+// Lock should be held.
+func (n *raft) resetPendingEntries() {
+	if len(n.pae) > 0 {
+		n.pae = make(map[uint64]*appendEntry)
+	}
+	n.paeBytes = 0
 }
 
 type extensionState uint16
@@ -5693,9 +5748,7 @@ retry:
 	} else if state == Leader && pstate != Leader {
 		// Don't updateLeadChange here, it will be done in switchToLeader or after initial messages are applied.
 		leadChanged = true
-		if len(n.pae) > 0 {
-			n.pae = make(map[uint64]*appendEntry)
-		}
+		n.resetPendingEntries()
 	}
 
 	n.writeTermVote()

--- a/server/raft.go
+++ b/server/raft.go
@@ -2577,6 +2577,10 @@ const (
 	raftRemovePeerSubj = "$NRG.RP.%s"
 	raftReply          = "$NRG.R.%s"
 	raftCatchupReply   = "$NRG.CR.%s"
+	// Catchup progress replies happen in their own subject space for
+	// flow control to the leader, but not counting toward quorum.
+	raftCatchupProgressReply = "$NRG.CP.%s"
+	raftCatchupProgressPre   = "$NRG.CP."
 )
 
 // Lock should be held (due to use of random generator)
@@ -2588,6 +2592,17 @@ func (n *raft) newCatchupInbox() string {
 		l /= base
 	}
 	return fmt.Sprintf(raftCatchupReply, b[:])
+}
+
+// Lock should be held (due to use of random generator)
+func (n *raft) newCatchupProgressInbox() string {
+	var b [replySuffixLen]byte
+	rn := fastrand.Uint64()
+	for i, l := 0, rn; i < len(b); i++ {
+		b[i] = digits[l%base]
+		l /= base
+	}
+	return fmt.Sprintf(raftCatchupProgressReply, b[:])
 }
 
 func (n *raft) newInbox() string {
@@ -3577,17 +3592,32 @@ func (n *raft) loadFirstEntry() (ae *appendEntry, err error) {
 }
 
 func (n *raft) runCatchup(ar *appendEntryResponse, indexUpdatesQ *ipQueue[uint64]) {
-	n.RLock()
-	s, reply := n.s, n.areply
+	n.Lock()
+	s := n.s
 	peer, subj, term, pterm, last := ar.peer, ar.reply, n.term, n.pterm, n.pindex
 	leader := n.State() == Leader // Grab while holding lock, to not race.
-	n.RUnlock()
+	// Catchup progress responses for flow control happen on its own subscription,
+	// not counting toward quorum.
+	reply := n.newCatchupProgressInbox()
+	psub, err := n.subscribe(reply, func(_ *subscription, _ *client, _ *Account, _, _ string, msg []byte) {
+		if pr := decodeAppendEntryResponse(msg); pr != nil {
+			n.trackPeer(pr.peer)
+			if pr.success && pr.peer == peer {
+				indexUpdatesQ.push(pr.index)
+			}
+			arPool.Put(pr)
+		}
+	})
+	n.Unlock()
 
 	defer s.grWG.Done()
 	defer arPool.Put(ar)
 
 	defer func() {
 		n.Lock()
+		if psub != nil {
+			n.unsubscribe(psub)
+		}
 		// Only remove our own progress entry.
 		if q, ok := n.progress[peer]; ok && q == indexUpdatesQ {
 			delete(n.progress, peer)
@@ -3605,6 +3635,11 @@ func (n *raft) runCatchup(ar *appendEntryResponse, indexUpdatesQ *ipQueue[uint64
 		indexUpdatesQ.unregister()
 	}()
 
+	if err != nil {
+		// Without the progress subscription, there's no flow control, so catchup would stall.
+		n.warn("Canceling catchup for %q, could not subscribe to progress inbox: %v", peer, err)
+		return
+	}
 	if !leader {
 		n.debug("Canceling catchup for %q, not leader anymore", peer)
 		return
@@ -3981,11 +4016,6 @@ func (n *raft) trackResponse(ar *appendEntryResponse) bool {
 	// Update peer's last index.
 	if ps != nil && ar.index > ps.li {
 		ps.li = ar.index
-	}
-
-	// If we are tracking this peer as a catchup follower, update that here.
-	if indexUpdateQ := n.progress[ar.peer]; indexUpdateQ != nil {
-		indexUpdateQ.push(ar.index)
 	}
 
 	// Ignore items already committed, or skip if this is not about an entry that matches our current term.
@@ -4506,6 +4536,9 @@ func (n *raft) processAppendEntry(ae *appendEntry, sub *subscription) {
 	// Is this a new entry? New entries will be delivered on the append entry
 	// sub, rather than a catch-up sub.
 	isNew := sub != nil && sub == n.aesub
+	// Entries arriving on any other subscription are catchup entries being streamed
+	// to our dedicated catchup inbox.
+	isCatchup := sub != nil && !isNew
 
 	// If we are/were catching up ignore old catchup subs, but only if catching up from an older server
 	// that doesn't send the leader term when catching up or if we would truncate as a result.
@@ -4863,11 +4896,12 @@ CONTINUE:
 		}
 	}
 
-	// Only ever respond to new entries.
-	// Never respond to catchup messages, because providing quorum based on this is unsafe.
 	// The only way for the leader to receive "success" MUST be through this path.
+	// Only new entries are allowed to provide quorum, since providing quorum based
+	// on catchup is unsafe. Catchup entries are acked through here, but only on a
+	// dedicated progress inbox.
 	var ar *appendEntryResponse
-	if sub != nil && isNew {
+	if isNew || (isCatchup && strings.HasPrefix(aeReply, raftCatchupProgressPre)) {
 		ar = newAppendEntryResponse(n.pterm, n.pindex, n.id, true)
 	}
 	n.Unlock()

--- a/server/raft.go
+++ b/server/raft.go
@@ -1462,6 +1462,10 @@ func (n *raft) ResumeApply() {
 func (n *raft) DrainAndReplaySnapshot() bool {
 	n.Lock()
 	defer n.Unlock()
+	// If the node was deleted, we can't replay the snapshot.
+	if n.deleted {
+		return false
+	}
 	snap, err := n.loadLastSnapshot()
 	if err != nil {
 		return false
@@ -2492,6 +2496,7 @@ func (n *raft) Delete() {
 		wal.Delete(false)
 	}
 	os.RemoveAll(n.sd)
+	n.snapfile = _EMPTY_
 	n.debug("Deleted")
 }
 

--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -8331,3 +8331,195 @@ func TestNRGRescueQuorumEmptyVotesRequireRescue(t *testing.T) {
 	n.runAsCandidate()
 	require_NotEqual(t, n.State(), Leader)
 }
+
+func TestNRGEntryBytesEstimate(t *testing.T) {
+	n, cleanup := initSingleMemRaftNode(t)
+	defer cleanup()
+
+	n.Lock()
+	defer n.Unlock()
+
+	const largeEntryBytes = 512 * 1024
+	for _, test := range []struct {
+		name     string
+		pindex   uint64
+		papplied uint64
+		bytes    uint64
+		entries  uint64
+		expected uint64
+	}{
+		{"no entries in the wal", 0, 0, 0, 100, 0},
+		{"no bytes in the wal", 1000, 0, 0, 100, 0},
+		{"pindex equals papplied", 1000, 1000, 1024, 100, 0},
+		{"large entries", 1000, 0, 1000 * largeEntryBytes, 100, 100 * largeEntryBytes},
+		{"small entries", 1000, 0, 1000 * 1024, 100, 100 * 1024},
+		{"offset by papplied", 1500, 500, 1000 * largeEntryBytes, 100, 100 * largeEntryBytes},
+		{"asking for more than we hold", 1000, 0, 1000 * largeEntryBytes, 2000, 2000 * largeEntryBytes},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			n.pindex, n.papplied, n.bytes = test.pindex, test.papplied, test.bytes
+			require_Equal(t, n.entryBytes(test.entries), test.expected)
+		})
+	}
+}
+
+func TestNRGOverrunUsesBytesWhenEntryCountIsLow(t *testing.T) {
+	n, cleanup := initSingleMemRaftNode(t)
+	defer cleanup()
+
+	n.Lock()
+	defer n.Unlock()
+
+	// A backlog of large entries. The entry count stays two orders of magnitude
+	// below the count threshold the whole time, so only the byte threshold can
+	// catch this.
+	const largeEntryBytes = 512 * 1024
+	setAverage := func(entries, avg uint64) {
+		n.papplied, n.pindex, n.bytes = 0, entries, entries*avg
+	}
+
+	// 2500 entries of 512KiB is ~1.22GB, over pauseQuorumBytes.
+	setAverage(2500, largeEntryBytes)
+	require_True(t, 2500 < uint64(pauseQuorumThreshold))
+	require_True(t, n.overrun(2500, pauseQuorumThreshold, pauseQuorumBytes))
+
+	// 900 entries of 512KiB is ~460MB, under pauseQuorumBytes.
+	setAverage(900, largeEntryBytes)
+	require_False(t, n.overrun(900, pauseQuorumThreshold, pauseQuorumBytes))
+
+	// The entry count path must still work for small entries.
+	setAverage(2500, 1024)
+	require_False(t, n.overrun(2500, pauseQuorumThreshold, pauseQuorumBytes))
+	setAverage(pauseQuorumThreshold+1, 1024)
+	require_True(t, n.overrun(pauseQuorumThreshold+1, pauseQuorumThreshold, pauseQuorumBytes))
+}
+
+func TestNRGLeaderOverrunOnLargeEntries(t *testing.T) {
+	const largeEntryBytes = 512 * 1024
+	for _, test := range []struct {
+		name     string
+		lagging  string // which counter lags behind
+		expected bool
+		avg      uint64
+	}{
+		{"uncommitted large entries", "commit", true, largeEntryBytes},
+		{"uncommitted small entries", "commit", false, 1024},
+		{"unapplied large entries", "applied", true, largeEntryBytes},
+		{"unapplied small entries", "applied", false, 1024},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			n, cleanup := initSingleMemRaftNode(t)
+			defer cleanup()
+
+			n.Lock()
+			defer n.Unlock()
+
+			// 2500 entries is far below pauseQuorumThreshold, so whether we are
+			// overrun depends entirely on the byte estimate.
+			const entries = 2500
+			n.papplied, n.pindex, n.bytes = 0, entries, entries*test.avg
+			if test.lagging == "commit" {
+				// We are not getting quorum from our followers.
+				n.commit, n.applied = 0, 0
+			} else {
+				// We are committing but too slow to apply.
+				n.commit, n.applied = entries, 0
+			}
+
+			require_Equal(t, n.isLeaderOverrun(), test.expected)
+		})
+	}
+}
+
+func TestNRGCachePendingEntryBoundedByBytes(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		payloadSize int
+		inserts     int
+		capped      bool
+	}{
+		// Large entries: the cache fills up to paeDropBytes and stops
+		// there, nowhere near paeDropThreshold.
+		{"large entries stop at the byte cap", 512 * 1024, 1000, true},
+		// Small entries: 1000 of them is ~1MB, so nothing is dropped.
+		{"small entries are all cached", 1024, 1000, false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			n, cleanup := initSingleMemRaftNode(t)
+			defer cleanup()
+
+			entries := []*Entry{newEntry(EntryNormal, make([]byte, test.payloadSize))}
+			ae := encode(t, &appendEntry{leader: "S1Nunr6R", term: 1, entries: entries})
+
+			n.Lock()
+			defer n.Unlock()
+
+			sz := n.entryStoreSize(ae)
+			require_True(t, sz > 0)
+
+			// We stop caching once we'd go over paeDropBytes.
+			expected := test.inserts
+			if test.capped {
+				expected = int((paeDropBytes + sz - 1) / sz)
+			}
+
+			// A long history of entries that were applied but not snapshotted yet
+			// must not dilute what we account for, only what's cached counts.
+			n.papplied, n.bytes = 0, 100*1024*1024
+
+			for i := 1; i <= test.inserts; i++ {
+				n.pindex = uint64(i)
+				n.cachePendingEntry(ae)
+			}
+
+			require_Len(t, len(n.pae), expected)
+			// Whatever we dropped, it was not because of the entry count.
+			require_True(t, len(n.pae) < paeDropThreshold)
+			// We must account for exactly what we've cached.
+			require_Equal(t, n.paeBytes, uint64(len(n.pae))*sz)
+		})
+	}
+}
+
+func TestNRGCachePendingEntryBytesAccounting(t *testing.T) {
+	n, cleanup := initSingleMemRaftNode(t)
+	defer cleanup()
+
+	nats0 := "S1Nunr6R" // "nats-0"
+	newAE := func(index uint64, payload int) *appendEntry {
+		entries := []*Entry{newEntry(EntryNormal, make([]byte, payload))}
+		return encode(t, &appendEntry{leader: nats0, term: 1, pterm: 1, pindex: index - 1, entries: entries})
+	}
+
+	n.Lock()
+	defer n.Unlock()
+
+	large := newAE(3, 4*1024)
+	ssz, lsz := n.entryStoreSize(newAE(1, 128)), n.entryStoreSize(large)
+	require_True(t, lsz > ssz)
+
+	// Cache a couple of entries.
+	for i := uint64(1); i <= 3; i++ {
+		n.pindex = i
+		n.cachePendingEntry(newAE(i, 128))
+	}
+	require_Len(t, len(n.pae), 3)
+	require_Equal(t, n.paeBytes, 3*ssz)
+
+	// Re-caching an index with a different value must not account for it twice.
+	n.pindex = 3
+	n.cachePendingEntry(large)
+	require_Len(t, len(n.pae), 3)
+	require_Equal(t, n.paeBytes, 2*ssz+lsz)
+
+	// Truncating must remove the bytes of the entries the WAL no longer has.
+	n.pterm, n.pindex = 1, 3
+	n.truncateWAL(1, 2)
+	require_Len(t, len(n.pae), 2)
+	require_Equal(t, n.paeBytes, 2*ssz)
+
+	// Resetting the cache clears our accounting.
+	n.resetPendingEntries()
+	require_Len(t, len(n.pae), 0)
+	require_Equal(t, n.paeBytes, 0)
+}

--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -6526,6 +6526,67 @@ func TestNRGSnapshotCheckpointNodeClosed(t *testing.T) {
 	}
 }
 
+func TestNRGDrainAndReplaySnapshotNodeClosed(t *testing.T) {
+	for _, test := range []struct {
+		title  string
+		close  func(n *raft)
+		replay bool
+	}{
+		{title: "Stop", close: func(n *raft) { n.Stop() }, replay: true},
+		{title: "Delete", close: func(n *raft) { n.Delete() }, replay: false},
+	} {
+		t.Run(test.title, func(t *testing.T) {
+			n, cleanup := initSingleMemRaftNode(t)
+			defer cleanup()
+
+			// Create a sample entry, the content doesn't matter, just that it's stored.
+			esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true)
+			entries := []*Entry{newEntry(EntryNormal, esm)}
+
+			nats0 := "S1Nunr6R" // "nats-0"
+
+			// Timeline, the second message ups the pterm so we can snapshot on the first.
+			aeMsg1 := encode(t, &appendEntry{leader: nats0, term: 1, commit: 0, pterm: 0, pindex: 0, entries: entries})
+			aeHeartbeat := encode(t, &appendEntry{leader: nats0, term: 1, commit: 1, pterm: 1, pindex: 1, entries: nil})
+			aeMsg2 := encode(t, &appendEntry{leader: nats0, term: 2, commit: 1, pterm: 1, pindex: 1, entries: entries})
+
+			n.processAppendEntry(aeMsg1, n.aesub)
+			n.processAppendEntry(aeHeartbeat, n.aesub)
+			require_Equal(t, n.commit, 1)
+			n.Applied(1)
+			n.processAppendEntry(aeMsg2, n.aesub)
+
+			// Snapshot, so we have something to replay.
+			require_NoError(t, n.InstallSnapshot(nil, false))
+			require_True(t, n.snapfile != _EMPTY_)
+			sfile := n.snapfile
+			sdata, err := os.ReadFile(sfile)
+			require_NoError(t, err)
+
+			test.close(n)
+
+			if test.replay {
+				require_True(t, n.snapfile != _EMPTY_)
+				require_True(t, n.DrainAndReplaySnapshot())
+				return
+			}
+
+			// Delete must not leave us pointing at a file it just removed.
+			require_Equal(t, n.snapfile, _EMPTY_)
+			require_False(t, n.DrainAndReplaySnapshot())
+
+			// Snapshot filenames are only "snap.<term>.<index>", so a later
+			// incarnation of a same-named group can recreate this exact path.
+			// Even then a deleted node must refuse to replay, or we'd adopt
+			// another generation's state.
+			require_NoError(t, os.MkdirAll(filepath.Dir(sfile), defaultDirPerms))
+			require_NoError(t, os.WriteFile(sfile, sdata, defaultFilePerms))
+			n.snapfile = sfile
+			require_False(t, n.DrainAndReplaySnapshot())
+		})
+	}
+}
+
 func TestNRGInstallSnapshotForce(t *testing.T) {
 	n, cleanup := initSingleMemRaftNode(t)
 	defer cleanup()

--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -3242,6 +3242,198 @@ func TestNRGCatchupDontCountTowardQuorum(t *testing.T) {
 	require_Equal(t, msg.Reply, _EMPTY_)
 }
 
+func TestNRGCatchupAcksProgressWhenGivenProgressInbox(t *testing.T) {
+	n, cleanup := initSingleMemRaftNode(t)
+	defer cleanup()
+
+	// Create a sample entry, the content doesn't matter, just that it's stored.
+	esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true)
+	entries := []*Entry{newEntry(EntryNormal, esm)}
+
+	nats0 := "S1Nunr6R" // "nats-0"
+
+	aeReply := "$TEST"
+	progressReply := fmt.Sprintf(raftCatchupProgressReply, "test")
+
+	nc, err := nats.Connect(n.s.ClientURL(), nats.UserInfo("admin", "s3cr3t!"))
+	require_NoError(t, err)
+	defer nc.Close()
+
+	sub, err := nc.SubscribeSync(aeReply)
+	require_NoError(t, err)
+	defer sub.Drain()
+	psub, err := nc.SubscribeSync(progressReply)
+	require_NoError(t, err)
+	defer psub.Drain()
+	require_NoError(t, nc.Flush())
+
+	// Timeline
+	aeMissedMsg := encode(t, &appendEntry{leader: nats0, term: 1, commit: 0, pterm: 0, pindex: 0, entries: entries, reply: progressReply})
+	ae := appendEntry{leader: nats0, term: 1, commit: 0, pterm: 1, pindex: 1, entries: entries, reply: aeReply}
+	aeCatchupTrigger := encode(t, &ae)
+
+	// Simulate we missed all messages up to this point.
+	n.processAppendEntry(aeCatchupTrigger, n.aesub)
+	require_True(t, n.catchup != nil)
+
+	// Should reply we require catchup.
+	msg, err := sub.NextMsg(time.Second)
+	require_NoError(t, err)
+	ar := decodeAppendEntryResponse(msg.Data)
+	require_False(t, ar.success)
+	require_True(t, strings.HasPrefix(msg.Reply, "$NRG.CR"))
+
+	// A catchup entry that carries a dedicated progress inbox MUST be acked, that
+	// response is what lets the leader move its send window forward. Without it the
+	// leader can only ever have one window in flight before it gives up and stalls.
+	n.processAppendEntry(aeMissedMsg, n.catchup.sub)
+	msg, err = psub.NextMsg(time.Second)
+	require_NoError(t, err)
+	ar = decodeAppendEntryResponse(msg.Data)
+	require_Equal(t, ar.index, 1)
+	require_True(t, ar.success)
+
+	// It must NOT also show up on the general append entry inbox, since that is the
+	// path that feeds quorum.
+	_, err = sub.NextMsg(250 * time.Millisecond)
+	require_Error(t, err, nats.ErrTimeout)
+}
+
+func TestNRGCatchupSendsProgressInboxAndRefillsWindow(t *testing.T) {
+	n, cleanup := initSingleMemRaftNode(t)
+	defer cleanup()
+
+	nats0 := "S1Nunr6R" // "nats-0"
+	nats1 := "yrzKKRBu" // "nats-1"
+
+	n.Lock()
+	n.addPeer(nats1)
+	n.Unlock()
+
+	// Entries large enough that only a handful fit in the leader's 2MB send window,
+	// so catching this log up must span several windows.
+	const (
+		entrySize  = 512 * 1024
+		numEntries = 12
+	)
+	entries := []*Entry{newEntry(EntryNormal, make([]byte, entrySize))}
+
+	// Fill our WAL, so we have something to catch a follower up on.
+	for i := range numEntries {
+		pterm := uint64(1)
+		if i == 0 {
+			pterm = 0
+		}
+		ae := encode(t, &appendEntry{leader: nats0, term: 1, commit: 0, pterm: pterm, pindex: uint64(i), entries: entries})
+		n.processAppendEntry(ae, n.aesub)
+	}
+	require_Equal(t, n.pindex, numEntries)
+
+	catchupSubj := "$TEST.catchup"
+	nc, err := nats.Connect(n.s.ClientURL(), nats.UserInfo("admin", "s3cr3t!"))
+	require_NoError(t, err)
+	defer nc.Close()
+
+	sub, err := nc.SubscribeSync(catchupSubj)
+	require_NoError(t, err)
+	defer sub.Drain()
+	sub.SetPendingLimits(-1, -1)
+	require_NoError(t, nc.Flush())
+
+	n.switchToLeader()
+
+	// Pretend we haven't heard from the follower in a while. It's the only other peer,
+	// so as far as we're concerned right now we've lost quorum.
+	n.Lock()
+	n.lsut = time.Time{}
+	n.peers[nats1].ts = time.Now().Add(-2 * lostQuorumInterval)
+	n.Unlock()
+	require_True(t, n.lostQuorum())
+
+	// Ask to be caught up from the very beginning.
+	ar := newAppendEntryResponse(0, 0, nats1, false)
+	ar.reply = catchupSubj
+	n.catchupFollower(ar)
+
+	// Act as the follower. Every catchup entry is acknowledged on the reply subject
+	// the leader handed us, which is what refills its send window.
+	var received int
+	for received < numEntries {
+		msg, err := sub.NextMsg(time.Second)
+		if err != nil {
+			t.Fatalf("Only received %d of %d catchup entries before stalling: %v", received, numEntries, err)
+		}
+		// The leader must point catchup responses at a dedicated progress inbox, never
+		// at its general append entry inbox, so they can't be counted towards quorum.
+		require_True(t, strings.HasPrefix(msg.Reply, raftCatchupProgressPre))
+
+		cae, err := decodeAppendEntry(msg.Data, nil, msg.Reply)
+		require_NoError(t, err)
+		received++
+
+		par := newAppendEntryResponse(cae.term, cae.pindex+1, nats1, true)
+		require_NoError(t, nc.Publish(msg.Reply, par.encode(nil)))
+		require_NoError(t, nc.Flush())
+		arPool.Put(par)
+
+		// These acks don't go through processAppendEntryResponse, but they must still
+		// count as having heard from the peer. Otherwise, a catchup outlasting
+		// lostQuorumInterval makes us step down, while the follower is responding to us.
+		checkFor(t, time.Second, 10*time.Millisecond, func() error {
+			if n.lostQuorum() {
+				return errors.New("should not have lost quorum, peer is acking catchup progress")
+			}
+			return nil
+		})
+	}
+}
+
+func TestNRGCatchupLargeEntriesProgressesAcrossWindows(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	rg := c.createMemRaftGroup("TEST", 3, newStateAdder)
+	rg.waitOnLeader()
+
+	// The leader keeps at most maxOutstanding (2MB) of catchup entries in flight, so
+	// entries this large mean a catchup spans many send windows. A window can only be
+	// refilled once the follower reports progress on what it already received.
+	const (
+		entrySize  = 512 * 1024
+		numEntries = 64
+	)
+
+	// Take a follower down so it misses everything that follows.
+	follower := rg.nonLeader().(*stateAdder)
+	follower.stop()
+
+	leader := rg.leader().(*stateAdder)
+	for range numEntries {
+		data := make([]byte, entrySize)
+		binary.PutVarint(data, 1)
+		leader.propose(data)
+	}
+	rg.waitOnTotal(t, numEntries)
+
+	// Bring it back with an empty log, it must now be caught up from scratch.
+	follower.restart()
+
+	// Without working catchup flow control the leader pushes one 2MB window and then
+	// stalls out for a couple of seconds before the follower re-requests, which for a
+	// log this size takes the better part of a minute.
+	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+		var err error
+		for _, sm := range rg {
+			asm := sm.(*stateAdder)
+			if total := asm.total(); total != numEntries {
+				err = errors.Join(err, fmt.Errorf("Adder on %v has wrong total: %d vs %d",
+					asm.server(), total, numEntries))
+			}
+		}
+		return err
+	})
+}
+
 func TestNRGIgnoreTrackResponseWhenNotLeader(t *testing.T) {
 	n, cleanup := initSingleMemRaftNode(t)
 	defer cleanup()


### PR DESCRIPTION
This PR fixes various issues found while running in Antithesis a workload that scales streams up and down (which cycles Raft group names):
- `resetClusteredState` could resurrect a remapped/replaced group. `monitorStream` captures the Raft node, so `resetClusteredState` can now check whether the stream was remapped to host a different node in the meantime (or was in the process, in which case `mset.node` would be nil).
- The server could go out of memory due to the pending entry cache only limiting on entry count and not on bytes, given the append entries were very large in size. The cache size is now capped at ~256MB. This same bytes-awareness has been added to the overrun condition, such that the unapplied part of the log/disk can't take up more than ~1GB even if the number of entries itself was small.
- Catchup would stall, since the flow control was broken. PR https://github.com/nats-io/nats-server/pull/6944 correctly fixed the bug to not mark catchup entries for quorum, but broke flow control in the process, since `trackResponse` no longer receives progress messages. This PR introduces a specific inbox used for flow control/progress, without contributing it to quorum.
- `DrainAndReplaySnapshot` could replay a snapshot from a previous group that was since deleted, if a new snapshot existed with the same name.