### PR TITLE
Reduce lock contention during concurrent client disconnects

### DIFF
--- a/locksordering.txt
+++ b/locksordering.txt
@@ -65,3 +65,9 @@ while holding the Server lock, but the Server lock must not be acquired while
 holding eventIdsMu.
 
     Server -> eventIdsMu
+
+The "closedMu" lock protects the server's closed connection ring. It may be
+acquired while holding the Server lock, but the Server lock must not be acquired
+while holding closedMu.
+
+    Server -> closedMu

--- a/locksordering.txt
+++ b/locksordering.txt
@@ -65,9 +65,3 @@ while holding the Server lock, but the Server lock must not be acquired while
 holding eventIdsMu.
 
     Server -> eventIdsMu
-
-The "closedMu" lock protects the server's closed connection ring. It may be
-acquired while holding the Server lock, but the Server lock must not be acquired
-while holding closedMu.
-
-    Server -> closedMu

--- a/locksordering.txt
+++ b/locksordering.txt
@@ -59,3 +59,9 @@ mirrors/sources, info requests, etc.) are sequentially consistent and may observ
 an inflight batch. It must be acquired before the stream lock, never while holding it.
 
     isolateMu -> stream
+
+The "eventIdsMu" lock protects the server's event ID generator. It may be acquired
+while holding the Server lock, but the Server lock must not be acquired while
+holding eventIdsMu.
+
+    Server -> eventIdsMu

--- a/server/accounts.go
+++ b/server/accounts.go
@@ -1068,6 +1068,7 @@ func (a *Account) addClient(c *client) int {
 	} else if c.kind == LEAF {
 		a.nleafs++
 	}
+	isGlobal := a.Name == globalAccountName
 	a.mu.Unlock()
 
 	// If we added a new leaf use the list lock and add it to the list.
@@ -1077,7 +1078,7 @@ func (a *Account) addClient(c *client) int {
 		a.lmu.Unlock()
 	}
 
-	if c != nil && c.srv != nil {
+	if !isGlobal && c != nil && c.srv != nil {
 		c.srv.accConnsUpdate(a)
 	}
 
@@ -1162,13 +1163,14 @@ func (a *Account) removeClient(c *client) int {
 			}
 		}
 	}
+	isGlobal := a.Name == globalAccountName
 	a.mu.Unlock()
 
 	if c.kind == LEAF {
 		a.removeLeafNode(c)
 	}
 
-	if c != nil && c.srv != nil {
+	if !isGlobal && c != nil && c.srv != nil {
 		c.srv.accConnsUpdate(a)
 	}
 

--- a/server/client.go
+++ b/server/client.go
@@ -876,8 +876,11 @@ func (c *client) registerWithAccount(acc *Account) error {
 		return ErrBadAccount
 	}
 	// If we were previously registered, usually to $G, do accounting here to remove.
-	if c.acc != nil {
-		if prev := c.acc.removeClient(c); prev == 1 && c.srv != nil {
+	c.mu.Lock()
+	prevAcc := c.acc
+	c.mu.Unlock()
+	if prevAcc != nil {
+		if prev := prevAcc.removeClient(c); prev == 1 && c.srv != nil {
 			c.srv.decActiveAccounts()
 		}
 	}

--- a/server/closed_conns_test.go
+++ b/server/closed_conns_test.go
@@ -26,7 +26,7 @@ import (
 func checkClosedConns(t *testing.T, s *Server, num int, wait time.Duration) {
 	t.Helper()
 	checkFor(t, wait, 5*time.Millisecond, func() error {
-		if nc := s.numClosedConns(); nc != num {
+		if nc := s.closed.len(); nc != num {
 			return fmt.Errorf("Closed conns expected to be %v, got %v", num, nc)
 		}
 		return nil
@@ -36,7 +36,7 @@ func checkClosedConns(t *testing.T, s *Server, num int, wait time.Duration) {
 func checkTotalClosedConns(t *testing.T, s *Server, num uint64, wait time.Duration) {
 	t.Helper()
 	checkFor(t, wait, 5*time.Millisecond, func() error {
-		if nc := s.totalClosedConns(); nc != num {
+		if nc := s.closed.totalConns(); nc != num {
 			return fmt.Errorf("Total closed conns expected to be %v, got %v", num, nc)
 		}
 		return nil
@@ -62,7 +62,7 @@ func TestClosedConnsAccounting(t *testing.T) {
 
 	checkClosedConns(t, s, 1, wait)
 
-	conns := s.closedClients()
+	conns := s.closed.closedClients()
 	if lc := len(conns); lc != 1 {
 		t.Fatalf("len(conns) expected to be %d, got %d\n", 1, lc)
 	}
@@ -83,7 +83,7 @@ func TestClosedConnsAccounting(t *testing.T) {
 	checkClosedConns(t, s, opts.MaxClosedClients, wait)
 	checkTotalClosedConns(t, s, 22, wait)
 
-	conns = s.closedClients()
+	conns = s.closed.closedClients()
 	if lc := len(conns); lc != opts.MaxClosedClients {
 		t.Fatalf("len(conns) expected to be %d, got %d\n",
 			opts.MaxClosedClients, lc)
@@ -122,7 +122,7 @@ func TestClosedConnsSubsAccounting(t *testing.T) {
 	nc.Close()
 
 	checkClosedConns(t, s, 1, 20*time.Millisecond)
-	conns := s.closedClients()
+	conns := s.closed.closedClients()
 	if lc := len(conns); lc != 1 {
 		t.Fatalf("len(conns) expected to be 1, got %d\n", lc)
 	}
@@ -154,7 +154,7 @@ func TestClosedAuthorizationTimeout(t *testing.T) {
 	defer conn.Close()
 
 	checkClosedConns(t, s, 1, 2*time.Second)
-	conns := s.closedClients()
+	conns := s.closed.closedClients()
 	if lc := len(conns); lc != 1 {
 		t.Fatalf("len(conns) expected to be %d, got %d\n", 1, lc)
 	}
@@ -177,7 +177,7 @@ func TestClosedAuthorizationViolation(t *testing.T) {
 	}
 
 	checkClosedConns(t, s, 1, 2*time.Second)
-	conns := s.closedClients()
+	conns := s.closed.closedClients()
 	if lc := len(conns); lc != 1 {
 		t.Fatalf("len(conns) expected to be %d, got %d\n", 1, lc)
 	}
@@ -208,7 +208,7 @@ func TestClosedUPAuthorizationViolation(t *testing.T) {
 	}
 
 	checkClosedConns(t, s, 2, 2*time.Second)
-	conns := s.closedClients()
+	conns := s.closed.closedClients()
 	if lc := len(conns); lc != 2 {
 		t.Fatalf("len(conns) expected to be %d, got %d\n", 2, lc)
 	}
@@ -237,7 +237,7 @@ func TestClosedMaxPayload(t *testing.T) {
 	conn.Write([]byte(pub))
 
 	checkClosedConns(t, s, 1, 2*time.Second)
-	conns := s.closedClients()
+	conns := s.closed.closedClients()
 	if lc := len(conns); lc != 1 {
 		t.Fatalf("len(conns) expected to be %d, got %d\n", 1, lc)
 	}
@@ -262,7 +262,7 @@ func TestClosedTLSHandshake(t *testing.T) {
 	}
 
 	checkClosedConns(t, s, 1, 2*time.Second)
-	conns := s.closedClients()
+	conns := s.closed.closedClients()
 	if lc := len(conns); lc != 1 {
 		t.Fatalf("len(conns) expected to be %d, got %d\n", 1, lc)
 	}

--- a/server/events.go
+++ b/server/events.go
@@ -2561,21 +2561,23 @@ func (s *Server) accConnsUpdate(a *Account) {
 	s.sendAccConnsUpdate(a, fmt.Sprintf(accConnsEventSubjOld, a.Name), fmt.Sprintf(accConnsEventSubjNew, a.Name))
 }
 
-// server lock should be held
 func (s *Server) nextEventID() string {
-	return s.eventIds.Next()
+	s.eventIdsMu.Lock()
+	id := s.eventIds.Next()
+	s.eventIdsMu.Unlock()
+	return id
 }
 
 // accountConnectEvent will send an account client connect event if there is interest.
 // This is a billing event.
 func (s *Server) accountConnectEvent(c *client) {
-	s.mu.Lock()
-	if !s.eventsEnabled() {
-		s.mu.Unlock()
+	s.mu.RLock()
+	eventsEnabled := s.eventsEnabled()
+	s.mu.RUnlock()
+	if !eventsEnabled {
 		return
 	}
 	eid := s.nextEventID()
-	s.mu.Unlock()
 
 	c.mu.Lock()
 	if c.acc == nil {
@@ -2616,13 +2618,13 @@ func (s *Server) accountConnectEvent(c *client) {
 // accountDisconnectEvent will send an account client disconnect event if there is interest.
 // This is a billing event.
 func (s *Server) accountDisconnectEvent(c *client, now time.Time, reason string) {
-	s.mu.Lock()
-	if !s.eventsEnabled() {
-		s.mu.Unlock()
+	s.mu.RLock()
+	eventsEnabled := s.eventsEnabled()
+	s.mu.RUnlock()
+	if !eventsEnabled {
 		return
 	}
 	eid := s.nextEventID()
-	s.mu.Unlock()
 
 	c.mu.Lock()
 
@@ -2678,13 +2680,13 @@ func (s *Server) accountDisconnectEvent(c *client, now time.Time, reason string)
 
 // This is the system level event sent to the system account for operators.
 func (s *Server) sendAuthErrorEvent(c *client, reason string) {
-	s.mu.Lock()
-	if !s.eventsEnabled() {
-		s.mu.Unlock()
+	s.mu.RLock()
+	eventsEnabled := s.eventsEnabled()
+	s.mu.RUnlock()
+	if !eventsEnabled {
 		return
 	}
 	eid := s.nextEventID()
-	s.mu.Unlock()
 
 	now := time.Now().UTC()
 	c.mu.Lock()
@@ -2740,13 +2742,13 @@ func (s *Server) sendAccountAuthErrorEvent(c *client, acc *Account, reason strin
 	if acc == nil {
 		return
 	}
-	s.mu.Lock()
-	if !s.eventsEnabled() {
-		s.mu.Unlock()
+	s.mu.RLock()
+	eventsEnabled := s.eventsEnabled()
+	s.mu.RUnlock()
+	if !eventsEnabled {
 		return
 	}
 	eid := s.nextEventID()
-	s.mu.Unlock()
 
 	now := time.Now().UTC()
 	c.mu.Lock()
@@ -3314,9 +3316,11 @@ func (s *Server) wrapChk(f func()) func() {
 // sendOCSPPeerRejectEvent sends a system level event to system account when a peer connection is
 // rejected due to OCSP invalid status of its trust chain(s).
 func (s *Server) sendOCSPPeerRejectEvent(kind string, peer *x509.Certificate, reason string) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if !s.eventsEnabled() {
+	s.mu.RLock()
+	eventsEnabled := s.eventsEnabled()
+	serverID := s.info.ID
+	s.mu.RUnlock()
+	if !eventsEnabled {
 		return
 	}
 	if peer == nil {
@@ -3340,16 +3344,18 @@ func (s *Server) sendOCSPPeerRejectEvent(kind string, peer *x509.Certificate, re
 		},
 		Reason: reason,
 	}
-	subj := fmt.Sprintf(ocspPeerRejectEventSubj, s.info.ID)
-	s.sendInternalMsg(subj, _EMPTY_, &m.Server, &m)
+	subj := fmt.Sprintf(ocspPeerRejectEventSubj, serverID)
+	s.sendInternalMsgLocked(subj, _EMPTY_, &m.Server, &m)
 }
 
 // sendOCSPPeerChainlinkInvalidEvent sends a system level event to system account when a link in a peer's trust chain
 // is OCSP invalid.
 func (s *Server) sendOCSPPeerChainlinkInvalidEvent(peer *x509.Certificate, link *x509.Certificate, reason string) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if !s.eventsEnabled() {
+	s.mu.RLock()
+	eventsEnabled := s.eventsEnabled()
+	serverID := s.info.ID
+	s.mu.RUnlock()
+	if !eventsEnabled {
 		return
 	}
 	if peer == nil || link == nil {
@@ -3378,6 +3384,6 @@ func (s *Server) sendOCSPPeerChainlinkInvalidEvent(peer *x509.Certificate, link 
 		},
 		Reason: reason,
 	}
-	subj := fmt.Sprintf(ocspPeerChainlinkInvalidEventSubj, s.info.ID)
-	s.sendInternalMsg(subj, _EMPTY_, &m.Server, &m)
+	subj := fmt.Sprintf(ocspPeerChainlinkInvalidEventSubj, serverID)
+	s.sendInternalMsgLocked(subj, _EMPTY_, &m.Server, &m)
 }

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -323,11 +323,11 @@ func (s *Server) Connz(opts *ConnzOptions) (*Connz, error) {
 	case ConnOpen:
 		c.Total = len(clist)
 	case ConnClosed:
-		closedClients = s.closedClients()
+		closedClients = s.closed.closedClients()
 		c.Total = len(closedClients)
 	case ConnAll:
 		c.Total = len(clist)
-		closedClients = s.closedClients()
+		closedClients = s.closed.closedClients()
 		c.Total += len(closedClients)
 	}
 

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -277,6 +277,8 @@ func (s *Server) Connz(opts *ConnzOptions) (*Connz, error) {
 
 	// Open clients
 	var openClients []*client
+	// Selected client
+	var cidClient *client
 	// Hold for closed clients if requested.
 	var closedClients []*closedClient
 
@@ -298,7 +300,7 @@ func (s *Server) Connz(opts *ConnzOptions) (*Connz, error) {
 		a.mu.RUnlock()
 	}
 
-	// Walk the open client list with server lock held.
+	// Snapshot server connection state.
 	s.mu.RLock()
 	// Default to all client unless filled in above.
 	if clist == nil {
@@ -309,6 +311,11 @@ func (s *Server) Connz(opts *ConnzOptions) (*Connz, error) {
 
 	// copy the server id for monitoring
 	c.ID = s.info.ID
+	// select client by CID
+	if cid > 0 {
+		cidClient = s.clients[cid]
+	}
+	s.mu.RUnlock()
 
 	// Number of total clients. The resulting ConnInfo array
 	// may be smaller if pagination is used.
@@ -365,8 +372,8 @@ func (s *Server) Connz(opts *ConnzOptions) (*Connz, error) {
 		// Let's first check if user also selects on ConnOpen or ConnAll
 		// and look for opened connections.
 		if state == ConnOpen || state == ConnAll {
-			if client := s.clients[cid]; client != nil {
-				openClients = append(openClients, client)
+			if cidClient != nil {
+				openClients = append(openClients, cidClient)
 				closedClients = nil
 			}
 		}
@@ -412,7 +419,6 @@ func (s *Server) Connz(opts *ConnzOptions) (*Connz, error) {
 			}
 		}
 	}
-	s.mu.RUnlock()
 
 	// Filter by subject now if needed. We do this outside of server lock.
 	if filter != _EMPTY_ {

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -316,11 +316,11 @@ func (s *Server) Connz(opts *ConnzOptions) (*Connz, error) {
 	case ConnOpen:
 		c.Total = len(clist)
 	case ConnClosed:
-		closedClients = s.closed.closedClients()
+		closedClients = s.closedClients()
 		c.Total = len(closedClients)
 	case ConnAll:
 		c.Total = len(clist)
-		closedClients = s.closed.closedClients()
+		closedClients = s.closedClients()
 		c.Total += len(closedClients)
 	}
 

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -1206,7 +1206,7 @@ func TestMonitorConnzSortedByStopTimeClosedConn(t *testing.T) {
 
 	// Now adjust the Stop times for these with some random values.
 	now := time.Now().UTC()
-	ccs := s.closedClients()
+	ccs := s.closed.closedClients()
 	for _, cc := range ccs {
 		newStop := now.Add(time.Duration(rand.Int()%120) * -time.Minute)
 		cc.Stop = &newStop
@@ -1248,7 +1248,7 @@ func TestMonitorConnzSortedByReason(t *testing.T) {
 	checkClosedConns(t, s, 20, time.Second)
 
 	// Now adjust the Reasons for these with some random values.
-	ccs := s.closedClients()
+	ccs := s.closed.closedClients()
 	max := int(ServerShutdown)
 	for _, cc := range ccs {
 		cc.Reason = ClosedState(rand.Int() % max).String()
@@ -7004,9 +7004,7 @@ func TestConnzClosedSubsDetailNoSharedMutation(t *testing.T) {
 	cc.Cid = 1
 	cc.subs = []SubDetail{{Subject: "foo.bar"}}
 	cc.NumSubs = 1
-	s.closedMu.Lock()
 	s.closed.append(cc)
-	s.closedMu.Unlock()
 
 	// Concurrently request closed connections with subscription detail.
 	var wg sync.WaitGroup

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -1205,14 +1205,12 @@ func TestMonitorConnzSortedByStopTimeClosedConn(t *testing.T) {
 	checkClosedConns(t, s, 4, time.Second)
 
 	// Now adjust the Stop times for these with some random values.
-	s.mu.Lock()
 	now := time.Now().UTC()
-	ccs := s.closed.closedClients()
+	ccs := s.closedClients()
 	for _, cc := range ccs {
 		newStop := now.Add(time.Duration(rand.Int()%120) * -time.Minute)
 		cc.Stop = &newStop
 	}
-	s.mu.Unlock()
 
 	url = fmt.Sprintf("http://127.0.0.1:%d/", s.MonitorAddr().Port)
 	for mode := 0; mode < 2; mode++ {
@@ -1250,13 +1248,11 @@ func TestMonitorConnzSortedByReason(t *testing.T) {
 	checkClosedConns(t, s, 20, time.Second)
 
 	// Now adjust the Reasons for these with some random values.
-	s.mu.Lock()
-	ccs := s.closed.closedClients()
+	ccs := s.closedClients()
 	max := int(ServerShutdown)
 	for _, cc := range ccs {
 		cc.Reason = ClosedState(rand.Int() % max).String()
 	}
-	s.mu.Unlock()
 
 	url = fmt.Sprintf("http://127.0.0.1:%d/", s.MonitorAddr().Port)
 	for mode := 0; mode < 2; mode++ {
@@ -7008,9 +7004,9 @@ func TestConnzClosedSubsDetailNoSharedMutation(t *testing.T) {
 	cc.Cid = 1
 	cc.subs = []SubDetail{{Subject: "foo.bar"}}
 	cc.NumSubs = 1
-	s.mu.Lock()
+	s.closedMu.Lock()
 	s.closed.append(cc)
-	s.mu.Unlock()
+	s.closedMu.Unlock()
 
 	// Concurrently request closed connections with subscription detail.
 	var wg sync.WaitGroup

--- a/server/norace_1_test.go
+++ b/server/norace_1_test.go
@@ -255,7 +255,7 @@ func TestNoRaceClosedSlowConsumerWriteDeadline(t *testing.T) {
 
 	// At this point server should have closed connection c.
 	checkClosedConns(t, s, 1, 2*time.Second)
-	conns := s.closedClients()
+	conns := s.closed.closedClients()
 	if lc := len(conns); lc != 1 {
 		t.Fatalf("len(conns) expected to be %d, got %d\n", 1, lc)
 	}
@@ -303,7 +303,7 @@ func TestNoRaceClosedSlowConsumerPendingBytes(t *testing.T) {
 
 	// At this point server should have closed connection c.
 	checkClosedConns(t, s, 1, 2*time.Second)
-	conns := s.closedClients()
+	conns := s.closed.closedClients()
 	if lc := len(conns); lc != 1 {
 		t.Fatalf("len(conns) expected to be %d, got %d\n", 1, lc)
 	}

--- a/server/ring.go
+++ b/server/ring.go
@@ -13,6 +13,8 @@
 
 package server
 
+import "sync"
+
 // We wrap to hold onto optional items for /connz.
 type closedClient struct {
 	ConnInfo
@@ -23,6 +25,7 @@ type closedClient struct {
 
 // Fixed sized ringbuffer for closed connections.
 type closedRingBuffer struct {
+	mu    sync.Mutex
 	total uint64
 	conns []*closedClient
 }
@@ -37,15 +40,23 @@ func newClosedRingBuffer(max int) *closedRingBuffer {
 // Adds in a new closed connection. If there is no more room,
 // remove the oldest.
 func (rb *closedRingBuffer) append(cc *closedClient) {
-	rb.conns[rb.next()] = cc
+	rb.mu.Lock()
+	defer rb.mu.Unlock()
+	rb.conns[rb.nextLocked()] = cc
 	rb.total++
 }
 
-func (rb *closedRingBuffer) next() int {
+func (rb *closedRingBuffer) nextLocked() int {
 	return int(rb.total % uint64(cap(rb.conns)))
 }
 
 func (rb *closedRingBuffer) len() int {
+	rb.mu.Lock()
+	defer rb.mu.Unlock()
+	return rb.lenLocked()
+}
+
+func (rb *closedRingBuffer) lenLocked() int {
 	if rb.total > uint64(cap(rb.conns)) {
 		return cap(rb.conns)
 	}
@@ -53,6 +64,8 @@ func (rb *closedRingBuffer) len() int {
 }
 
 func (rb *closedRingBuffer) totalConns() uint64 {
+	rb.mu.Lock()
+	defer rb.mu.Unlock()
 	return rb.total
 }
 
@@ -63,10 +76,13 @@ func (rb *closedRingBuffer) totalConns() uint64 {
 // list inside monitor which allows programatic access, we do not
 // know when it would be done.
 func (rb *closedRingBuffer) closedClients() []*closedClient {
-	dup := make([]*closedClient, rb.len())
-	head := rb.next()
+	rb.mu.Lock()
+	defer rb.mu.Unlock()
+	n := rb.lenLocked()
+	dup := make([]*closedClient, n)
+	head := rb.nextLocked()
 	if rb.total <= uint64(cap(rb.conns)) || head == 0 {
-		copy(dup, rb.conns[:rb.len()])
+		copy(dup, rb.conns[:n])
 	} else {
 		fp := rb.conns[head:]
 		sp := rb.conns[:head]

--- a/server/server.go
+++ b/server/server.go
@@ -309,7 +309,8 @@ type Server struct {
 	}
 
 	// For eventIDs
-	eventIds *nuid.NUID
+	eventIdsMu sync.Mutex
+	eventIds   *nuid.NUID
 
 	// Websocket structure
 	websocket srvWebsocket

--- a/server/server.go
+++ b/server/server.go
@@ -211,6 +211,7 @@ type Server struct {
 	users               map[string]*User
 	nkeys               map[string]*NkeyUser
 	totalClients        uint64
+	closedMu            sync.Mutex // Protects the closedRingBuffer
 	closed              *closedRingBuffer
 	done                chan bool
 	start               time.Time
@@ -3608,11 +3609,11 @@ func (s *Server) saveClosedClient(c *client, nc net.Conn, subs map[string]*subsc
 	c.mu.Unlock()
 
 	// Place in the ring buffer
-	s.mu.Lock()
+	s.closedMu.Lock()
 	if s.closed != nil {
 		s.closed.append(cc)
 	}
-	s.mu.Unlock()
+	s.closedMu.Unlock()
 }
 
 // Adds to the list of client and websocket clients connect URLs.
@@ -4102,20 +4103,20 @@ func (s *Server) startGoRoutine(f func(), tags ...pprofLabels) bool {
 }
 
 func (s *Server) numClosedConns() int {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	s.closedMu.Lock()
+	defer s.closedMu.Unlock()
 	return s.closed.len()
 }
 
 func (s *Server) totalClosedConns() uint64 {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	s.closedMu.Lock()
+	defer s.closedMu.Unlock()
 	return s.closed.totalConns()
 }
 
 func (s *Server) closedClients() []*closedClient {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	s.closedMu.Lock()
+	defer s.closedMu.Unlock()
 	return s.closed.closedClients()
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -3392,10 +3392,9 @@ func (s *Server) createClientEx(conn net.Conn, inProcess bool) *client {
 	// Re-Grab lock
 	c.mu.Lock()
 
-	isClosed := c.isClosed()
 	var pre []byte
 	// We need first to check for "TLS First" fallback delay.
-	if !isClosed && tlsFirstFallback > 0 {
+	if !c.isClosed() && tlsFirstFallback > 0 {
 		// We wait and see if we are getting any data. Since we did not send
 		// the INFO protocol yet, only clients that use TLS first should be
 		// sending data (the TLS handshake). We don't really check the content:
@@ -3403,9 +3402,12 @@ func (s *Server) createClientEx(conn net.Conn, inProcess bool) *client {
 		// TLS handshake, the error will be detected when performing the
 		// handshake on our side.
 		pre = make([]byte, 4)
-		c.nc.SetReadDeadline(time.Now().Add(tlsFirstFallback))
-		n, _ := io.ReadFull(c.nc, pre[:])
-		c.nc.SetReadDeadline(time.Time{})
+		nc := c.nc
+		c.mu.Unlock()
+		_ = nc.SetReadDeadline(time.Now().Add(tlsFirstFallback))
+		n, _ := io.ReadFull(nc, pre[:])
+		_ = nc.SetReadDeadline(time.Time{})
+		c.mu.Lock()
 		// If we get any data (regardless of possible timeout), we will proceed
 		// with the TLS handshake.
 		if n > 0 {
@@ -3423,19 +3425,20 @@ func (s *Server) createClientEx(conn net.Conn, inProcess bool) *client {
 			c.sendProtoNow(infoBytes)
 			// Set the boolean to false for the rest of the function.
 			tlsFirst = false
-			// Check closed status again
-			isClosed = c.isClosed()
 		}
 	}
 	// If we have both TLS and non-TLS allowed we need to see which
 	// one the client wants. We'll always allow this for in-process
 	// connections.
 	sniffTLS := !tlsFirst && opts.TLSConfig != nil && (inProcess || opts.AllowNonTLS)
-	if !isClosed && sniffTLS {
+	if !c.isClosed() && sniffTLS {
 		pre = make([]byte, 6) // Minimum 6 bytes for proxy proto in next step.
-		c.nc.SetReadDeadline(time.Now().Add(secondsToDuration(opts.TLSTimeout)))
-		n, _ := io.ReadFull(c.nc, pre[:])
-		c.nc.SetReadDeadline(time.Time{})
+		nc := c.nc
+		c.mu.Unlock()
+		_ = nc.SetReadDeadline(time.Now().Add(secondsToDuration(opts.TLSTimeout)))
+		n, _ := io.ReadFull(nc, pre[:])
+		_ = nc.SetReadDeadline(time.Time{})
+		c.mu.Lock()
 		pre = pre[:n]
 		tlsRequired = n > 0 && pre[0] == 0x16
 	}
@@ -3445,18 +3448,27 @@ func (s *Server) createClientEx(conn net.Conn, inProcess bool) *client {
 	// before doing TLS even when TLS is required. Any bytes read past the
 	// header are kept in `pre` and replayed into the TLS handshake (or the
 	// non-TLS protocol parser) by the tlsMixConn wrapper used below.
-	if !isClosed && opts.ProxyProtocol {
+	if !c.isClosed() && opts.ProxyProtocol {
 		if len(pre) == 0 {
 			// There has been no pre-read yet, do so so we can work out
 			// if the client is trying to negotiate PROXY.
 			pre = make([]byte, 6)
-			c.nc.SetReadDeadline(time.Now().Add(proxyProtoReadTimeout))
-			n, _ := io.ReadFull(c.nc, pre)
-			c.nc.SetReadDeadline(time.Time{})
+			nc := c.nc
+			c.mu.Unlock()
+			_ = nc.SetReadDeadline(time.Now().Add(proxyProtoReadTimeout))
+			n, _ := io.ReadFull(nc, pre)
+			_ = nc.SetReadDeadline(time.Time{})
+			c.mu.Lock()
 			pre = pre[:n]
 		}
 		conn = &tlsMixConn{conn, bytes.NewBuffer(pre)}
+		c.mu.Unlock()
 		addr, proxyPre, err := readProxyProtoHeader(conn)
+		c.mu.Lock()
+		if c.isClosed() {
+			c.mu.Unlock()
+			return nil
+		}
 		if err != nil && err != errProxyProtoUnrecognized {
 			// err != errProxyProtoUnrecognized implies that we detected a proxy
 			// protocol header but we failed to parse it, so don't continue.
@@ -3491,9 +3503,12 @@ func (s *Server) createClientEx(conn net.Conn, inProcess bool) *client {
 			// header (reading it from the connection if needed).
 			if len(pre) == 0 {
 				buf := make([]byte, 1)
-				c.nc.SetReadDeadline(time.Now().Add(secondsToDuration(opts.TLSTimeout)))
-				n, _ := io.ReadFull(c.nc, buf)
-				c.nc.SetReadDeadline(time.Time{})
+				nc := c.nc
+				c.mu.Unlock()
+				_ = nc.SetReadDeadline(time.Now().Add(secondsToDuration(opts.TLSTimeout)))
+				n, _ := io.ReadFull(nc, buf)
+				_ = nc.SetReadDeadline(time.Time{})
+				c.mu.Lock()
 				pre = buf[:n]
 			}
 			tlsRequired = len(pre) > 0 && pre[0] == 0x16
@@ -3506,7 +3521,7 @@ func (s *Server) createClientEx(conn net.Conn, inProcess bool) *client {
 	}
 
 	// Check for TLS
-	if !isClosed && tlsRequired {
+	if !c.isClosed() && tlsRequired {
 		if s.connRateCounter != nil && !s.connRateCounter.allow() {
 			c.mu.Unlock()
 			c.sendErr("Connection throttling is active. Please try again later.")
@@ -3528,15 +3543,13 @@ func (s *Server) createClientEx(conn net.Conn, inProcess bool) *client {
 	}
 
 	// Now, send the INFO if it was delayed
-	if !isClosed && tlsFirst {
+	if !c.isClosed() && tlsFirst {
 		c.flags.set(didTLSFirst)
 		c.sendProtoNow(infoBytes)
-		// Check closed status
-		isClosed = c.isClosed()
 	}
 
 	// Connection could have been closed while sending the INFO proto.
-	if isClosed {
+	if c.isClosed() {
 		c.mu.Unlock()
 		// We need to call closeConnection() to make sure that proper cleanup is done.
 		c.closeConnection(WriteError)

--- a/server/server.go
+++ b/server/server.go
@@ -211,7 +211,6 @@ type Server struct {
 	users               map[string]*User
 	nkeys               map[string]*NkeyUser
 	totalClients        uint64
-	closedMu            sync.Mutex // Protects the closedRingBuffer
 	closed              *closedRingBuffer
 	done                chan bool
 	start               time.Time
@@ -3622,11 +3621,9 @@ func (s *Server) saveClosedClient(c *client, nc net.Conn, subs map[string]*subsc
 	c.mu.Unlock()
 
 	// Place in the ring buffer
-	s.closedMu.Lock()
 	if s.closed != nil {
 		s.closed.append(cc)
 	}
-	s.closedMu.Unlock()
 }
 
 // Adds to the list of client and websocket clients connect URLs.
@@ -4113,24 +4110,6 @@ func (s *Server) startGoRoutine(f func(), tags ...pprofLabels) bool {
 		started = true
 	}
 	return started
-}
-
-func (s *Server) numClosedConns() int {
-	s.closedMu.Lock()
-	defer s.closedMu.Unlock()
-	return s.closed.len()
-}
-
-func (s *Server) totalClosedConns() uint64 {
-	s.closedMu.Lock()
-	defer s.closedMu.Unlock()
-	return s.closed.totalConns()
-}
-
-func (s *Server) closedClients() []*closedClient {
-	s.closedMu.Lock()
-	defer s.closedMu.Unlock()
-	return s.closed.closedClients()
 }
 
 // getClientConnectURLs returns suitable URLs for clients to connect to the listen


### PR DESCRIPTION
Reduce server lock contention by introducing two additional locks: 
 * `eventIdsMu` to protect event id generation
 * `closedMu` to protect the closed connections ring buffer