### PR TITLE
Reduce heap escapes in subject tree matching

### DIFF
--- a/server/stree/leaf.go
+++ b/server/stree/leaf.go
@@ -32,13 +32,10 @@ func (n *leaf[T]) base() *meta               { return nil }
 func (n *leaf[T]) match(subject []byte) bool { return string(subject) == n.suffix }
 func (n *leaf[T]) setSuffix(suffix []byte)   { n.suffix = string(suffix) }
 func (n *leaf[T]) isFull() bool              { return true }
-func (n *leaf[T]) matchParts(parts [][]byte) ([][]byte, bool) {
-	return matchParts(parts, n.suffix)
-}
-func (n *leaf[T]) iter(f func(node) bool) {}
-func (n *leaf[T]) children() []node       { return nil }
-func (n *leaf[T]) numChildren() uint16    { return 0 }
-func (n *leaf[T]) path() string           { return n.suffix }
+func (n *leaf[T]) iter(f func(node) bool)    {}
+func (n *leaf[T]) children() []node          { return nil }
+func (n *leaf[T]) numChildren() uint16       { return 0 }
+func (n *leaf[T]) path() string              { return n.suffix }
 
 // Not applicable to leafs and should not be called, so panic if we do.
 func (n *leaf[T]) setPrefix(pre []byte)    { panic("setPrefix called on leaf") }

--- a/server/stree/node.go
+++ b/server/stree/node.go
@@ -24,7 +24,6 @@ type node interface {
 	isFull() bool
 	grow() node
 	shrink() node
-	matchParts(parts [][]byte) ([][]byte, bool)
 	kind() string
 	iter(f func(node) bool)
 	children() []node
@@ -46,8 +45,3 @@ func (n *meta) setPrefix(pre []byte) {
 
 func (n *meta) numChildren() uint16 { return n.size }
 func (n *meta) path() string        { return n.prefix }
-
-// Will match parts against our prefix.
-func (n *meta) matchParts(parts [][]byte) ([][]byte, bool) {
-	return matchParts(parts, n.prefix)
-}

--- a/server/stree/stree.go
+++ b/server/stree/stree.go
@@ -122,7 +122,7 @@ func (t *SubjectTree[T]) Match(filter []byte, cb func(subject []byte, val *T)) {
 		return
 	}
 	// We need to break this up into chunks based on wildcards, either pwc '*' or fwc '>'.
-	var raw [16][]byte
+	var raw [32][]byte
 	parts := genParts(filter, raw[:0])
 	var _pre [256]byte
 	t.match(t.root, parts, _pre[:0], func(subject []byte, val *T) bool {
@@ -140,7 +140,7 @@ func (t *SubjectTree[T]) MatchUntil(filter []byte, cb func(subject []byte, val *
 		return true
 	}
 	// We need to break this up into chunks based on wildcards, either pwc '*' or fwc '>'.
-	var raw [16][]byte
+	var raw [32][]byte
 	parts := genParts(filter, raw[:0])
 	var _pre [256]byte
 	return t.match(t.root, parts, _pre[:0], cb)
@@ -322,7 +322,7 @@ func (t *SubjectTree[T]) match(n node, parts [][]byte, pre []byte, cb func(subje
 	}
 
 	for n != nil {
-		nparts, matched := n.matchParts(parts)
+		nparts, matched := matchParts(parts, n.path())
 		// Check if we did not match.
 		if !matched {
 			return true


### PR DESCRIPTION
This stops the pre-allocated `raw` array from heap-escaping as it is no longer passed through an interface boundary unnecessarily.

Before:
```
stree_test.go:874: Match took 69.979084ms for 5000000 entries with 2 allocations per traversal
```

After:
```
stree_test.go:874: Match took 65.055ms for 5000000 entries with 1 allocations per traversal
```