### PR TITLE
Fix TestJetStreamClusterMemoryConsumerCompactVsSnapshot

### DIFF
--- a/server/jetstream_cluster_2_test.go
+++ b/server/jetstream_cluster_2_test.go
@@ -5596,7 +5596,18 @@ func TestJetStreamClusterMemoryConsumerCompactVsSnapshot(t *testing.T) {
 
 	checkFor(t, 5*time.Second, 100*time.Millisecond, func() error {
 		ci, err := js.ConsumerInfo("test", "d")
-		require_NoError(t, err)
+		if err != nil {
+			return err
+		}
+		// The restarted server can be assigned the consumer but not have created
+		// its Raft node yet, in which case it answers with defaults and no cluster
+		// info. Retry until we get an answer from the consumer leader.
+		if ci.Cluster == nil {
+			return errors.New("no cluster info")
+		}
+		if len(ci.Cluster.Replicas) != 2 {
+			return fmt.Errorf("expected 2 replicas, got %d", len(ci.Cluster.Replicas))
+		}
 		for _, r := range ci.Cluster.Replicas {
 			if !r.Current || r.Lag != 0 {
 				return fmt.Errorf("Replica not current: %+v", r)


### PR DESCRIPTION
Fix test panic

```
--- FAIL: TestJetStreamClusterMemoryConsumerCompactVsSnapshot (4.40s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered, repanicked]
[signal SIGSEGV: segmentation violation code=0x1 addr=0x50 pc=0x119f772]

goroutine 61033 [running]:
testing.tRunner.func1.2({0x23093b8, 0x2461f70})
	/opt/hostedtoolcache/go/1.27.0/x64/src/testing/testing.go:2123 +0x232
testing.tRunner.func1()
	/opt/hostedtoolcache/go/1.27.0/x64/src/testing/testing.go:2126 +0x329
panic({0x23093b8?, 0x2461f70?})
	/opt/hostedtoolcache/go/1.27.0/x64/src/runtime/panic.go:859 +0x125
github.com/nats-io/nats-server/v2/server.TestJetStreamClusterMemoryConsumerCompactVsSnapshot.func1()
	/home/runner/work/nats-server/nats-server/server/jetstream_cluster_2_test.go:5600 +0x72
github.com/nats-io/nats-server/v2/server.checkForErr(0x12a05f200, 0x5f5e100, 0x213a5c8fdf28)
	/home/runner/work/nats-server/nats-server/server/server_test.go:48 +0x94
github.com/nats-io/nats-server/v2/server.checkFor({0x2405ea0, 0x213a5b438908}, 0x12a05f200, 0x5f5e100, 0x213a5c8fdf28)
	/home/runner/work/nats-server/nats-server/server/server_test.go:59 +0x48
github.com/nats-io/nats-server/v2/server.TestJetStreamClusterMemoryConsumerCompactVsSnapshot(0x213a5b438908)
	/home/runner/work/nats-server/nats-server/server/jetstream_cluster_2_test.go:5597 +0x568
```

Signed-off-by: Waldemar Quevedo <wally@nats.io>
