### PR TITLE
Add missing --logtime_utc flag to usage output

### DIFF
--- a/main.go
+++ b/main.go
@@ -44,6 +44,7 @@ Server Options:
 Logging Options:
     -l, --log <file>                 File to redirect log output
     -T, --logtime                    Timestamp log entries (default: true)
+        --logtime_utc                Timestamps in UTC instead of local timezone (default: false)
     -s, --syslog                     Log to syslog or windows event log
     -r, --remote_syslog <addr>       Syslog server addr (udp://localhost:514)
     -D, --debug                      Enable debugging output


### PR DESCRIPTION
The `--logtime_utc` flag (added in #3833) never made it into the hand-maintained
usage string in `main.go`, so `nats-server -h` doesn't show it. Since `main.go`
installs its own `fs.Usage`, the flag package's per-flag help never prints either —
the flag is effectively undiscoverable from the CLI.

Every other flag registered in `ConfigureOptions` is listed in the usage text; this
adds the one missing line under Logging Options, aligned with its neighbors:

```
    -T, --logtime                    Timestamp log entries (default: true)
        --logtime_utc                Timestamps in UTC instead of local timezone (default: false)
```

`go build ./...` passes.
