### PR TITLE
[FIXED] JetStream: decDeliveryCount underflow treated messages as exhausting MaxDeliver

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -4851,9 +4851,21 @@ func (o *consumer) incDeliveryCount(sseq uint64) uint64 {
 // Lock should be held.
 func (o *consumer) decDeliveryCount(sseq uint64) {
 	if o.rdc == nil {
-		o.rdc = make(map[uint64]uint64)
+		return
 	}
-	o.rdc[sseq] -= 1
+	dc, ok := o.rdc[sseq]
+	if !ok {
+		return
+	}
+	// Mirror incDeliveryCount, which goes from "no entry" to 1 on the first
+	// redelivery. Going back to the initial delivery therefore has to remove
+	// the entry rather than leave a zero behind, since a number of call sites
+	// (needAck, decStreamPending) test for key presence rather than value.
+	if dc > 1 {
+		o.rdc[sseq] = dc - 1
+	} else {
+		delete(o.rdc, sseq)
+	}
 }
 
 // send a delivery exceeded advisory.

--- a/server/jetstream_consumer_test.go
+++ b/server/jetstream_consumer_test.go
@@ -13388,3 +13388,58 @@ func TestJetStreamConsumerCreateCollisionPreservesExistingConsumerQueues(t *test
 	require_True(t, ok)
 	require_Equal(t, v.(*ipQueue[*nextMsgReq]), o.nextMsgReqs)
 }
+
+func TestJetStreamConsumerDeliveryCountUnderflow(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	nc, js := jsClientConnect(t, s)
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+	})
+	require_NoError(t, err)
+
+	_, err = js.Publish("foo", nil)
+	require_NoError(t, err)
+
+	acc, err := s.lookupAccount(globalAccountName)
+	require_NoError(t, err)
+	mset, err := acc.lookupStream("TEST")
+	require_NoError(t, err)
+
+	o, err := mset.addConsumer(&ConsumerConfig{
+		Durable:    "CONSUMER",
+		AckPolicy:  AckExplicit,
+		MaxDeliver: 3,
+	})
+	require_NoError(t, err)
+
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	// A failed delivery attempt on a message that was never redelivered must
+	// not fabricate redelivery state for it.
+	o.decDeliveryCount(1)
+	require_True(t, o.rdc == nil)
+	require_Equal(t, o.deliveryCount(1), 1)
+	// Underflow used to report a delivery count of 2^64-1 here, which is
+	// >= any configured MaxDeliver, so the message was immediately treated as
+	// having exhausted its delivery attempts.
+	require_False(t, o.hasMaxDeliveries(1))
+
+	// A failed delivery attempt after a redelivery has to be reversible, all
+	// the way back to no redelivery state at all.
+	require_Equal(t, o.incDeliveryCount(1), 2)
+	require_Equal(t, o.deliveryCount(1), 1)
+	require_Equal(t, o.incDeliveryCount(1), 3)
+	require_Equal(t, o.deliveryCount(1), 2)
+	o.decDeliveryCount(1)
+	require_Equal(t, o.deliveryCount(1), 1)
+	o.decDeliveryCount(1)
+	require_Equal(t, o.deliveryCount(1), 1)
+	_, present := o.rdc[1]
+	require_False(t, present)
+}


### PR DESCRIPTION
Resolves #8511.

### Problem

`decDeliveryCount` decremented `o.rdc[sseq]` without checking that an entry existed:

```go
func (o *consumer) decDeliveryCount(sseq uint64) {
	if o.rdc == nil {
		o.rdc = make(map[uint64]uint64)
	}
	o.rdc[sseq] -= 1
}
```

`incDeliveryCount` only creates an entry on redelivery, so a message on its first delivery has none. All three callers that undo a delivery attempt — `didNotDeliver`, the failed-delivery path in the delivery loop, and the `LoadMsg` failure path during redelivery — can therefore reach this with no entry present, and `0 - 1` wraps to `18446744073709551615`. The nil branch makes it worse by creating the map first, so a consumer that has never redelivered anything still ends up carrying redelivery state.

The `dc >= 1` guard in `deliveryCount` does not catch a wrapped value, so it is returned unchanged and `hasMaxDeliveries` compares `2^64-1 >= o.maxdc`, which holds for any configured `MaxDeliver`. One failed delivery attempt on a message's *first* delivery was consequently enough to have it dropped from pending, have the ack floor advanced past it, and have a max-deliveries advisory emitted with the wrapped count — the message never redelivered.

The same value reaches the `BackOff` index computations at `consumer.go:2281`, `:5944` and `:6122` as `int(-1)`. Those sites already carry `if dc < 0 { dc = 0 }` guards, which is what pointed me at the write side.

There is a second, smaller asymmetry: `incDeliveryCount` goes from *no entry* to `1`, but `decDeliveryCount` went from `1` to `0` and left the key behind. `needAck` (`consumer.go:3996`) and `decStreamPending` (`consumer.go:6981`) test for key presence rather than value, so a zero entry is not equivalent to no entry.

### Change

Make `decDeliveryCount` the exact inverse of `incDeliveryCount`: return early when there is no map or no entry, decrement above 1, and delete the entry at 1 so the consumer returns to having no redelivery state for that sequence.

### Tests

Adds `TestJetStreamConsumerDeliveryCountUnderflow`, covering both the underflow (a failed attempt on a never-redelivered message must leave `deliveryCount == 1` and `hasMaxDeliveries == false`) and the round-trip (two increments then two decrements must return to no entry). The test fails on the first assertion without the fix.

Verified locally on darwin/arm64, Go 1.26.7:

- `TestJetStreamConsumer*` — 368 pass
- `TestJetStreamClusterConsumer*` — 100 pass
- `TestJetStream.*(Redeliver|MaxDeliver|BackOff|AckAll|AckPending|Nak)` — 90 pass
- `go vet ./server` and `gofmt` clean

No new dependencies.
