### PR TITLE
[FIXED] Internal msg delete proposals counted as JetStream API requests

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -5111,6 +5111,8 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 				} else {
 					removed, err = mset.eraseMsg(md.Seq)
 				}
+				// Only respond for deletes that originated from a client request.
+				isClientReq := md.Client != nil
 
 				var isLeader bool
 				if node := mset.raftNode(); node != nil && node.Leader() {
@@ -5118,7 +5120,7 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 				}
 
 				if err == ErrStoreEOF {
-					if isLeader && !isRecovering {
+					if isClientReq && isLeader && !isRecovering {
 						var resp = JSApiMsgDeleteResponse{ApiResponse: ApiResponse{Type: JSApiMsgDeleteResponseType}}
 						resp.Error = NewJSStreamMsgDeleteFailedError(err, Unless(err))
 						s.sendAPIErrResponse(md.Client, mset.account(), md.Subject, md.Reply, _EMPTY_, s.jsonResponse(resp))
@@ -5131,7 +5133,7 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 						md.Seq, md.Client.serviceAccount(), md.Stream, err)
 				}
 
-				if isLeader && !isRecovering {
+				if isClientReq && isLeader && !isRecovering {
 					var resp = JSApiMsgDeleteResponse{ApiResponse: ApiResponse{Type: JSApiMsgDeleteResponseType}}
 					if err != nil {
 						resp.Error = NewJSStreamMsgDeleteFailedError(err, Unless(err))


### PR DESCRIPTION
Internal message deletes, such as those for replicated Interest/WQ as a result of message acknowledgement, were accounted in the API stats. This PR fixes that by preventing the accounting as well as advisories that would be sent for all these acked and removed messages.