### PR TITLE
(2.15) [IMPROVED] Index all stream sources, drop stream-level scan

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -2273,13 +2273,13 @@ func (fs *fileStore) recoverPerMessageState() error {
 	}
 
 	// Create or delete the source tracking if needed.
+	var sourcesScan map[string]*StreamSource
 	if sources != nil && fs.sources == nil {
 		sourcesSeq = fs.recoverSourcesState()
-		// Only allow scanning if the index recovered something. If there is no index
-		// yet, then we'll just not do the scan and let the upper layer do so when needed.
-		if fs.sources != nil {
-			sourcesRecover = true
-			scanSeq = min(scanSeq, sourcesSeq)
+		sourcesRecover = true
+		scanSeq = min(scanSeq, sourcesSeq)
+		if sourcesSeq <= fs.state.LastSeq {
+			sourcesScan = sources
 		}
 	}
 	if len(sources) > 0 {
@@ -2296,28 +2296,26 @@ func (fs *fileStore) recoverPerMessageState() error {
 			}
 		}
 		// Seed sources that aren't in the map yet.
-		for k := range sources {
+		for k, v := range sources {
 			if _, ok := fs.sources[k]; !ok {
 				fs.sources[k] = &StreamSourceState{}
+				// Since we're adding a new source, we'll need to recover its sequence (if any).
+				sourcesSeq = fs.state.FirstSeq
+				sourcesRecover = true
+				scanSeq = min(scanSeq, sourcesSeq)
+				if sourcesScan == nil {
+					sourcesScan = make(map[string]*StreamSource)
+				}
+				if _, ok = sourcesScan[k]; !ok {
+					sourcesScan[k] = v
+				}
 			}
 		}
 	}
-	if fs.sources != nil {
-		// No sources configured anymore, clear.
-		if len(sources) == 0 {
-			fs.sources = nil
-		}
-		// If all zeros or empty, remove the index from disk.
-		remove := true
-		for _, ss := range fs.sources {
-			if ss.Seq > 0 {
-				remove = false
-				break
-			}
-		}
-		if remove {
-			_ = os.Remove(fs.sourcesStatePath())
-		}
+	// No sources configured anymore, clear and remove the index from disk.
+	if fs.sources != nil && len(sources) == 0 {
+		fs.sources = nil
+		_ = os.Remove(fs.sourcesStatePath())
 	}
 
 	// Short-circuit if no recovering is required.
@@ -2336,7 +2334,7 @@ func (fs *fileStore) recoverPerMessageState() error {
 	if sourcesRecover && !ttlRecover && !schedRecover {
 		if fs.state.Msgs > 0 && sourcesSeq <= fs.state.LastSeq {
 			fs.warn("Sourcing state is outdated; attempting to recover using backward scan (seq %d to %d)", sourcesSeq, fs.state.LastSeq)
-			if err := fs.recoverSourcesBackwardScan(sourcesSeq, sources); err != nil {
+			if err := fs.recoverSourcesBackwardScan(sourcesSeq, sourcesScan); err != nil {
 				return err
 			}
 		}
@@ -2352,6 +2350,15 @@ func (fs *fileStore) recoverPerMessageState() error {
 		}
 		if sourcesRecover && sourcesSeq <= fs.state.LastSeq {
 			fs.warn("Sourcing state is outdated; attempting to recover using linear scan (seq %d to %d)", sourcesSeq, fs.state.LastSeq)
+		}
+		// Only consider sources that need recovering.
+		update := func(iName string, sseq uint64, ident string) {
+			if _, ok := sourcesScan[iName]; !ok {
+				return
+			}
+			if sss, ok := fs.sources[iName]; ok {
+				sss.Seq, sss.Ident = sseq, ident
+			}
 		}
 		var (
 			mb     *msgBlock
@@ -2417,11 +2424,17 @@ func (fs *fileStore) recoverPerMessageState() error {
 				}
 				if sourcesRecover && seq >= sourcesSeq {
 					if ss := sliceHeader(JSStreamSource, msg.hdr); len(ss) > 0 {
-						_, indexName, sseq, ident := streamAndSeq(bytesToString(ss))
-						if indexName != _EMPTY_ {
-							if sss, ok := fs.sources[indexName]; ok {
-								sss.Seq, sss.Ident = sseq, ident
+						streamName, iName, sseq, ident := streamAndSeq(bytesToString(ss))
+						if iName == _EMPTY_ {
+							// Pre-2.10 message header means it's a match for any source using that stream name.
+							// Such headers carry no identity, so it is left unset.
+							for _, ssi := range fs.cfg.Sources {
+								if streamName == ssi.Name || (ssi.External != nil && streamName == ssi.Name+":"+getHash(ssi.External.ApiPrefix)) {
+									update(ssi.composeIName(), sseq, _EMPTY_)
+								}
 							}
+						} else {
+							update(iName, sseq, ident)
 						}
 					}
 				}
@@ -4995,21 +5008,15 @@ func (fs *fileStore) ApplySourcesState(sources map[string]StreamSourceState) {
 }
 
 // SourcesState return sources keys and their last known state.
-func (fs *fileStore) SourcesState() (dst map[string]StreamSourceState) {
+func (fs *fileStore) SourcesState() map[string]StreamSourceState {
 	fs.mu.RLock()
 	defer fs.mu.RUnlock()
 	if len(fs.sources) == 0 {
 		return nil
 	}
-	// Allocate lazily so that a map containing only seeded (zero) entries returns
-	// nil rather than an empty map; zeros must not leak out of SourcesState.
+	dst := make(map[string]StreamSourceState, len(fs.sources))
 	for k, ss := range fs.sources {
-		if ss.Seq > 0 {
-			if dst == nil {
-				dst = make(map[string]StreamSourceState, 1)
-			}
-			dst[k] = *ss
-		}
+		dst[k] = *ss
 	}
 	return dst
 }
@@ -12423,7 +12430,7 @@ func (fs *fileStore) sourcesStatePath() string {
 
 func (fs *fileStore) writeSourcesState() error {
 	fs.mu.RLock()
-	if fs.sources == nil {
+	if len(fs.sources) == 0 {
 		fs.mu.RUnlock()
 		return nil
 	}
@@ -12432,30 +12439,19 @@ func (fs *fileStore) writeSourcesState() error {
 	// Must be lseq+1 to identify up to which sequence the sources are valid.
 	highSeq := fs.state.LastSeq + 1
 
-	var count, sz uint64
+	count := uint64(len(fs.sources))
+	var sz uint64
 	for source, ss := range fs.sources {
-		if ss.Seq > 0 {
-			count++
-			// Length prefix + source bytes + seq varint +
-			// length prefix + identity bytes.
-			sz += uint64(uvarintLen(uint64(len(source)))) + uint64(len(source)) + binary.MaxVarintLen64 +
-				uint64(uvarintLen(uint64(len(ss.Ident)))) + uint64(len(ss.Ident))
-		}
-	}
-	// Nothing observed yet, don't persist an empty index. Any stale file is
-	// removed by recoverPerMessageState on recovery.
-	if count == 0 {
-		fs.mu.RUnlock()
-		return nil
+		// Length prefix + source bytes + seq varint +
+		// length prefix + identity bytes.
+		sz += uint64(uvarintLen(uint64(len(source)))) + uint64(len(source)) + binary.MaxVarintLen64 +
+			uint64(uvarintLen(uint64(len(ss.Ident)))) + uint64(len(ss.Ident))
 	}
 	buf := make([]byte, 0, sourcesHeaderLen+sz)
 	buf = append(buf, 1)                                 // Magic version
 	buf = binary.LittleEndian.AppendUint64(buf, count)   // Entry count
 	buf = binary.LittleEndian.AppendUint64(buf, highSeq) // Stamp
 	for source, ss := range fs.sources {
-		if ss.Seq == 0 {
-			continue
-		}
 		buf = binary.AppendUvarint(buf, uint64(len(source)))
 		buf = append(buf, source...)
 		buf = binary.AppendUvarint(buf, ss.Seq)
@@ -12541,8 +12537,7 @@ func (fs *fileStore) decodeSourcesState(b []byte) (uint64, error) {
 	return stamp, nil
 }
 
-// recoverSourcesBackwardScan recovers fs.sources by scanning the stream backwards,
-// mirroring stream.startingSequenceForSources, down to and including the stopSeq.
+// recoverSourcesBackwardScan recovers fs.sources by scanning the stream backwards.
 // Lock should be held.
 func (fs *fileStore) recoverSourcesBackwardScan(stopSeq uint64, sources map[string]*StreamSource) error {
 	var sl *gsl.SimpleSublist

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -11508,21 +11508,64 @@ func TestFileStoreSourcesRecovery(t *testing.T) {
 		require_NoError(t, err)
 		defer fs.Stop()
 
+		// Sequence and identity must both survive the restart, otherwise
+		// stream recreation can't be detected.
+		// Recovered if it still exists, but otherwise the store needs to scan.
 		state = fs.SourcesState()
-		if remove {
-			// Should not recover the sources state if it didn't exist at least partially.
-			require_True(t, state == nil)
-		} else {
-			// Sequence and identity must both survive the restart, otherwise
-			// stream recreation can't be detected.
-			require_NotNil(t, state)
-			require_Equal(t, state["ORIGIN > >"].Seq, N)
-			require_Equal(t, state["ORIGIN > >"].Ident, ident)
-		}
+		require_NotNil(t, state)
+		require_Equal(t, state["ORIGIN > >"].Seq, N)
+		require_Equal(t, state["ORIGIN > >"].Ident, ident)
 	}
 
 	t.Run("Normal", func(t *testing.T) { test(t, false) })
 	t.Run("Remove", func(t *testing.T) { test(t, true) })
+}
+
+func TestFileStoreSourcesRecoveryPre210Headers(t *testing.T) {
+	// Pre-2.10 source headers carry no index name, they match any source using
+	// that stream name. Both the backward scan and the combined forward scan
+	// (taken when TTL/scheduling state must be recovered as well) must honor them,
+	// otherwise the source consumer restarts from sequence 1 and redelivers.
+	test := func(t *testing.T, allowMsgTTL bool) {
+		dir := t.TempDir()
+		cfg := StreamConfig{
+			Name:        "SOURCE",
+			Subjects:    []string{"foo.*"},
+			Storage:     FileStorage,
+			Sources:     []*StreamSource{{Name: "ORIGIN"}},
+			AllowMsgTTL: allowMsgTTL,
+		}
+		fcfg := FileStoreConfig{StoreDir: dir, BlockSize: 256}
+
+		fs, err := newFileStore(fcfg, cfg)
+		require_NoError(t, err)
+
+		// Pre-2.10 header format, just "<stream> <seq>", no index name and no identity.
+		const N = 10
+		for i := 1; i <= N; i++ {
+			hdr := genHeader(nil, JSStreamSource, fmt.Sprintf("ORIGIN %d", i))
+			_, _, err = fs.StoreMsg("foo.bar", hdr, nil, 0)
+			require_NoError(t, err)
+		}
+		require_NoError(t, fs.Stop())
+
+		// Drop the persisted index so recovery must scan for the source sequence.
+		require_NoError(t, os.Remove(filepath.Join(dir, sourcesStreamStateFile)))
+
+		fs, err = newFileStore(fcfg, cfg)
+		require_NoError(t, err)
+		defer fs.Stop()
+
+		// Must resume from the latest source sequence, not from zero.
+		state := fs.SourcesState()
+		require_NotNil(t, state)
+		require_Equal(t, state["ORIGIN > >"].Seq, N)
+		require_Equal(t, state["ORIGIN > >"].Ident, _EMPTY_)
+	}
+
+	// Without TTLs this takes the backward scan, with TTLs the combined forward scan.
+	t.Run("BackwardScan", func(t *testing.T) { test(t, false) })
+	t.Run("ForwardScan", func(t *testing.T) { test(t, true) })
 }
 
 func TestFileStoreSourcesStaleConfig(t *testing.T) {
@@ -11590,11 +11633,15 @@ func TestFileStoreSourcesStaleConfig(t *testing.T) {
 		fn := filepath.Join(dir, sourcesStreamStateFile)
 
 		// Sources are configured but nothing has been observed yet, so the map only
-		// holds seeded (zero) entries. Persisting state must not write an empty index.
-		require_True(t, fs.SourcesState() == nil)
+		// holds seeded (zero) entries.
+		state := fs.SourcesState()
+		require_Len(t, len(state), 1)
+		sss, ok := state["ORIGIN > >"]
+		require_True(t, ok)
+		require_Equal(t, sss.Seq, 0)
 		require_NoError(t, fs.writeFullState())
 		_, err = os.Stat(fn)
-		require_True(t, os.IsNotExist(err))
+		require_NoError(t, err)
 
 		// Observe a source, the index should now be written.
 		hdr := genHeader(nil, JSStreamSource, "ORIGIN 1 > > foo.bar")
@@ -11612,6 +11659,63 @@ func TestFileStoreSourcesStaleConfig(t *testing.T) {
 		_, err = os.Stat(fn)
 		require_True(t, os.IsNotExist(err))
 	})
+}
+
+func TestFileStoreSourcesAddedSourceKeepsExistingState(t *testing.T) {
+	origin1 := &StreamSource{Name: "ORIGIN1"}
+	origin2 := &StreamSource{Name: "ORIGIN2"}
+	iName1, iName2 := origin1.composeIName(), origin2.composeIName()
+
+	// Adding a source must only recover the sequence of the source that was just
+	// added. Sources that are already tracked must keep their state, even if a
+	// scan derives a lower sequence for them, since that would result in
+	// the source consumer re-delivering messages it had already stored.
+	test := func(t *testing.T, allowMsgTTL bool) {
+		dir := t.TempDir()
+		fcfg := FileStoreConfig{StoreDir: dir}
+		cfg := StreamConfig{
+			Name:     "SOURCE",
+			Subjects: []string{"foo"},
+			Storage:  FileStorage,
+			Sources:  []*StreamSource{origin1},
+		}
+
+		fs, err := newFileStore(fcfg, cfg)
+		require_NoError(t, err)
+		defer fs.Stop()
+
+		for i := range 10 {
+			hdr := genHeader(nil, JSStreamSource, fmt.Sprintf("ORIGIN1 %d > > foo", i+1))
+			_, _, err = fs.StoreMsg("foo", hdr, nil, 0)
+			require_NoError(t, err)
+		}
+		state := fs.SourcesState()
+		require_Len(t, len(state), 1)
+		require_Equal(t, state[iName1].Seq, 10)
+
+		// Remove the newest message, a scan would now only be able to derive
+		// ORIGIN1 up to sequence 9.
+		removed, err := fs.RemoveMsg(10)
+		require_NoError(t, err)
+		require_True(t, removed)
+
+		// Add a second source. Optionally enabling TTLs as well, which forces
+		// recovery through the forward linear scan instead of the backward scan.
+		ucfg := cfg
+		ucfg.AllowMsgTTL = allowMsgTTL
+		ucfg.Sources = []*StreamSource{origin1, origin2}
+		require_NoError(t, fs.UpdateConfig(&ucfg))
+
+		state = fs.SourcesState()
+		require_Len(t, len(state), 2)
+		// ORIGIN1 must not have moved backward.
+		require_Equal(t, state[iName1].Seq, 10)
+		// ORIGIN2 is newly seeded and has nothing to recover.
+		require_Equal(t, state[iName2].Seq, 0)
+	}
+
+	t.Run("BackwardScan", func(t *testing.T) { test(t, false) })
+	t.Run("LinearScan", func(t *testing.T) { test(t, true) })
 }
 
 func TestFileStoreSourcesRecoveredFromOutdatedState(t *testing.T) {
@@ -16059,7 +16163,7 @@ func TestFileStoreEncodedStreamStateWithSources(t *testing.T) {
 	fs2.ApplySourcesState(map[string]StreamSourceState{"OTHER > >": {Seq: 9}})
 	require_Equal(t, fs2.SourcesState()["OTHER > >"].Seq, 9)
 	_, ok := fs2.SourcesState()[iname]
-	require_False(t, ok)
+	require_True(t, ok)
 	fs2.mu.RLock()
 	seeded := fs2.sources[iname]
 	fs2.mu.RUnlock()

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -19195,90 +19195,92 @@ func addConsumerWithError(t *testing.T, nc *nats.Conn, cfg *CreateConsumerReques
 }
 
 func TestJetStreamSourceRemovalAndReAdd(t *testing.T) {
-	s := RunBasicJetStreamServer(t)
-	defer s.Shutdown()
+	test := func(t *testing.T, storageType nats.StorageType) {
+		s := RunBasicJetStreamServer(t)
+		defer s.Shutdown()
 
-	nc, js := jsClientConnect(t, s)
-	defer nc.Close()
+		nc, js := jsClientConnect(t, s)
+		defer nc.Close()
 
-	// The source stream.
-	_, err := js.AddStream(&nats.StreamConfig{
-		Name:     "SRC",
-		Subjects: []string{"foo.*"},
-	})
-	require_NoError(t, err)
-
-	// The stream that sources.
-	_, err = js.AddStream(&nats.StreamConfig{
-		Name: "TEST",
-		Sources: []*nats.StreamSource{{
-			Name: "SRC",
-		}},
-	})
-	require_NoError(t, err)
-
-	// Now add in 10 msgs.
-	for i := 0; i < 10; i++ {
-		_, err := js.Publish(fmt.Sprintf("foo.%d", i), []byte("test"))
+		// The source stream.
+		_, err := js.AddStream(&nats.StreamConfig{
+			Name:     "SRC",
+			Subjects: []string{"foo.*"},
+		})
 		require_NoError(t, err)
-	}
 
-	// Make sure we have 10 msgs in TEST.
-	checkFor(t, time.Second, 200*time.Millisecond, func() error {
+		// The stream that sources.
+		cfg := &nats.StreamConfig{
+			Name: "TEST",
+			Sources: []*nats.StreamSource{{
+				Name: "SRC",
+			}},
+			Storage: storageType,
+		}
+		_, err = js.AddStream(cfg)
+		require_NoError(t, err)
+
+		// Now add in 10 msgs.
+		for i := range 10 {
+			_, err := js.Publish(fmt.Sprintf("foo.%d", i), []byte("test"))
+			require_NoError(t, err)
+		}
+
+		// Make sure we have 10 msgs in TEST.
+		checkFor(t, time.Second, 200*time.Millisecond, func() error {
+			si, err := js.StreamInfo("TEST")
+			require_NoError(t, err)
+			if si.State.Msgs == 10 {
+				return nil
+			}
+			return fmt.Errorf("Do not have all msgs yet, %d of 10", si.State.Msgs)
+		})
+
+		// Now update the TEST stream to no longer source.
+		cfg.Sources = nil
+		_, err = js.UpdateStream(cfg)
+		require_NoError(t, err)
+
+		// Now add in 10 more msgs.
+		for i := range 10 {
+			_, err := js.Publish(fmt.Sprintf("foo.%d", i+10), []byte("test"))
+			require_NoError(t, err)
+		}
+		// Make sure we are still stuck at 10 for TEST.
 		si, err := js.StreamInfo("TEST")
 		require_NoError(t, err)
-		if si.State.Msgs == 10 {
-			return nil
-		}
-		return fmt.Errorf("Do not have all msgs yet, %d of 10", si.State.Msgs)
-	})
+		require_Equal(t, si.State.Msgs, 10)
 
-	// Now update the TEST stream to no longer source.
-	_, err = js.UpdateStream(&nats.StreamConfig{
-		Name: "TEST",
-	})
-	require_NoError(t, err)
-
-	// Now add in 10 more msgs.
-	for i := 0; i < 10; i++ {
-		_, err := js.Publish(fmt.Sprintf("foo.%d", i+10), []byte("test"))
+		// Now re-add the source to our stream.
+		cfg.Sources = []*nats.StreamSource{{Name: "SRC"}}
+		_, err = js.UpdateStream(cfg)
 		require_NoError(t, err)
+
+		// Make sure we have 20 msgs now.
+		checkFor(t, time.Second, 200*time.Millisecond, func() error {
+			si, err := js.StreamInfo("TEST")
+			require_NoError(t, err)
+			if si.State.Msgs == 20 {
+				return nil
+			}
+			return fmt.Errorf("Do not have all msgs yet, %d of 20", si.State.Msgs)
+		})
+
+		// Check that we get what we want in the stream.
+		sub, err := js.PullSubscribe("foo.*", "d")
+		require_NoError(t, err)
+
+		msgs, err := sub.Fetch(20)
+		require_NoError(t, err)
+		require_Equal(t, len(msgs), 20)
+
+		for i, m := range msgs {
+			require_Equal(t, m.Subject, fmt.Sprintf("foo.%d", i))
+		}
 	}
-	// Make sure we are still stuck at 10 for TEST.
-	si, err := js.StreamInfo("TEST")
-	require_NoError(t, err)
-	require_Equal(t, si.State.Msgs, 10)
 
-	// Now re-add the source to our stream.
-	_, err = js.UpdateStream(&nats.StreamConfig{
-		Name: "TEST",
-		Sources: []*nats.StreamSource{{
-			Name: "SRC",
-		}},
-	})
-	require_NoError(t, err)
-
-	// Make sure we have 20 msgs now.
-	// Make sure we have 10 msgs in TEST.
-	checkFor(t, time.Second, 200*time.Millisecond, func() error {
-		si, err := js.StreamInfo("TEST")
-		require_NoError(t, err)
-		if si.State.Msgs == 20 {
-			return nil
-		}
-		return fmt.Errorf("Do not have all msgs yet, %d of 20", si.State.Msgs)
-	})
-
-	// Check that we get what we want in the stream.
-	sub, err := js.PullSubscribe("foo.*", "d")
-	require_NoError(t, err)
-
-	msgs, err := sub.Fetch(20)
-	require_NoError(t, err)
-	require_Equal(t, len(msgs), 20)
-
-	for i, m := range msgs {
-		require_Equal(t, m.Subject, fmt.Sprintf("foo.%d", i))
+	for _, storageType := range []nats.StorageType{nats.FileStorage, nats.MemoryStorage} {
+		t.Run(storageType.String(), func(t *testing.T) { test(t, storageType) })
 	}
 }
 
@@ -25086,7 +25088,8 @@ func TestJetStreamSourcesState(t *testing.T) {
 		require_NoError(t, err)
 		store := mset.Store()
 		state := store.SourcesState()
-		require_True(t, state == nil)
+		require_NotNil(t, state)
+		require_Equal(t, state["ORIGIN > >"].Seq, 0)
 
 		_, err = js.Publish("foo", nil)
 		require_NoError(t, err)

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -133,9 +133,9 @@ func (ms *memStore) UpdateConfig(cfg *StreamConfig) error {
 		if ms.sources == nil {
 			ms.sources = make(map[string]*StreamSourceState, len(cfg.Sources))
 		}
-		sources := make(map[string]struct{}, len(cfg.Sources))
+		sources := make(map[string]*StreamSource, len(cfg.Sources))
 		for _, ssi := range cfg.Sources {
-			sources[ssi.composeIName()] = struct{}{}
+			sources[ssi.composeIName()] = ssi
 		}
 		// Remove sources that are tracked but no longer exist.
 		for k := range ms.sources {
@@ -143,11 +143,17 @@ func (ms *memStore) UpdateConfig(cfg *StreamConfig) error {
 				delete(ms.sources, k)
 			}
 		}
-		// Seed sources that aren't in the map yet.
-		for k := range sources {
+		// Seed sources that aren't in the map yet. Anything newly seeded needs its
+		// sequence recovered, otherwise it would re-source from the very beginning.
+		scan := make(map[string]*StreamSource)
+		for k, ssi := range sources {
 			if _, ok := ms.sources[k]; !ok {
 				ms.sources[k] = &StreamSourceState{}
+				scan[k] = ssi
 			}
+		}
+		if len(scan) > 0 && ms.state.Msgs > 0 {
+			ms.recoverSourcesBackwardScan(scan)
 		}
 	}
 
@@ -1048,21 +1054,15 @@ func (ms *memStore) ApplySourcesState(sources map[string]StreamSourceState) {
 }
 
 // SourcesState return sources keys and their last known state.
-func (ms *memStore) SourcesState() (dst map[string]StreamSourceState) {
+func (ms *memStore) SourcesState() map[string]StreamSourceState {
 	ms.mu.RLock()
 	defer ms.mu.RUnlock()
 	if len(ms.sources) == 0 {
 		return nil
 	}
-	// Allocate lazily so that a map containing only seeded (zero) entries returns
-	// nil rather than an empty map; zeros must not leak out of SourcesState.
+	dst := make(map[string]StreamSourceState, len(ms.sources))
 	for k, ss := range ms.sources {
-		if ss.Seq > 0 {
-			if dst == nil {
-				dst = make(map[string]StreamSourceState, 1)
-			}
-			dst[k] = *ss
-		}
+		dst[k] = *ss
 	}
 	return dst
 }
@@ -2153,12 +2153,83 @@ func (ms *memStore) LoadPrevMsg(filter string, wc bool, start uint64, smp *Store
 	return nil, ms.state.FirstSeq, ErrStoreEOF
 }
 
+// recoverSourcesBackwardScan recovers ms.sources by scanning the stream backwards.
+// Lock should be held.
+func (ms *memStore) recoverSourcesBackwardScan(sources map[string]*StreamSource) {
+	var sl *gsl.SimpleSublist
+	refreshSublist := func() {
+		sl = gsl.NewSimpleSublist()
+		for _, src := range sources {
+			if src.FilterSubject == _EMPTY_ {
+				sl.Insert(fwcs, struct{}{})
+			} else {
+				sl.Insert(src.FilterSubject, struct{}{})
+			}
+			for _, tr := range src.SubjectTransforms {
+				if tr.Destination == _EMPTY_ {
+					sl.Insert(fwcs, struct{}{})
+				} else {
+					sl.Insert(tr.Destination, struct{}{})
+				}
+			}
+		}
+	}
+	refreshSublist()
+
+	update := func(iName string, sseq uint64, ident string) {
+		// Only consider sources that are configured and not yet found. The backward
+		// scan visits the highest matching sequence first, so the first hit per source
+		// is the latest.
+		if _, ok := sources[iName]; !ok {
+			return
+		}
+		ms.sources[iName] = &StreamSourceState{Seq: sseq, Ident: ident}
+		delete(sources, iName)
+		refreshSublist()
+	}
+
+	var smv StoreMsg
+	for last := ms.state.LastSeq; ; {
+		sm, seq, err := ms.loadPrevMsgMultiLocked(sl, last, &smv)
+		if err != nil {
+			// Done, including ErrStoreEOF.
+			return
+		}
+		if len(sm.hdr) > 0 {
+			if ss := sliceHeader(JSStreamSource, sm.hdr); len(ss) > 0 {
+				streamName, iName, sseq, ident := streamAndSeq(bytesToString(ss))
+				if iName == _EMPTY_ {
+					// Pre-2.10 message header means it's a match for any source using that
+					// stream name. Such headers carry no identity, so it is left unset.
+					for _, ssi := range ms.cfg.Sources {
+						if streamName == ssi.Name || (ssi.External != nil && streamName == ssi.Name+":"+getHash(ssi.External.ApiPrefix)) {
+							update(ssi.composeIName(), sseq, _EMPTY_)
+						}
+					}
+				} else {
+					update(iName, sseq, ident)
+				}
+			}
+		}
+		// Done once every source has been resolved, or we've reached the floor.
+		if len(sources) == 0 || seq <= ms.state.FirstSeq {
+			return
+		}
+		last = seq - 1
+	}
+}
+
 // LoadPrevMsgMulti will find the previous message matching any entry in the sublist.
 func (ms *memStore) LoadPrevMsgMulti(sl *gsl.SimpleSublist, start uint64, smp *StoreMsg) (sm *StoreMsg, skip uint64, err error) {
-	// TODO(dlc) - for now simple linear walk to get started.
 	ms.mu.RLock()
 	defer ms.mu.RUnlock()
+	return ms.loadPrevMsgMultiLocked(sl, start, smp)
+}
 
+// loadPrevMsgMultiLocked will find the previous message matching any entry in the sublist.
+// Lock should be held.
+func (ms *memStore) loadPrevMsgMultiLocked(sl *gsl.SimpleSublist, start uint64, smp *StoreMsg) (sm *StoreMsg, skip uint64, err error) {
+	// TODO(dlc) - for now simple linear walk to get started.
 	if start > ms.state.LastSeq {
 		start = ms.state.LastSeq
 	}

--- a/server/memstore_test.go
+++ b/server/memstore_test.go
@@ -1789,3 +1789,49 @@ func TestMemStoreMultiLastSeqsDoesNotReorderConfigSubjects(t *testing.T) {
 	require_Equal(t, ms.cfg.Subjects[0], "orders.*")
 	require_Equal(t, ms.cfg.Subjects[1], "billing.*")
 }
+
+func TestMemStoreSourcesAddedSourceKeepsExistingState(t *testing.T) {
+	origin1 := &StreamSource{Name: "ORIGIN1"}
+	origin2 := &StreamSource{Name: "ORIGIN2"}
+	iName1, iName2 := origin1.composeIName(), origin2.composeIName()
+
+	cfg := StreamConfig{
+		Name:     "SOURCE",
+		Subjects: []string{"foo"},
+		Storage:  MemoryStorage,
+		Sources:  []*StreamSource{origin1},
+	}
+	ms, err := newMemStore(&cfg)
+	require_NoError(t, err)
+	defer ms.Stop()
+
+	for i := range 10 {
+		hdr := genHeader(nil, JSStreamSource, fmt.Sprintf("ORIGIN1 %d > > foo", i+1))
+		_, _, err = ms.StoreMsg("foo", hdr, nil, 0)
+		require_NoError(t, err)
+	}
+	state := ms.SourcesState()
+	require_Len(t, len(state), 1)
+	require_Equal(t, state[iName1].Seq, 10)
+
+	// Remove the newest message, a scan would now only be able to derive
+	// ORIGIN1 up to sequence 9.
+	removed, err := ms.RemoveMsg(10)
+	require_NoError(t, err)
+	require_True(t, removed)
+
+	// Adding a source must only recover the sequence of the source that was just
+	// added. Sources that are already tracked must keep their state, even if a
+	// scan derives a lower sequence for them, since that would result in
+	// the source consumer re-delivering messages it had already stored.
+	ucfg := cfg
+	ucfg.Sources = []*StreamSource{origin1, origin2}
+	require_NoError(t, ms.UpdateConfig(&ucfg))
+
+	state = ms.SourcesState()
+	require_Len(t, len(state), 2)
+	// ORIGIN1 must not have moved backward.
+	require_Equal(t, state[iName1].Seq, 10)
+	// ORIGIN2 is newly seeded and has nothing to recover.
+	require_Equal(t, state[iName2].Seq, 0)
+}

--- a/server/stream.go
+++ b/server/stream.go
@@ -2704,6 +2704,8 @@ func (mset *stream) updateWithAdvisory(config *StreamConfig, sendAdvisory bool, 
 	jsa.mu.RUnlock()
 
 	mset.mu.Lock()
+
+	var needsStartingSeqNum map[string]struct{}
 	if mset.active {
 		// Check for mirror promotion.
 		if ocfg.Mirror != nil && cfg.Mirror == nil {
@@ -2720,7 +2722,6 @@ func (mset *stream) updateWithAdvisory(config *StreamConfig, sendAdvisory bool, 
 		for _, s := range ocfg.Subjects {
 			current[s] = struct{}{}
 		}
-		// Update config with new values. The store update will enforce any stricter limits.
 
 		// Now walk new subjects. All of these need to be added, but we will check
 		// the originals first, since if it is in there we can skip, already added.
@@ -2753,7 +2754,6 @@ func (mset *stream) updateWithAdvisory(config *StreamConfig, sendAdvisory bool, 
 		if len(cfg.Sources) > 0 || len(ocfg.Sources) > 0 {
 			currentIName := make(map[string]struct{})
 			currentConsumers := make(map[string]*StreamSource)
-			needsStartingSeqNum := make(map[string]struct{})
 
 			getSourcingConsumerIName := func(ssi *StreamSource, sources []*StreamSource) string {
 				var iName = ssi.Name
@@ -2801,6 +2801,9 @@ func (mset *stream) updateWithAdvisory(config *StreamConfig, sendAdvisory bool, 
 					}
 
 					mset.sources[s.iname] = si
+					if needsStartingSeqNum == nil {
+						needsStartingSeqNum = make(map[string]struct{})
+					}
 					needsStartingSeqNum[s.iname] = struct{}{}
 				} else {
 					// source already exists
@@ -2821,14 +2824,6 @@ func (mset *stream) updateWithAdvisory(config *StreamConfig, sendAdvisory bool, 
 			for iName := range currentIName {
 				mset.cancelSourceConsumer(iName)
 				delete(mset.sources, iName)
-			}
-			neededCopy := make(map[string]struct{}, len(needsStartingSeqNum))
-			for iName := range needsStartingSeqNum {
-				neededCopy[iName] = struct{}{}
-			}
-			mset.setStartingSequenceForSources(needsStartingSeqNum)
-			for iName := range neededCopy {
-				mset.setupSourceConsumer(iName, mset.sources[iName].sseq+1, time.Time{})
 			}
 		}
 	}
@@ -2957,6 +2952,7 @@ func (mset *stream) updateWithAdvisory(config *StreamConfig, sendAdvisory bool, 
 	if mset.isLeader() && sendAdvisory {
 		mset.sendUpdateAdvisoryLocked()
 	}
+	active := mset.active
 	mset.mu.Unlock()
 
 	if js != nil {
@@ -2976,7 +2972,26 @@ func (mset *stream) updateWithAdvisory(config *StreamConfig, sendAdvisory bool, 
 		}
 	}
 
-	mset.store.UpdateConfig(cfg)
+	if err = mset.store.UpdateConfig(cfg); err != nil {
+		return err
+	}
+
+	// Newly added sources can now setup their source consumers, since the store scanned
+	// if the source was pre-existing as part of the config update above.
+	if active && len(needsStartingSeqNum) > 0 {
+		mset.mu.Lock()
+		if mset.active {
+			mset.setStartingSequenceForSources(needsStartingSeqNum)
+			for iName := range needsStartingSeqNum {
+				// A concurrent update could have removed or replaced the source
+				// in the meantime, only set up the ones still present.
+				if si, ok := mset.sources[iName]; ok {
+					mset.setupSourceConsumer(iName, si.sseq+1, time.Time{})
+				}
+			}
+		}
+		mset.mu.Unlock()
+	}
 
 	return nil
 }
@@ -4991,112 +5006,18 @@ func streamAndSeq(shdr string) (string, string, uint64, string) {
 
 // Lock should be held.
 func (mset *stream) setStartingSequenceForSources(iNames map[string]struct{}) {
-	var state StreamState
-	mset.store.FastState(&state)
-
-	// Collect known sources state and reuse where possible. This persisted state
-	// survives a full purge/expiry of the destination messages, so it has to be
-	// consulted before bailing out below on an emptied store.
+	// The store contains an index of the source state, use it here without doing lookups ourselves.
 	sourcesState := mset.store.SourcesState()
 	for iName := range iNames {
-		if sss, ok := sourcesState[iName]; ok {
-			if si, ok := mset.sources[iName]; ok {
+		if si, ok := mset.sources[iName]; ok {
+			if sss, ok := sourcesState[iName]; ok {
 				si.sseq = sss.Seq
 				si.dseq = 0
 				si.ident, si.rc = sss.Ident, false
-				delete(iNames, iName)
-			}
-		}
-	}
-	if len(iNames) == 0 {
-		return
-	}
-
-	// Do not reset sseq here so we can remember when purge/expiration happens.
-	if state.Msgs == 0 {
-		for iName := range iNames {
-			si := mset.sources[iName]
-			if si == nil {
-				continue
 			} else {
+				// If it doesn't exist, only reset the delivery sequence.
 				si.dseq = 0
 			}
-		}
-		return
-	}
-
-	// From the provided list of sources, we build a sublist that contains
-	// the interested filters (including transforms). As we figure out the
-	// starting sequence for each source, we will eliminate the source from
-	// the map and then refresh the sublist, which in turn makes the sublist
-	// ideally more specific. This allows LoadPrevMsgsMulti to work most
-	// effectively.
-	// Because this is a SimpleSublist we can't just remove the entries per
-	// source so we have no other option but to rebuild it from scratch, but
-	// this is cheap enough to do so not the end of the world.
-	var sl *gsl.SimpleSublist
-	refreshSublist := func() {
-		sl = gsl.NewSimpleSublist()
-		for iName := range iNames {
-			si := mset.sources[iName]
-			if si == nil {
-				continue
-			}
-			if si.sf == _EMPTY_ {
-				sl.Insert(fwcs, struct{}{})
-			} else {
-				sl.Insert(si.sf, struct{}{})
-			}
-			for _, sf := range si.sfs {
-				if sf == _EMPTY_ {
-					sl.Insert(fwcs, struct{}{})
-				} else {
-					sl.Insert(sf, struct{}{})
-				}
-			}
-		}
-	}
-	refreshSublist()
-
-	var smv StoreMsg
-	for last := state.LastSeq; ; {
-		sm, seq, err := mset.store.LoadPrevMsgMulti(sl, last, &smv)
-		if err != nil {
-			break
-		}
-		last = seq - 1
-		if len(sm.hdr) == 0 {
-			continue
-		}
-		ss := sliceHeader(JSStreamSource, sm.hdr)
-		if len(ss) == 0 {
-			continue
-		}
-
-		streamName, indexName, sseq, identity := streamAndSeq(bytesToString(ss))
-		if _, ok := iNames[indexName]; ok {
-			si := mset.sources[indexName]
-			si.sseq = sseq
-			si.dseq = 0
-			si.ident, si.rc = identity, false
-			delete(iNames, indexName)
-			refreshSublist()
-		} else if indexName == _EMPTY_ && streamName != _EMPTY_ {
-			for iName := range iNames {
-				// TODO streamSource is a linear walk, to optimize later
-				if si := mset.sources[iName]; si != nil && streamName == si.name ||
-					(mset.streamSource(iName).External != nil && streamName == si.name+":"+getHash(mset.streamSource(iName).External.ApiPrefix)) {
-					si.sseq = sseq
-					si.dseq = 0
-					si.ident, si.rc = _EMPTY_, false
-					delete(iNames, iName)
-					refreshSublist()
-					break
-				}
-			}
-		}
-		if len(iNames) == 0 {
-			break
 		}
 	}
 }
@@ -5146,106 +5067,19 @@ func (mset *stream) startingSequenceForSources() {
 	// Always reset here.
 	mset.resetSourceInfo()
 
-	var state StreamState
-	mset.store.FastState(&state)
-
-	// Generate a list of sources and, from that, a sublist that contains
-	// the interested filters (including transforms). As we figure out the
-	// starting sequence for each source, we will eliminate the source from
-	// the map and then refresh the sublist, which in turn makes the sublist
-	// ideally more specific. This allows LoadPrevMsgsMulti to work most
-	// effectively.
-	// Because this is a SimpleSublist we can't just remove the entries per
-	// source so we have no other option but to rebuild it from scratch, but
-	// this is cheap enough to do so not the end of the world.
-	sources := map[string]*StreamSource{}
-	for _, src := range mset.cfg.Sources {
-		sources[src.composeIName()] = src
-	}
-	var sl *gsl.SimpleSublist
-	refreshSublist := func() {
-		sl = gsl.NewSimpleSublist()
-		for _, src := range sources {
-			if src.FilterSubject == _EMPTY_ {
-				sl.Insert(fwcs, struct{}{})
-			} else {
-				sl.Insert(src.FilterSubject, struct{}{})
-			}
-			for _, tr := range src.SubjectTransforms {
-				if tr.Destination == _EMPTY_ {
-					sl.Insert(fwcs, struct{}{})
-				} else {
-					sl.Insert(tr.Destination, struct{}{})
-				}
-			}
-		}
-	}
-	refreshSublist()
-
-	update := func(iName string, seq uint64, ident string) {
-		// Only update active in case we have older ones in here that got configured out.
-		if si := mset.sources[iName]; si != nil {
-			if _, ok := sources[iName]; ok {
-				// Ignore if not set.
-				if seq == 0 {
-					delete(sources, iName)
-					refreshSublist()
-					return
-				}
-				si.sseq = seq
-				si.dseq = 0
-				si.ident, si.rc = ident, false
-				delete(sources, iName)
-				refreshSublist()
-			}
-		}
-	}
-
-	// Collect known sources state and reuse where possible. This persisted
-	// state survives a full purge/expiry of the destination messages. Otherwise,
-	// we would reset every source back to the origin's beginning.
+	// The store contains an index of the source state, use it here without doing lookups ourselves.
 	sourcesState := mset.store.SourcesState()
-	for iName := range sources {
-		if sss, ok := sourcesState[iName]; ok {
-			update(iName, sss.Seq, sss.Ident)
-		}
-	}
-	if len(sources) == 0 {
-		return
-	}
-
-	// Bail if no messages, meaning no further context to scan for.
-	if state.Msgs == 0 {
-		return
-	}
-
-	var smv StoreMsg
-	for last := state.LastSeq; ; {
-		sm, seq, err := mset.store.LoadPrevMsgMulti(sl, last, &smv)
-		if err != nil {
-			break
-		}
-		last = seq - 1
-		if len(sm.hdr) == 0 {
-			continue
-		}
-		ss := sliceHeader(JSStreamSource, sm.hdr)
-		if len(ss) == 0 {
-			continue
-		}
-
-		streamName, iName, sseq, identity := streamAndSeq(bytesToString(ss))
-		if iName == _EMPTY_ { // Pre-2.10 message header means it's a match for any source using that stream name
-			for _, ssi := range mset.cfg.Sources {
-				if streamName == ssi.Name || (ssi.External != nil && streamName == ssi.Name+":"+getHash(ssi.External.ApiPrefix)) {
-					update(ssi.iname, sseq, _EMPTY_)
-				}
+	for _, src := range mset.cfg.Sources {
+		iName := src.composeIName()
+		if si, ok := mset.sources[iName]; ok {
+			if sss, ok := sourcesState[iName]; ok {
+				si.sseq = sss.Seq
+				si.dseq = 0
+				si.ident, si.rc = sss.Ident, false
+			} else {
+				// If it doesn't exist, only reset the delivery sequence.
+				si.dseq = 0
 			}
-		} else {
-			update(iName, sseq, identity)
-		}
-		if len(sources) == 0 {
-			return
 		}
 	}
 }


### PR DESCRIPTION
Previously we only indexed non-zero sources. However, if new sources were added but not used for an extended period of time, then backward scans would still happen every single time to come to the same conclusion of it not existing.

This PR fixes that by fully removing the stream-level scan and ensuring the store-level scan always exposes the same information. Then the store only needs to scan once, and can reliably keep an up-to-date index. This also resolves the case where a source is added with no messages sourced, since the backward scan will only happen once and will be indexed/reused going forward.

Note that `memStore` had no store-level scan at all and relied entirely on the stream-level one, so it gains a `recoverSourcesBackwardScan` of its own. As a result the mirror/source reconciliation in `updateWithAdvisory` now runs after `mset.store.UpdateConfig(cfg)`, since the store must have seeded and scanned for a newly added source before `setStartingSequenceForSources` consults `SourcesState`.
  
Follow-up of https://github.com/nats-io/nats-server/pull/8282