### PR TITLE
fix: ensure no data race in processServiceImport during config reload

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -4839,15 +4839,18 @@ func (c *client) processServiceImport(si *serviceImport, acc *Account, msg []byt
 		return false
 	}
 	// Detect cycles and ignore (return) when we detect one.
+	// Note that this and the captures below read si.se, which can be updated
+	// concurrently by configureAccounts() while options are being reloaded
+	// (see #8499), so this is done under the account lock (RLock).
+	acc.mu.RLock()
 	if len(c.pa.psi) > 0 {
 		for i := len(c.pa.psi) - 1; i >= 0; i-- {
 			if psi := c.pa.psi[i]; psi.se == si.se {
+				acc.mu.RUnlock()
 				return false
 			}
 		}
 	}
-
-	acc.mu.RLock()
 	var checkJS bool
 	shouldReturn := si.invalid || acc.sl == nil
 	if !shouldReturn && !isResponse && si.to == jsAllAPI {
@@ -4858,14 +4861,31 @@ func (c *client) processServiceImport(si *serviceImport, acc *Account, msg []byt
 	siAcc := si.acc
 	allowTrace := si.atrc
 	isMsgTraceResp := isResponse && si.mt != nil
+	// Capture si.se under the account lock. configureAccounts() updates this
+	// field under the importing account's lock, so reading it under RLock is
+	// safe. The service export's .acc field (read below) is updated by the
+	// exporting account's configureAccounts() under the exporting account's
+	// lock, so we must read it under that lock.
+	siSe := si.se
 	acc.mu.RUnlock()
 
 	// We have a special case where JetStream pulls in all service imports through one export.
 	// However the GetNext for consumers and DirectGet for streams are a no-op and causes buildups of service imports,
 	// response service imports and rrMap entries which all will need to simply expire.
 	// TODO(dlc) - Come up with something better.
-	if shouldReturn || (checkJS && si.se != nil && si.se.acc == c.srv.SystemAccount()) {
+	if shouldReturn {
 		return false
+	}
+	if checkJS && siSe != nil {
+		// siSe.acc is updated by configureAccounts() under the exporting
+		// account's lock (siAcc), so read it under that lock.
+		var viaSysAcc bool
+		siAcc.mu.RLock()
+		viaSysAcc = siSe.acc == c.srv.SystemAccount()
+		siAcc.mu.RUnlock()
+		if viaSysAcc {
+			return false
+		}
 	}
 
 	mt, traceOnly := c.isMsgTraceEnabled()

--- a/server/reload_race_test.go
+++ b/server/reload_race_test.go
@@ -1,0 +1,137 @@
+// Copyright 2026 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nkeys"
+)
+
+// Regression test for https://github.com/nats-io/nats-server/issues/8499
+//
+// ReloadOptions() while JetStream / service-import traffic is flowing used to
+// trip a data race: reloadAuthorization() -> configureAccounts() writes an
+// account's service-import map (and si.se in particular) while the client
+// read-loop reads the same data in processServiceImport() during deliverMsg.
+//
+// This test only reproduces reliably under the race detector, mirroring the
+// reporter's embedded setup: JetStream + an nkey user (so that
+// reloadAuthorization() actually reprocesses authorization) plus concurrent
+// publishers/fetches that keep $JS.API service imports busy while options are
+// reloaded in a loop. TLS is intentionally omitted (the reporter noted it is
+// incidental).
+func TestReloadRaceWithServiceImports(t *testing.T) {
+	kp, err := nkeys.CreateUser()
+	if err != nil {
+		t.Fatalf("nkey: %v", err)
+	}
+	pub, _ := kp.PublicKey()
+
+	port := -1 // let the server pick a free port
+	storeDir := t.TempDir()
+	mkOpts := func() *Options {
+		return &Options{
+			Host:      "127.0.0.1",
+			Port:      port,
+			JetStream: true,
+			StoreDir:  storeDir,
+			NoSigs:    true,
+			Nkeys:     []*NkeyUser{{Nkey: pub}},
+		}
+	}
+
+	srv := New(mkOpts())
+	go srv.Start()
+	if !srv.ReadyForConnections(5 * time.Second) {
+		srv.Shutdown()
+		t.Fatalf("server not ready")
+	}
+	defer srv.Shutdown()
+
+	sign := func(nonce []byte) ([]byte, error) { return kp.Sign(nonce) }
+	nc, err := nats.Connect(srv.ClientURL(), nats.Nkey(pub, sign), nats.Timeout(5*time.Second))
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer nc.Close()
+
+	js, err := nc.JetStream()
+	if err != nil {
+		t.Fatalf("jetstream: %v", err)
+	}
+	if _, err := js.AddStream(&nats.StreamConfig{Name: "S", Subjects: []string{"js.>"}}); err != nil {
+		t.Fatalf("add stream: %v", err)
+	}
+	pull, err := js.PullSubscribe("js.>", "dur")
+	if err != nil {
+		t.Fatalf("pull subscribe: %v", err)
+	}
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < 4; i++ { // concurrent JetStream publishers ($JS.API service imports)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				_, _ = js.Publish("js.x", []byte("x"), nats.AckWait(500*time.Millisecond))
+			}
+		}()
+	}
+	wg.Add(1)
+	go func() { // consumer fetch loop: delivery is the read side
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			msgs, _ := pull.Fetch(20, nats.MaxWait(200*time.Millisecond))
+			for _, m := range msgs {
+				_ = m.Ack()
+			}
+		}
+	}()
+	wg.Add(1)
+	go func() { // ReloadOptions loop: the write side
+		defer wg.Done()
+		tk := time.NewTicker(5 * time.Millisecond)
+		defer tk.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-tk.C:
+				if err := srv.ReloadOptions(mkOpts()); err != nil {
+					t.Errorf("reload: %v", err)
+					return
+				}
+			}
+		}
+	}()
+
+	time.Sleep(3 * time.Second)
+	close(stop)
+	wg.Wait()
+}


### PR DESCRIPTION
Fixes #8499

## Problem

ReloadOptions() while JetStream / service-import traffic is flowing trips a data race (reported by the Go race detector):

```
Write at 0x... by goroutine N:
  server.(*Server).configureAccounts.func2()   server/server.go:1374
  server.(*Server).reloadAuthorization()        server/reload.go:2213
Previous read at 0x... by goroutine M:
  server.(*client).processServiceImport()       server/client.go:4865
  server.(*Account).addServiceImportSub.func1() server/accounts.go:2277
  server.(*client).deliverMsg()                 server/client.go:3916
```

`reloadAuthorization` -> `configureAccounts` writes an account's service-import state (`si.se`, and the service export's bound account `si.se.acc`) while the client read-loop reads the same fields in `processServiceImport` during `deliverMsg`.

## Fix

- Read `si.se` under the importing account's `RLock` (matching the lock `configureAccounts` uses to update it), including the cycle-detection loop and capturing the pointer for later use.
- Read `siSe.acc` under the exporting account's lock (`siAcc.mu`), matching the lock used by `configureAccounts` when it rewrites the service export's bound account.

## Testing

- New regression test `TestReloadRaceWithServiceImports`: embedded server with JetStream + nkey user, concurrent publishers/fetches keeping $JS.API service imports busy, and a ReloadOptions loop. Fails with a data-race report before this change, passes after.
- Existing service-import / reload / JetStream tests pass.
