### PR TITLE
(2.15) Leafnode interest propagation over routes for isolation

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -647,6 +647,7 @@ type subscription struct {
 	im      *streamImport // This is for import stream support.
 	rsi     bool
 	si      bool
+	leaf    bool            // Subscription interest originated from a leaf node.
 	shadow  []*subscription // This is to track shadowed accounts.
 	icb     msgHandler
 	subject []byte
@@ -5568,9 +5569,8 @@ func (c *client) processMsgResults(acc *Account, r *SublistResult, msg, deliver,
 					continue
 				} else {
 					// We want to favor qsubs in our own cluster. If the routed
-					// qsub has an origin, it means that is on behalf of a leaf.
-					// We need to treat it differently.
-					if len(sub.origin) > 0 {
+					// qsub is on behalf of a leaf, we need to treat it differently.
+					if sub.leaf {
 						// If we already have an rsub, nothing to do. Also, do
 						// not pick a routed qsub for a LEAF origin cluster
 						// that is the same than where the message comes from.

--- a/server/errors.go
+++ b/server/errors.go
@@ -197,6 +197,9 @@ var (
 	// ErrClusterNameHasSpaces signals that the cluster name contains spaces, which is not allowed.
 	ErrClusterNameHasSpaces = errors.New("cluster name cannot contain spaces")
 
+	// ErrClusterNameReserved signals that the cluster name is reserved for internal protocol use.
+	ErrClusterNameReserved = errors.New("cluster name is reserved")
+
 	// ErrMalformedSubject is returned when a subscription is made with a subject that does not conform to subject rules.
 	ErrMalformedSubject = errors.New("malformed subject")
 

--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -1672,6 +1672,12 @@ func (c *client) processLeafnodeInfo(info *Info) {
 			c.closeConnection(ProtocolViolation)
 			return
 		}
+		if info.Cluster == leafNoOriginCluster {
+			c.mu.Unlock()
+			c.sendErrAndErr(ErrClusterNameReserved.Error())
+			c.closeConnection(ProtocolViolation)
+			return
+		}
 		// For solicited outbound leaf connections, capture the remote's nonce.
 		// For inbound leaf connections, keep using the server-issued nonce that
 		// was sent in our initial INFO and must be signed in CONNECT.
@@ -2234,6 +2240,11 @@ func (c *client) processLeafNodeConnect(s *Server, arg []byte, lang string) erro
 		c.closeConnection(ProtocolViolation)
 		return ErrClusterNameHasSpaces
 	}
+	if proto.Cluster == leafNoOriginCluster {
+		c.sendErrAndErr(ErrClusterNameReserved.Error())
+		c.closeConnection(ProtocolViolation)
+		return ErrClusterNameReserved
+	}
 
 	// Check for cluster name collisions.
 	if cn := s.cachedClusterName(); cn != _EMPTY_ && proto.Cluster != _EMPTY_ && proto.Cluster == cn {
@@ -2538,7 +2549,7 @@ func (s *Server) initLeafNodeSmapAndSendSubs(c *client) {
 			continue
 		}
 		// Don't advertise interest from leafnodes to other isolated leafnodes.
-		if sub.client.kind == LEAF && c.isIsolatedLeafNode() {
+		if (sub.client.kind == LEAF || sub.leaf) && c.isIsolatedLeafNode() {
 			continue
 		}
 		// We ignore ourselves here.
@@ -2671,7 +2682,7 @@ func (acc *Account) updateLeafNodesEx(sub *subscription, delta int32, hubOnly bo
 		}
 		ln.mu.RLock()
 		// Don't advertise interest from leafnodes to other isolated leafnodes.
-		if sub.client.kind == LEAF && ln.isIsolatedLeafNode() {
+		if (sub.client.kind == LEAF || sub.leaf) && ln.isIsolatedLeafNode() {
 			ln.mu.RUnlock()
 			continue
 		}
@@ -2840,10 +2851,12 @@ func keyFromSub(sub *subscription) string {
 }
 
 const (
-	keyRoutedSub         = "R"
-	keyRoutedSubByte     = 'R'
-	keyRoutedLeafSub     = "L"
-	keyRoutedLeafSubByte = 'L'
+	keyRoutedSub                 = "R"
+	keyRoutedSubByte             = 'R'
+	keyRoutedLeafSub             = "L"
+	keyRoutedLeafSubByte         = 'L'
+	keyRoutedLeafNoOriginSub     = "N"
+	keyRoutedLeafNoOriginSubByte = 'N'
 )
 
 // Helper function to build the key that prevents collisions between normal
@@ -2851,14 +2864,18 @@ const (
 // Keys will look like this:
 // "R foo"          -> plain routed sub on "foo"
 // "R foo bar"      -> queue routed sub on "foo", queue "bar"
+// "N foo"          -> plain routed leaf sub on "foo" without an origin
+// "N foo bar"      -> queue routed leaf sub on "foo", queue "bar", without an origin
 // "L foo bar"      -> plain routed leaf sub on "foo", leaf "bar"
 // "L foo bar baz"  -> queue routed sub on "foo", queue "bar", leaf "baz"
 func keyFromSubWithOrigin(sub *subscription) string {
 	var sb strings.Builder
 	sb.Grow(2 + len(sub.origin) + 1 + len(sub.subject) + 1 + len(sub.queue))
-	leaf := len(sub.origin) > 0
-	if leaf {
+	hasOrigin := len(sub.origin) > 0
+	if hasOrigin {
 		sb.WriteByte(keyRoutedLeafSubByte)
+	} else if sub.leaf {
+		sb.WriteByte(keyRoutedLeafNoOriginSubByte)
 	} else {
 		sb.WriteByte(keyRoutedSubByte)
 	}
@@ -2868,7 +2885,7 @@ func keyFromSubWithOrigin(sub *subscription) string {
 		sb.WriteByte(' ')
 		sb.Write(sub.queue)
 	}
-	if leaf {
+	if hasOrigin {
 		sb.WriteByte(' ')
 		sb.Write(sub.origin)
 	}
@@ -2923,7 +2940,7 @@ func (c *client) processLeafSub(argo []byte) (err error) {
 	copy(arg, argo)
 
 	args := splitArg(arg)
-	sub := &subscription{client: c}
+	sub := &subscription{client: c, leaf: true}
 
 	delta := int32(1)
 	switch len(args) {

--- a/server/leafnode_test.go
+++ b/server/leafnode_test.go
@@ -11754,6 +11754,108 @@ func TestLeafNodeIsolatedLeafSubjectPropagationLocalIsolation(t *testing.T) {
 	}
 }
 
+func TestLeafNodeClusterIsolatedLeafSubjectPropagation(t *testing.T) {
+	spokeTmpl := `
+		port: -1
+		server_name: "%s"
+		accounts {
+			A { users: [{user: A, password: pwd}] }
+		}
+		leafnodes { port: -1 }
+	`
+
+	sp1Conf := createConfFile(t, []byte(fmt.Sprintf(spokeTmpl, "SP1")))
+	sp1, sp1Opts := RunServerWithConfig(sp1Conf)
+	defer sp1.Shutdown()
+
+	sp2Conf := createConfFile(t, []byte(fmt.Sprintf(spokeTmpl, "SP2")))
+	sp2, sp2Opts := RunServerWithConfig(sp2Conf)
+	defer sp2.Shutdown()
+
+	hubTmpl := `
+		port: -1
+		server_name: "%s"
+		accounts {
+			HA { users: [{user: HA, password: pwd}] }
+		}
+		cluster {
+			name: HUB
+			listen: 127.0.0.1:-1
+			%s
+		}
+		leafnodes {
+			port: -1
+			%s
+		}
+	`
+	remoteTmpl := `
+		remotes: [{
+			url: "nats://A:pwd@127.0.0.1:%d"
+			local: "HA"
+			isolate: %v
+			hub: true
+		}]
+	`
+
+	h1Conf := createConfFile(t, []byte(fmt.Sprintf(hubTmpl, "H1", _EMPTY_, fmt.Sprintf(remoteTmpl, sp1Opts.LeafNode.Port, false))))
+	h1, h1Opts := RunServerWithConfig(h1Conf)
+	defer h1.Shutdown()
+
+	routeToH1 := fmt.Sprintf("routes: [\"nats://127.0.0.1:%d\"]", h1Opts.Cluster.Port)
+	h2Conf := createConfFile(t, []byte(fmt.Sprintf(hubTmpl, "H2", routeToH1, _EMPTY_)))
+	h2, _ := RunServerWithConfig(h2Conf)
+	defer h2.Shutdown()
+
+	h3Conf := createConfFile(t, []byte(fmt.Sprintf(hubTmpl, "H3", routeToH1, fmt.Sprintf(remoteTmpl, sp2Opts.LeafNode.Port, true))))
+	h3, _ := RunServerWithConfig(h3Conf)
+	defer h3.Shutdown()
+
+	checkClusterFormed(t, h1, h2, h3)
+	checkLeafNodeConnected(t, h1)
+	checkLeafNodeConnected(t, h3)
+	checkLeafNodeConnected(t, sp1)
+	checkLeafNodeConnected(t, sp2)
+
+	// Hub-originated interest remains north-south even when the leaf connection
+	// is isolated. Connect the clients to different members of the hub cluster.
+	nch1 := natsConnect(t, h1.ClientURL(), nats.UserInfo("HA", "pwd"))
+	defer nch1.Close()
+
+	nch3 := natsConnect(t, h3.ClientURL(), nats.UserInfo("HA", "pwd"))
+	defer nch3.Close()
+
+	ns1, err := nch1.SubscribeSync("northsouth.h1")
+	require_NoError(t, err)
+
+	ns3, err := nch3.SubscribeSync("northsouth.h3")
+	require_NoError(t, err)
+
+	checkSubInterest(t, sp1, "A", "northsouth.h1", time.Second)
+	checkSubInterest(t, sp2, "A", "northsouth.h1", time.Second)
+	checkSubInterest(t, sp1, "A", "northsouth.h3", time.Second)
+	checkSubInterest(t, sp2, "A", "northsouth.h3", time.Second)
+
+	// Interest originating from SP1 enters the cluster through H1 and reaches
+	// H3 over a route. It must not be forwarded through H3's isolated leaf.
+	nc1 := natsConnect(t, sp1.ClientURL(), nats.UserInfo("A", "pwd"))
+	defer nc1.Close()
+
+	ew, err := nc1.SubscribeSync("eastwest")
+	require_NoError(t, err)
+
+	checkSubInterest(t, h3, "HA", "eastwest", time.Second)
+	checkSubNoInterest(t, sp2, "A", "eastwest", time.Second)
+
+	require_NoError(t, ew.Unsubscribe())
+
+	checkSubNoInterest(t, h1, "HA", "eastwest", time.Second)
+	checkSubNoInterest(t, h2, "HA", "eastwest", time.Second)
+	checkSubNoInterest(t, h3, "HA", "eastwest", time.Second)
+
+	require_NoError(t, ns1.Unsubscribe())
+	require_NoError(t, ns3.Unsubscribe())
+}
+
 func TestLeafNodeDaisyChainWithAccountImportExport(t *testing.T) {
 	hubConf := createConfFile(t, []byte(`
 		server_name: hub

--- a/server/opts.go
+++ b/server/opts.go
@@ -2036,6 +2036,11 @@ func parseCluster(v any, opts *Options, errors *[]error, warnings *[]error) erro
 				*errors = append(*errors, err)
 				continue
 			}
+			if cn == leafNoOriginCluster {
+				err := &configErr{tk, ErrClusterNameReserved.Error()}
+				*errors = append(*errors, err)
+				continue
+			}
 			opts.Cluster.Name = cn
 		case "listen":
 			hp, err := parseListen(mv)
@@ -2283,6 +2288,11 @@ func parseGateway(v any, o *Options, errors *[]error, warnings *[]error) error {
 			gn := mv.(string)
 			if strings.Contains(gn, " ") {
 				err := &configErr{tk, ErrGatewayNameHasSpaces.Error()}
+				*errors = append(*errors, err)
+				continue
+			}
+			if gn == leafNoOriginCluster {
+				err := &configErr{tk, ErrClusterNameReserved.Error()}
 				*errors = append(*errors, err)
 				continue
 			}

--- a/server/parser.go
+++ b/server/parser.go
@@ -691,12 +691,12 @@ func (c *client) parse(buf []byte) error {
 						if trace {
 							c.traceInOp("RS+", arg)
 						}
-						err = c.processRemoteSub(arg, false)
+						err = c.processRemoteSub(arg, false, false)
 					case 'L', 'l':
 						if trace {
 							c.traceInOp("LS+", arg)
 						}
-						err = c.processRemoteSub(arg, true)
+						err = c.processRemoteSub(arg, true, true)
 					}
 				case GATEWAY:
 					if trace {

--- a/server/route.go
+++ b/server/route.go
@@ -53,6 +53,8 @@ var (
 	lUnsubBytes = []byte{'L', 'S', '-', ' '}
 )
 
+const leafNoOriginCluster = "_"
+
 type route struct {
 	remoteID     string
 	remoteName   string
@@ -60,6 +62,7 @@ type route struct {
 	retry        bool
 	lnoc         bool
 	lnocu        bool
+	ln           bool
 	routeType    RouteType
 	url          *url.URL
 	authRequired bool
@@ -120,6 +123,7 @@ type connectInfo struct {
 	Dynamic  bool   `json:"cluster_dynamic,omitempty"`
 	LNOC     bool   `json:"lnoc,omitempty"`
 	LNOCU    bool   `json:"lnocu,omitempty"` // Support for LS- with origin cluster name
+	LN       bool   `json:"ln,omitempty"`    // Support for LS+/LS- leaf interest using a sentinel origin cluster
 	Gateway  string `json:"gateway,omitempty"`
 }
 
@@ -516,6 +520,7 @@ func (c *client) sendRouteConnect(clusterName string, tlsRequired bool) error {
 		Cluster:  clusterName,
 		Dynamic:  s.isClusterNameDynamic(),
 		LNOC:     true,
+		LN:       true,
 	}
 
 	b, err := json.Marshal(cinfo)
@@ -565,6 +570,11 @@ func (c *client) processRouteInfo(info *Info) {
 		c.route.remoteID = info.ID
 		c.mu.Unlock()
 		c.closeConnection(DuplicateRoute)
+		return
+	}
+	if info.Cluster == leafNoOriginCluster {
+		c.mu.Unlock()
+		c.closeConnection(ClusterNameConflict)
 		return
 	}
 
@@ -811,8 +821,9 @@ func (c *client) processRouteInfo(info *Info) {
 	c.route.tlsRequired = info.TLSRequired
 	c.route.gatewayURL = info.GatewayURL
 	c.route.remoteName = info.Name
-	c.route.lnoc = info.LNOC
-	c.route.lnocu = info.LNOCU
+	c.route.ln = info.LN
+	c.route.lnoc = info.LNOC || c.route.ln
+	c.route.lnocu = info.LNOCU || c.route.ln
 	c.route.jetstream = info.JetStream
 
 	// When sent through route INFO, if the field is set, it should be of size 1.
@@ -1266,18 +1277,20 @@ type asubs struct {
 // This is invoked knowing that the key contains an account name, so for a sub
 // that is not from a pinned-account route.
 // The `keyHasSubType` boolean indicates that the key starts with the indicator
-// for leaf or regular routed subscriptions.
+// for leaf or regular routed subscriptions. No-origin leaf subscriptions always have the
+// indicator so they remain distinct from RS+ even without LNOCU.
 func getAccNameFromRoutedSubKey(sub *subscription, key string, keyHasSubType bool) string {
+	fields := strings.Fields(key)
 	var accIdx int
-	if keyHasSubType {
+	if keyHasSubType || (sub.leaf && len(sub.origin) == 0) {
 		// Start after the sub type indicator.
 		accIdx = 1
 		// But if there is an origin, bump its index.
-		if len(sub.origin) > 0 {
+		if len(sub.origin) > 0 || (sub.leaf && len(fields) > 1 && fields[1] == leafNoOriginCluster) {
 			accIdx = 2
 		}
 	}
-	return strings.Fields(key)[accIdx]
+	return fields[accIdx]
 }
 
 // Returns if the route is dedicated to an account, its name, and a boolean
@@ -1410,16 +1423,18 @@ func (c *client) processRemoteUnsub(arg []byte, leafUnsub bool) (err error) {
 
 	c.mu.Lock()
 	originSupport := c.route.lnocu
+	lnSupport := c.route.ln
 	if c.route != nil && len(c.route.accName) > 0 {
 		accountName, accInProto = string(c.route.accName), false
 	}
 	c.mu.Unlock()
 
 	hasOrigin := leafUnsub && originSupport
-	_, accNameFromProto, subject, _, err := c.parseUnsubProto(arg, accInProto, hasOrigin)
+	origin, accNameFromProto, subject, _, err := c.parseUnsubProto(arg, accInProto, hasOrigin)
 	if err != nil {
 		return fmt.Errorf("processRemoteUnsub %s", err.Error())
 	}
+	noOrigin := lnSupport && bytesToString(origin) == leafNoOriginCluster
 	if accInProto {
 		accountName = accNameFromProto
 	}
@@ -1442,7 +1457,7 @@ func (c *client) processRemoteUnsub(arg []byte, leafUnsub bool) (err error) {
 	_key := _keya[:0]
 
 	var key string
-	if !originSupport {
+	if !originSupport && !noOrigin {
 		// If it is an LS- or RS-, we use the protocol as-is as the key.
 		key = bytesToString(arg)
 	} else {
@@ -1483,7 +1498,7 @@ func (c *client) processRemoteUnsub(arg []byte, leafUnsub bool) (err error) {
 	return nil
 }
 
-func (c *client) processRemoteSub(argo []byte, hasOrigin bool) (err error) {
+func (c *client) processRemoteSub(argo []byte, leafSub, hasOrigin bool) (err error) {
 	// Indicate activity.
 	c.in.subs++
 
@@ -1512,8 +1527,9 @@ func (c *client) processRemoteSub(argo []byte, hasOrigin bool) (err error) {
 	// the sub in the map.
 	c.mu.Lock()
 	accountName := string(c.route.accName)
-	oldStyle := !c.route.lnocu
+	lnSupport := c.route.ln
 	c.mu.Unlock()
+	oldStyle := !c.route.lnocu && !(leafSub && !hasOrigin)
 
 	// Indicate if the account name should be in the protocol. It would be the
 	// case if accountName is empty.
@@ -1522,7 +1538,7 @@ func (c *client) processRemoteSub(argo []byte, hasOrigin bool) (err error) {
 	// Copy so we do not reference a potentially large buffer.
 	// Add 2 more bytes for the routed sub type.
 	arg := make([]byte, 0, 2+len(argo))
-	if hasOrigin {
+	if leafSub {
 		arg = append(arg, keyRoutedLeafSubByte)
 	} else {
 		arg = append(arg, keyRoutedSubByte)
@@ -1552,7 +1568,7 @@ func (c *client) processRemoteSub(argo []byte, hasOrigin bool) (err error) {
 	}
 
 	delta := int32(1)
-	sub := &subscription{client: c}
+	sub := &subscription{client: c, leaf: leafSub}
 
 	// There will always be at least a subject, but its location will depend
 	// on if there is an origin, an account name, etc.. Since we know that
@@ -1585,8 +1601,10 @@ func (c *client) processRemoteSub(argo []byte, hasOrigin bool) (err error) {
 	// We know that the number of fields is correct. So we can access args[] based
 	// on where we expect the fields to be.
 
-	// If there is an origin, it will be at index 1.
-	if hasOrigin {
+	// If there is an origin, it will be at index 1. The negotiated sentinel
+	// denotes leaf interest without an actual origin cluster.
+	noOrigin := lnSupport && hasOrigin && bytesToString(args[1]) == leafNoOriginCluster
+	if hasOrigin && !noOrigin {
 		sub.origin = args[1]
 	}
 	// For subject, use subjIdx.
@@ -1738,6 +1756,14 @@ func (c *client) addRouteSubOrUnsubProtoToBuf(buf []byte, accName string, sub *s
 				buf = append(buf, ' ')
 			}
 		}
+	} else if sub.leaf && len(sub.origin) == 0 && c.route.ln {
+		if isSubProto {
+			buf = append(buf, lSubBytes...)
+		} else {
+			buf = append(buf, lUnsubBytes...)
+		}
+		buf = append(buf, leafNoOriginCluster...)
+		buf = append(buf, ' ')
 	} else {
 		if isSubProto {
 			buf = append(buf, rSubBytes...)
@@ -1843,13 +1869,15 @@ func (s *Server) sendSubsToRoute(route *client, idx int, account string) {
 			// Subject will always be the second field (index 1).
 			subj := stringToBytes(s[1])
 			// Check if the key is for a leaf (will be field 0).
-			forLeaf := s[0] == keyRoutedLeafSub
-			// For queue, if not for a leaf, we need 3 fields "R foo bar",
-			// but if for a leaf, we need 4 fields "L foo bar leaf_origin".
-			if l := len(s); (!forLeaf && l == 3) || (forLeaf && l == 4) {
+			leafWithOrigin := s[0] == keyRoutedLeafSub
+			leafWithoutOrigin := s[0] == keyRoutedLeafNoOriginSub
+			forLeaf := leafWithOrigin || leafWithoutOrigin
+			// For queue, regular and no-origin leaf keys have 3 fields,
+			// while a leaf key with an origin has 4.
+			if l := len(s); (!leafWithOrigin && l == 3) || (leafWithOrigin && l == 4) {
 				qn = stringToBytes(s[2])
 			}
-			if forLeaf {
+			if leafWithOrigin {
 				// The leaf origin will be the last field.
 				origin = stringToBytes(s[len(s)-1])
 			}
@@ -1858,7 +1886,7 @@ func (s *Server) sendSubsToRoute(route *client, idx int, account string) {
 			if !route.canImport(s[1]) {
 				continue
 			}
-			sub := subscription{origin: origin, subject: subj, queue: qn, qw: n}
+			sub := subscription{leaf: forLeaf, origin: origin, subject: subj, queue: qn, qw: n}
 			buf = route.addRouteSubOrUnsubProtoToBuf(buf, a.Name, &sub, true)
 		}
 		a.mu.RUnlock()
@@ -2751,6 +2779,7 @@ func (s *Server) startRouteAcceptLoop() {
 		Dynamic:      s.isClusterNameDynamic(),
 		LNOC:         true,
 		LNOCU:        true,
+		LN:           true,
 	}
 	// For tests that want to simulate old servers, do not set the compression
 	// on the INFO protocol if configured with CompressionNotSupported.
@@ -3045,6 +3074,13 @@ func (c *client) processRouteConnect(srv *Server, arg []byte, lang string) error
 	if srv == nil {
 		return ErrServerNotRunning
 	}
+	if proto.Cluster == leafNoOriginCluster {
+		errTxt := fmt.Sprintf("Rejecting connection, cluster name %q is reserved", proto.Cluster)
+		c.Errorf(errTxt)
+		c.sendErr(errTxt)
+		c.closeConnection(ClusterNameConflict)
+		return ErrClusterNameReserved
+	}
 
 	perms := srv.getOpts().Cluster.Permissions
 	clusterName := srv.ClusterName()
@@ -3083,8 +3119,9 @@ func (c *client) processRouteConnect(srv *Server, arg []byte, lang string) error
 	// Grab connection name of remote route.
 	c.mu.Lock()
 	c.route.remoteID = c.opts.Name
-	c.route.lnoc = proto.LNOC
-	c.route.lnocu = proto.LNOCU
+	c.route.ln = proto.LN // ... also implies LNOC+LNOCU
+	c.route.lnoc = proto.LNOC || c.route.ln
+	c.route.lnocu = proto.LNOCU || c.route.ln
 	c.setRoutePermissions(perms)
 	c.headers = supportsHeaders && proto.Headers
 	c.mu.Unlock()

--- a/server/server.go
+++ b/server/server.go
@@ -142,6 +142,7 @@ type Info struct {
 	Export        *SubjectPermission `json:"export,omitempty"`
 	LNOC          bool               `json:"lnoc,omitempty"`
 	LNOCU         bool               `json:"lnocu,omitempty"`
+	LN            bool               `json:"ln,omitempty"`              // Support for LS+/LS- leaf interest using a sentinel origin cluster, implies LNOC+LNOCU
 	InfoOnConnect bool               `json:"info_on_connect,omitempty"` // When true the server will respond to CONNECT with an INFO
 	RoutePoolSize int                `json:"route_pool_size,omitempty"`
 	RoutePoolIdx  int                `json:"route_pool_idx,omitempty"`
@@ -1128,6 +1129,13 @@ func validateCluster(o *Options) error {
 		}
 		// Set this here so we do not consider it dynamic.
 		o.Cluster.Name = o.Gateway.Name
+	}
+	clusterName := o.Cluster.Name
+	if clusterName == _EMPTY_ && len(o.LeafNode.Remotes) > 0 && o.Cluster.Port == 0 {
+		clusterName = o.ServerName
+	}
+	if clusterName == leafNoOriginCluster {
+		return ErrClusterNameReserved
 	}
 	if l := len(o.Cluster.PinnedAccounts); l > 0 {
 		if o.Cluster.PoolSize < 0 {

--- a/test/new_routes_test.go
+++ b/test/new_routes_test.go
@@ -17,6 +17,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"regexp"
 	"testing"
 	"time"
 
@@ -61,6 +62,186 @@ func TestNewRouteInfoOnConnect(t *testing.T) {
 	if !info.LNOCU {
 		t.Fatalf("Expected to have leafnode origin cluster in unsub protocol support")
 	}
+}
+
+func TestNewRouteLNImpliesLeafNodeOriginSupport(t *testing.T) {
+	t.Run("CONNECT", func(t *testing.T) {
+		s, opts := runNewRouteServer(t)
+		defer s.Shutdown()
+
+		rc := createRouteConn(t, opts.Cluster.Host, opts.Cluster.Port)
+		defer rc.Close()
+		checkInfoMsg(t, rc)
+		send, expect := sendCommand(t, rc), expectCommand(t, rc)
+		send(`CONNECT {"name":"LN-CONNECT","cluster":"xyz","ln":true}` + "\r\n")
+		send("LS+ leaf $G foo\r\nLS- leaf $G foo\r\nPING\r\n")
+		expect(pongRe)
+	})
+
+	t.Run("INFO", func(t *testing.T) {
+		s, opts := runNewRouteServer(t)
+		defer s.Shutdown()
+
+		rc := createRouteConn(t, opts.Cluster.Host, opts.Cluster.Port)
+		defer rc.Close()
+		info := checkInfoMsg(t, rc)
+		routeSend, routeExpect := setupRouteEx(t, rc, opts, "LN-INFO")
+		info.ID, info.Name = "LN-INFO", ""
+		info.LN, info.LNOC, info.LNOCU = true, false, false
+		b, err := json.Marshal(info)
+		if err != nil {
+			t.Fatalf("Could not marshal test route info: %v", err)
+		}
+		routeSend(fmt.Sprintf("INFO %s\r\n", b))
+		routeSend("LS+ leaf $G foo\r\nLS- leaf $G foo\r\nPING\r\n")
+		routeExpect(pongRe)
+	})
+}
+
+func TestNewRouteLNLeafInterestProtocol(t *testing.T) {
+	hubConf := createConfFile(t, []byte(`
+		listen: 127.0.0.1:-1
+		cluster { name: xyz, listen: 127.0.0.1:-1 }
+		leafnodes { listen: 127.0.0.1:-1, no_advertise: true }
+		no_sys_acc: true
+	`))
+	hub, opts := RunServerWithConfig(hubConf)
+	defer hub.Shutdown()
+
+	leafConf := createConfFile(t, []byte(fmt.Sprintf(`
+		listen: 127.0.0.1:-1
+		leafnodes { remotes: [{url: "nats-leaf://127.0.0.1:%d"}] }
+		no_sys_acc: true
+	`, opts.LeafNode.Port)))
+	leaf, _ := RunServerWithConfig(leafConf)
+	defer leaf.Shutdown()
+	checkLeafNodeConnected(t, hub)
+
+	lnSubRe := regexp.MustCompile(`LS\+\s+_\s+([^\s]+)\s+([^\s]+)\s*([^\s]+)?\s*(\d+)?\r\n`)
+	lnUnsubRe := regexp.MustCompile(`LS\-\s+_\s+([^\s]+)\s+([^\s]+)\s*([^\s]+)?\r\n`)
+
+	for _, test := range []struct {
+		name    string
+		ln      bool
+		subRe   *regexp.Regexp
+		unsubRe *regexp.Regexp
+	}{
+		{"LN", true, lnSubRe, lnUnsubRe},
+		{"pre-LN", false, rsubRe, runsubRe},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			nc, err := nats.Connect(leaf.ClientURL())
+			if err != nil {
+				t.Fatalf("Unexpected client connect error: %v", err)
+			}
+			defer nc.Close()
+			sub, err := nc.SubscribeSync("foo")
+			if err != nil {
+				t.Fatalf("Unexpected subscribe error: %v", err)
+			}
+			if err := nc.Flush(); err != nil {
+				t.Fatalf("Unexpected flush error: %v", err)
+			}
+			checkSubInterest(t, hub, "$G", "foo", time.Second)
+
+			rc := createRouteConn(t, opts.Cluster.Host, opts.Cluster.Port)
+			defer rc.Close()
+			routeID := "LN-PROTO-" + test.name
+			routeSend, routeExpect := setupRouteEx(t, rc, opts, routeID)
+			info := checkInfoMsg(t, rc)
+			info.ID, info.Name, info.LN = routeID, "", test.ln
+			b, err := json.Marshal(info)
+			if err != nil {
+				t.Fatalf("Could not marshal test route info: %v", err)
+			}
+			routeSend(fmt.Sprintf("INFO %s\r\n", b))
+			routeExpect(test.subRe)
+
+			if err := sub.Unsubscribe(); err != nil {
+				t.Fatalf("Unexpected unsubscribe error: %v", err)
+			}
+			routeExpect(test.unsubRe)
+		})
+	}
+}
+
+func TestNewRouteLNIsolatedLeafInterest(t *testing.T) {
+	hub1Conf := createConfFile(t, []byte(`
+		listen: 127.0.0.1:-1
+		cluster { name: xyz, listen: 127.0.0.1:-1 }
+		leafnodes { listen: 127.0.0.1:-1, no_advertise: true }
+		no_sys_acc: true
+	`))
+	hub1, hub1Opts := RunServerWithConfig(hub1Conf)
+	defer hub1.Shutdown()
+
+	hub2Conf := createConfFile(t, []byte(fmt.Sprintf(`
+		listen: 127.0.0.1:-1
+		cluster {
+			name: xyz
+			listen: 127.0.0.1:-1
+			routes: ["nats-route://127.0.0.1:%d"]
+		}
+		leafnodes { listen: 127.0.0.1:-1, no_advertise: true }
+		no_sys_acc: true
+	`, hub1Opts.Cluster.Port)))
+	hub2, hub2Opts := RunServerWithConfig(hub2Conf)
+	defer hub2.Shutdown()
+	checkClusterFormed(t, hub1, hub2)
+
+	startLeaf := func(name string, isolated bool) *server.Server {
+		t.Helper()
+		conf := createConfFile(t, []byte(fmt.Sprintf(`
+			server_name: %s
+			listen: 127.0.0.1:-1
+			leafnodes {
+				remotes: [{
+					url: "nats-leaf://127.0.0.1:%d"
+					request_isolation: %v
+				}]
+			}
+			no_sys_acc: true
+		`, name, hub2Opts.LeafNode.Port, isolated)))
+		leaf, _ := RunServerWithConfig(conf)
+		return leaf
+	}
+
+	normalLeaf := startLeaf("NORMAL", false)
+	defer normalLeaf.Shutdown()
+	isolatedLeaf := startLeaf("ISOLATED", true)
+	defer isolatedLeaf.Shutdown()
+	checkLeafNodeConnected(t, normalLeaf)
+	checkLeafNodeConnected(t, isolatedLeaf)
+
+	// Use a raw leaf connection with no cluster in CONNECT. Its interest must
+	// cross the hub route as LS+ with the no-origin sentinel so the second hub retains leaf provenance.
+	source := createLeafConn(t, hub1Opts.LeafNode.Host, hub1Opts.LeafNode.Port)
+	defer source.Close()
+	checkInfoMsg(t, source)
+	sourceSend := sendCommand(t, source)
+	sourceSend("CONNECT {}\r\nLS+ eastwest\r\n")
+
+	checkSubInterest(t, hub2, "$G", "eastwest", time.Second)
+	checkSubInterest(t, normalLeaf, "$G", "eastwest", time.Second)
+	isolatedAcc, err := isolatedLeaf.LookupAccount("$G")
+	if err != nil {
+		t.Fatalf("Could not lookup isolated leaf account: %v", err)
+	}
+	if isolatedAcc.SubscriptionInterest("eastwest") {
+		t.Fatal("Isolated leaf unexpectedly received routed leaf interest")
+	}
+
+	sourceSend("LS- eastwest\r\n")
+	checkFor(t, time.Second, 10*time.Millisecond, func() error {
+		acc, err := normalLeaf.LookupAccount("$G")
+		if err != nil {
+			return err
+		}
+		if acc.SubscriptionInterest("eastwest") {
+			return fmt.Errorf("normal leaf still has east-west interest")
+		}
+		return nil
+	})
 }
 
 func TestNewRouteHeaderSupport(t *testing.T) {
@@ -1717,8 +1898,9 @@ func TestNewRouteLeafNodeOriginSupport(t *testing.T) {
 	info.Name = ""
 	info.LNOC = true
 	// Overwrite to false to check that we are getting LS- without origin
-	// if we are an old server.
+	// if we are an old server. LN implies LNOCU, so clear it too.
 	info.LNOCU = false
+	info.LN = false
 	b, err := json.Marshal(info)
 	if err != nil {
 		t.Fatalf("Could not marshal test route info: %v", err)


### PR DESCRIPTION
This PR adds a new route capability `LN` that allows leafnode subscriptions to propagate over routes using `LS+`/`LS-` with a sentinel origin name `_` for when the remote leaf cluster origin is not known.

This PR also reserves that `_` cluster name so that it cannot be configured, hence why this PR is marked for 2.15, since technically this is the first time we have enacted such a reservation over the cluster name.

The problem with `RS` is that it loses fidelity: we can no longer see whether a remote subscription originated from a leaf connection or not, so it bypasses the isolation check and causes more east/west traffic than intended.

Having this origin information available will fix the leafnode isolation across multiple cluster nodes.

If the `LN` route capability is not available on a route, e.g. due to mixed versions during a rolling upgrade, we will fall back to `RS+`/`RS-` for compatibility. The `LN` capability also automatically implies the `LNOC` and `LNOCU` capabilities, although we will continue to send those too for compatibility.

Fixes #8481.