### PR TITLE
raft: widen catchup maxOutstanding to avoid a catchup livelock under sustained write load

### DIFF
--- a/server/raft.go
+++ b/server/raft.go
@@ -3592,7 +3592,7 @@ func (n *raft) runCatchup(ar *appendEntryResponse, indexUpdatesQ *ipQueue[uint64
 	}
 	n.debug("Running catchup for %q [%d:%d] to [%d:%d]", peer, ar.term, ar.index, pterm, last)
 
-	const maxOutstanding = 2 * 1024 * 1024 // 2MB for now.
+	const maxOutstanding = 64 * 1024 * 1024 // widen to avoid a catchup livelock under sustained write load (see #8519)
 	next, total, om := uint64(0), 0, make(map[uint64]int)
 
 	sendNext := func() bool {


### PR DESCRIPTION
**This is a candidate / discussion starter, not a proposed final fix.** It's the
smallest change that confirms the mechanism behind #8519 and removes the wedge in my
testing; a real fix is probably an adaptive window or a catchup-progress signal that
doesn't depend on a live-tip ack. Opening it so there's a concrete diff + numbers to
react to.

### Background (#8519)

An R3 stream whose leader survives a 2-of-3 restart under sustained write load can
stop serving writes indefinitely while every node reports the group healthy. With
debug logging the leader's catchup loops without converging:

```
Running catchup for "X" [4:72479] to [4:74078]     # window ~1600 entries
Catching up for "X" stalled                         # +2s (activityInterval), returns
Being asked to catch up follower: "X"               # follower re-requests
Running catchup for "X" [4:72611] to [4:74218]      # restart, target has moved
... repeats; stalled ×72, "Finished catching up" for the stream group ×0
```

The follower applies entries (its pindex advances) but never sends a `success` for
catchup entries (by design — `raft.go` "Never respond to catchup messages"), so
`runCatchup`'s `indexUpdatesQ` is only fed by a `success` on a *live* entry, which
only happens once the follower reaches the live tip. Under sustained writes the tip
moves faster than the 2 MB `maxOutstanding` window delivers per 2 s
`activityInterval`, so the follower never reaches the tip, the leader never gets an
ack, and the catchup restarts indefinitely while commit stays frozen. This fits the
"leader must survive" trigger — a surviving leader under load keeps the tip moving.

### The change

`maxOutstanding` in `runCatchup` 2 MB → 64 MB, so each catchup pass can deliver a
larger backlog before it needs an ack it will never get under load.

### Validation

From-source builds of `v2.12.12` (go1.25.11, `-trimpath -ldflags "-s -w"`), 3× R3
KV nodes, ~2 GB bucket under sustained ~2000 writes/s, same fault sequence, KV nodes
limited to 1 CPU / 1 GB:

| build | wedged |
|---|---|
| stock (2 MB window) | 3/8 |
| this PR (64 MB window) | 0/12 |

- Leader catchup mechanic under load flips from `stalled ×72 / finished ×0` to
  `stalled ×2 / finished ×14` (the stream group now logs "Finished catching up").
- No OOM / no restarts on the 1 GB-limited nodes; stream data intact on every run.
- Not CPU-related: the stock build still wedges at 2 and 4 CPUs (1/3 and 1/5) on an
  otherwise-idle 14-core host.

### Caveats

64 MB is a blunt constant, not a considered value — it raises the in-flight ceiling
for a lagging follower, which matters for large clusters / big backlogs. An adaptive
window, or decoupling the catchup activity timer from live-tip acks, would be a
better long-term fix. Happy to take this in whatever direction you prefer.
