### PR TITLE
[FIXED] Fix recycling pool buffers left by partial flushOutbound write

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -1810,7 +1810,7 @@ func (c *client) flushOutbound() bool {
 	}
 
 	// This is safe to do outside of the lock since "collapsed" is no longer
-	// referenced in c.out.nb (which can be modified in queueOutboud() while
+	// referenced in c.out.nb (which can be modified in queueOutbound() while
 	// the lock is released).
 	c.out.wnb = append(c.out.wnb, collapsed...)
 	var _orig [nbMaxVectorSize][]byte
@@ -1865,6 +1865,20 @@ func (c *client) flushOutbound() bool {
 		c.out.pb += attempted
 		if c.isWebsocket() {
 			c.ws.fs += attempted
+		}
+	}
+
+	// In case of a partial write, WriteTo will have resliced the buffer
+	// to drop the written bytes. As a side effect this will also change
+	// its capacity so it can't be recycled by nbPoolPut as originally intended
+	// and may either leak or land in the wrong pool.
+	// Prevent this by putting the remaining bytes back to the start of the slice
+	// so that it keeps its full capacity and is recycled once fully written or
+	// when the connection is closed.
+	if rem := len(c.out.wnb); rem > 0 && rem <= len(orig) {
+		if k := len(orig) - rem; len(c.out.wnb[0]) < len(orig[k]) {
+			n := copy(orig[k], c.out.wnb[0])
+			c.out.wnb[0] = orig[k][:n]
 		}
 	}
 

--- a/server/client_test.go
+++ b/server/client_test.go
@@ -2625,6 +2625,82 @@ func TestFlushOutboundFreesExcessiveWorkingBuffer(t *testing.T) {
 	}
 }
 
+type testTimeoutError struct{}
+
+func (testTimeoutError) Error() string   { return "i/o timeout" }
+func (testTimeoutError) Timeout() bool   { return true }
+func (testTimeoutError) Temporary() bool { return true }
+
+// Accepts up to maxWrite bytes per Write call, then reports a timeout,
+// leaving the rest of the buffer unwritten for the next flushOutbound.
+type testConnPartialWriteTimeout struct {
+	net.Conn
+	buf      bytes.Buffer
+	maxWrite int
+}
+
+func (c *testConnPartialWriteTimeout) Write(p []byte) (int, error) {
+	if c.maxWrite > 0 && len(p) > c.maxWrite {
+		n, _ := c.buf.Write(p[:c.maxWrite])
+		return n, testTimeoutError{}
+	}
+	return c.buf.Write(p)
+}
+
+func (c *testConnPartialWriteTimeout) RemoteAddr() net.Addr             { return nil }
+func (c *testConnPartialWriteTimeout) SetWriteDeadline(time.Time) error { return nil }
+
+func TestFlushOutboundPartialWriteKeepsPoolBufferCapacity(t *testing.T) {
+	opts := DefaultOptions()
+	s := &Server{opts: opts}
+
+	fakeConn := &testConnPartialWriteTimeout{maxWrite: 10}
+
+	// Use a ROUTER so that the write timeout policy is Retry, which keeps
+	// the connection open with the partially written buffer left in wnb.
+	c := &client{srv: s, kind: ROUTER, nc: fakeConn}
+	c.initClient()
+
+	payload := make([]byte, 100)
+	for i := range payload {
+		payload[i] = byte(i)
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.queueOutbound(payload)
+	c.flushOutbound()
+
+	// The write timed out after maxWrite bytes, so the rest of the buffer
+	// stays behind in the working copy for the next flush.
+	if n := len(c.out.wnb); n != 1 {
+		t.Fatalf("Expected 1 buffer left in wnb, got %v", n)
+	}
+	if n, expected := len(c.out.wnb[0]), len(payload)-fakeConn.maxWrite; n != expected {
+		t.Fatalf("Expected %v pending bytes in wnb, got %v", expected, n)
+	}
+	// The leftover buffer must retain its original pooled capacity.
+	if cp := cap(c.out.wnb[0]); cp != nbPoolSizeSmall {
+		t.Fatalf("Expected wnb buffer to keep pooled capacity %v, got %v", nbPoolSizeSmall, cp)
+	}
+
+	// Let the next flush complete the write and check nothing was lost
+	// or duplicated by the buffer shuffling.
+	fakeConn.maxWrite = 0
+	c.flushOutbound()
+
+	if n := len(c.out.wnb); n != 0 {
+		t.Fatalf("Expected no buffers left in wnb, got %v", n)
+	}
+	if c.out.pb != 0 {
+		t.Fatalf("Expected no pending bytes, got %v", c.out.pb)
+	}
+	if !bytes.Equal(payload, fakeConn.buf.Bytes()) {
+		t.Fatalf("Expected\n%q\ngot\n%q", payload, fakeConn.buf.Bytes())
+	}
+}
+
 type captureNoticeLogger struct {
 	DummyLogger
 	notices []string


### PR DESCRIPTION
In case of a partial write the internal buffer would have been resliced (via WriteTo) and change its capacity thus making it unable to be properly recycled.

Avoid this condition by putting the bytes back to original slice after detecting the partial write.

Signed-off-by: Waldemar Quevedo <wally@nats.io>