### PR TITLE
Fix TestJetStreamClusterHardKillAfterStreamAdd

### DIFF
--- a/server/jetstream_helpers_test.go
+++ b/server/jetstream_helpers_test.go
@@ -2183,6 +2183,12 @@ func copyDir(t *testing.T, dst, src string) error {
 		if err != nil {
 			return err
 		}
+		// A purge moves msgs to __msgs__ and removes that directory
+		// asynchronously. It is disposable and may disappear while walking a
+		// live store, so do not include it in the copy.
+		if d.IsDir() && d.Name() == purgeDir {
+			return fs.SkipDir
+		}
 		newPath := path.Join(dst, p)
 		if d.IsDir() {
 			return os.MkdirAll(newPath, defaultDirPerms)

--- a/server/jetstream_helpers_test.go
+++ b/server/jetstream_helpers_test.go
@@ -2189,6 +2189,13 @@ func copyDir(t *testing.T, dst, src string) error {
 		if d.IsDir() && d.Name() == purgeDir {
 			return fs.SkipDir
 		}
+		// Atomic writes use .tmp files that are renamed into place when complete.
+		if strings.HasSuffix(d.Name(), blkTmpSuffix) {
+			if d.IsDir() {
+				return fs.SkipDir
+			}
+			return nil
+		}
 		newPath := path.Join(dst, p)
 		if d.IsDir() {
 			return os.MkdirAll(newPath, defaultDirPerms)


### PR DESCRIPTION
Prevents stumbling upon:

```
=== RUN   TestJetStreamClusterHardKillAfterStreamAdd
  jetstream_cluster_4_test.go:3913: require no error, but got: open $SYS/_js_/S-R3F-3UlxOL47/__msgs__: no such file or directory
--- FAIL: TestJetStreamClusterHardKillAfterStreamAdd (0.51s)
```

Signed-off-by: Waldemar Quevedo <wally@nats.io>

