### PR TITLE
(2.14) [IMPROVED] Only allocate AckAll sequences when acking in place

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -3812,8 +3812,11 @@ func (o *consumer) processAckMsgLocked(sseq, dseq, dc uint64, reply string, doSa
 		sgap := sseq - o.asflr
 		o.adflr, o.asflr = dseq, sseq
 
+		// Only needed if we ack in place, otherwise we'd never collect anything.
 		// At most the pending entries below the ack, don't over-allocate.
-		ackAllSeqs = make([]uint64, 0, min(uint64(len(o.pending)), sgap-1))
+		if ackInPlace {
+			ackAllSeqs = make([]uint64, 0, min(uint64(len(o.pending)), sgap-1))
+		}
 
 		remove := func(seq uint64) {
 			// Only collect what was actually delivered to us.


### PR DESCRIPTION
Follow-up of https://github.com/nats-io/nats-server/pull/8431