### PR TITLE
(2.15) [FIXED] Migration stalls on peers being removed and consistency

### DIFF
--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -643,6 +643,20 @@ type JSApiStreamRemovePeerResponse struct {
 
 const JSApiStreamRemovePeerResponseType = "io.nats.jetstream.api.v1.stream_remove_peer_response"
 
+// JSApiStreamEvacuatePeerRequest is the required evacuate peer request.
+type JSApiStreamEvacuatePeerRequest struct {
+	// Server name or peer ID of the peer to be evacuated.
+	Peer string `json:"peer"`
+}
+
+// JSApiStreamEvacuatePeerResponse is the response to an evacuate peer request.
+type JSApiStreamEvacuatePeerResponse struct {
+	ApiResponse
+	Success bool `json:"success,omitempty"`
+}
+
+const JSApiStreamEvacuatePeerResponseType = "io.nats.jetstream.api.v1.stream_evacuate_peer_response"
+
 // JSApiStreamLeaderStepDownResponse is the response to a leader stepdown request.
 type JSApiStreamLeaderStepDownResponse struct {
 	ApiResponse
@@ -688,6 +702,23 @@ type JSApiMetaServerRemoveResponse struct {
 }
 
 const JSApiMetaServerRemoveResponseType = "io.nats.jetstream.api.v1.meta_server_remove_response"
+
+// JSApiMetaServerEvacuateRequest will evacuate a peer from the meta group.
+type JSApiMetaServerEvacuateRequest struct {
+	// Server name of the peer to be evacuated.
+	Server string `json:"peer,omitempty"`
+	// Peer ID of the peer to be evacuated. If specified this is used
+	// instead of the server name.
+	Peer string `json:"peer_id,omitempty"`
+}
+
+// JSApiMetaServerEvacuateResponse is the response to a peer evacuation request in the meta group.
+type JSApiMetaServerEvacuateResponse struct {
+	ApiResponse
+	Success bool `json:"success,omitempty"`
+}
+
+const JSApiMetaServerEvacuateResponseType = "io.nats.jetstream.api.v1.meta_server_evacuate_response"
 
 // JSApiMetaRescueRequest will unsafely lower the meta group's quorum requirement
 // on the receiving server for disaster recovery.
@@ -2475,17 +2506,44 @@ func (s *Server) jsStreamCancelMoveRequest(_ *subscription, c *client, _ *Accoun
 	s.jsClusteredStreamCancelMoveLocked(osa, acc.Name, reply)
 }
 
+// streamRemapPeerRequest is implemented by the stream remove and evacuate peer
+// requests. They are distinct models carrying the same content.
+type streamRemapPeerRequest interface {
+	// peer returns the server name or peer ID the request targets.
+	peer() string
+}
+
+func (r *JSApiStreamRemovePeerRequest) peer() string   { return r.Peer }
+func (r *JSApiStreamEvacuatePeerRequest) peer() string { return r.Peer }
+
+// streamRemapPeerResponse is implemented by the stream remove and evacuate peer
+// responses. They are distinct models carrying the same content.
+type streamRemapPeerResponse interface {
+	setError(err *ApiError)
+	setSuccess()
+}
+
+func (r *JSApiStreamRemovePeerResponse) setError(err *ApiError) { r.Error = err }
+func (r *JSApiStreamRemovePeerResponse) setSuccess()            { r.Success = true }
+
+func (r *JSApiStreamEvacuatePeerResponse) setError(err *ApiError) { r.Error = err }
+func (r *JSApiStreamEvacuatePeerResponse) setSuccess()            { r.Success = true }
+
 // Request to remove a peer from a clustered stream.
 func (s *Server) jsStreamRemovePeerRequest(_ *subscription, c *client, _ *Account, subject, reply string, rmsg []byte) {
-	s.jsStreamRemapPeerRequest(nil, c, nil, subject, reply, rmsg, true)
+	req := &JSApiStreamRemovePeerRequest{}
+	resp := &JSApiStreamRemovePeerResponse{ApiResponse: ApiResponse{Type: JSApiStreamRemovePeerResponseType}}
+	s.jsStreamRemapPeerRequest(nil, c, nil, subject, reply, rmsg, req, resp, true)
 }
 
 // Request to evacuate a peer from a clustered stream.
 func (s *Server) jsStreamEvacuatePeerRequest(_ *subscription, c *client, _ *Account, subject, reply string, rmsg []byte) {
-	s.jsStreamRemapPeerRequest(nil, c, nil, subject, reply, rmsg, false)
+	req := &JSApiStreamEvacuatePeerRequest{}
+	resp := &JSApiStreamEvacuatePeerResponse{ApiResponse: ApiResponse{Type: JSApiStreamEvacuatePeerResponseType}}
+	s.jsStreamRemapPeerRequest(nil, c, nil, subject, reply, rmsg, req, resp, false)
 }
 
-func (s *Server) jsStreamRemapPeerRequest(_ *subscription, c *client, _ *Account, subject, reply string, rmsg []byte, remove bool) {
+func (s *Server) jsStreamRemapPeerRequest(_ *subscription, c *client, _ *Account, subject, reply string, rmsg []byte, req streamRemapPeerRequest, resp streamRemapPeerResponse, remove bool) {
 	if c == nil || !s.JetStreamEnabled() {
 		return
 	}
@@ -2498,12 +2556,10 @@ func (s *Server) jsStreamRemapPeerRequest(_ *subscription, c *client, _ *Account
 	// Have extra token for this one.
 	name := tokenAt(subject, 6)
 
-	var resp = JSApiStreamRemovePeerResponse{ApiResponse: ApiResponse{Type: JSApiStreamRemovePeerResponseType}}
-
 	// If we are not in clustered mode this is a failed request.
 	if !s.JetStreamIsClustered() {
-		resp.Error = NewJSClusterRequiredError()
-		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
+		resp.setError(NewJSClusterRequiredError())
+		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(resp))
 		return
 	}
 
@@ -2513,8 +2569,8 @@ func (s *Server) jsStreamRemapPeerRequest(_ *subscription, c *client, _ *Account
 		return
 	}
 	if js.isLeaderless() {
-		resp.Error = NewJSClusterNotAvailError()
-		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
+		resp.setError(NewJSClusterNotAvailError())
+		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(resp))
 		return
 	}
 
@@ -2528,40 +2584,39 @@ func (s *Server) jsStreamRemapPeerRequest(_ *subscription, c *client, _ *Account
 	}
 
 	if errorOnRequiredApiLevel(hdr) {
-		resp.Error = NewJSRequiredApiLevelError()
-		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
+		resp.setError(NewJSRequiredApiLevelError())
+		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(resp))
 		return
 	}
 
 	if hasJS, doErr := acc.checkJetStream(); !hasJS {
 		if doErr {
-			resp.Error = NewJSNotEnabledForAccountError()
-			s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
+			resp.setError(NewJSNotEnabledForAccountError())
+			s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(resp))
 		}
 		return
 	}
 	if isEmptyRequest(msg) {
-		resp.Error = NewJSBadRequestError()
-		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
+		resp.setError(NewJSBadRequestError())
+		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(resp))
 		return
 	}
 
-	var req JSApiStreamRemovePeerRequest
-	if err := s.unmarshalRequest(c, acc, subject, msg, &req); err != nil {
-		resp.Error = NewJSInvalidJSONError(err)
-		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
+	if err := s.unmarshalRequest(c, acc, subject, msg, req); err != nil {
+		resp.setError(NewJSInvalidJSONError(err))
+		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(resp))
 		return
 	}
-	if req.Peer == _EMPTY_ {
-		resp.Error = NewJSBadRequestError()
-		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
+	if req.peer() == _EMPTY_ {
+		resp.setError(NewJSBadRequestError())
+		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(resp))
 		return
 	}
 
 	if sa == nil {
 		// No stream present.
-		resp.Error = NewJSStreamNotFoundError()
-		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
+		resp.setError(NewJSStreamNotFoundError())
+		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(resp))
 		return
 	}
 
@@ -2573,28 +2628,28 @@ func (s *Server) jsStreamRemapPeerRequest(_ *subscription, c *client, _ *Account
 
 	// Check to see if we are a member of the group.
 	// Peer here is either a peer ID or a server name, convert to node name.
-	nodeName := getHash(req.Peer)
+	nodeName := getHash(req.peer())
 	isMember := isGroupMember(nodeName)
 	if !isMember {
-		nodeName = req.Peer
+		nodeName = req.peer()
 		isMember = isGroupMember(nodeName)
 	}
 
 	// Make sure we are a member.
 	if !isMember {
-		resp.Error = NewJSClusterPeerNotMemberError()
-		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
+		resp.setError(NewJSClusterPeerNotMemberError())
+		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(resp))
 		return
 	}
 
 	// If we are here we have a valid peer member set for removal.
 	if !js.removePeerFromStreamLocked(sa, nodeName, peerRemoval{remove: remove, requireReplicas: true}) {
-		resp.Error = NewJSPeerRemapError()
-		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
+		resp.setError(NewJSPeerRemapError())
+		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(resp))
 		return
 	}
 
-	resp.Success = true
+	resp.setSuccess()
 	s.sendAPIResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(resp))
 }
 
@@ -2728,7 +2783,7 @@ func (s *Server) jsLeaderServerEvacuateRequest(sub *subscription, c *client, _ *
 		return
 	}
 
-	var resp = JSApiMetaServerRemoveResponse{ApiResponse: ApiResponse{Type: JSApiMetaServerRemoveResponseType}}
+	var resp = JSApiMetaServerEvacuateResponse{ApiResponse: ApiResponse{Type: JSApiMetaServerEvacuateResponseType}}
 	if errorOnRequiredApiLevel(hdr) {
 		resp.Error = NewJSRequiredApiLevelError()
 		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
@@ -2741,7 +2796,7 @@ func (s *Server) jsLeaderServerEvacuateRequest(sub *subscription, c *client, _ *
 		return
 	}
 
-	var req JSApiMetaServerRemoveRequest
+	var req JSApiMetaServerEvacuateRequest
 	if err := s.unmarshalRequest(c, acc, subject, msg, &req); err != nil {
 		resp.Error = NewJSInvalidJSONError(err)
 		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -199,6 +199,16 @@ const (
 	JSApiConsumerLeaderStepDown  = "$JS.API.CONSUMER.LEADER.STEPDOWN.*.*"
 	JSApiConsumerLeaderStepDownT = "$JS.API.CONSUMER.LEADER.STEPDOWN.%s.%s"
 
+	// JSApiConsumerRemovePeer is the endpoint to remove a peer from a single clustered consumer.
+	// Will return JSON response.
+	JSApiConsumerRemovePeer  = "$JS.API.CONSUMER.PEER.REMOVE.*.*"
+	JSApiConsumerRemovePeerT = "$JS.API.CONSUMER.PEER.REMOVE.%s.%s"
+
+	// JSApiConsumerEvacuatePeer is the endpoint to evacuate a peer from a single clustered consumer.
+	// Will return JSON response.
+	JSApiConsumerEvacuatePeer  = "$JS.API.CONSUMER.PEER.EVACUATE.*.*"
+	JSApiConsumerEvacuatePeerT = "$JS.API.CONSUMER.PEER.EVACUATE.%s.%s"
+
 	// JSApiLeaderStepDown is the endpoint to have our metaleader stepdown.
 	// Only works from system account.
 	// Will return JSON response.
@@ -673,6 +683,34 @@ type JSApiConsumerLeaderStepDownResponse struct {
 
 const JSApiConsumerLeaderStepDownResponseType = "io.nats.jetstream.api.v1.consumer_leader_stepdown_response"
 
+// JSApiConsumerRemovePeerRequest is the required remove peer request for a single consumer.
+type JSApiConsumerRemovePeerRequest struct {
+	// Server name or peer ID of the peer to be removed.
+	Peer string `json:"peer"`
+}
+
+// JSApiConsumerRemovePeerResponse is the response to a consumer remove peer request.
+type JSApiConsumerRemovePeerResponse struct {
+	ApiResponse
+	Success bool `json:"success,omitempty"`
+}
+
+const JSApiConsumerRemovePeerResponseType = "io.nats.jetstream.api.v1.consumer_remove_peer_response"
+
+// JSApiConsumerEvacuatePeerRequest is the required evacuate peer request for a single consumer.
+type JSApiConsumerEvacuatePeerRequest struct {
+	// Server name or peer ID of the peer to be evacuated.
+	Peer string `json:"peer"`
+}
+
+// JSApiConsumerEvacuatePeerResponse is the response to a consumer evacuate peer request.
+type JSApiConsumerEvacuatePeerResponse struct {
+	ApiResponse
+	Success bool `json:"success,omitempty"`
+}
+
+const JSApiConsumerEvacuatePeerResponseType = "io.nats.jetstream.api.v1.consumer_evacuate_peer_response"
+
 // JSApiLeaderStepdownRequest allows placement control over the meta leader placement.
 type JSApiLeaderStepdownRequest struct {
 	Placement *Placement `json:"placement,omitempty"`
@@ -1084,6 +1122,8 @@ func (s *Server) setJetStreamExportSubs() error {
 		{JSApiStreamCancelMove, s.jsStreamCancelMoveRequest},
 		{JSApiStreamLeaderStepDown, s.jsStreamLeaderStepDownRequest},
 		{JSApiConsumerLeaderStepDown, s.jsConsumerLeaderStepDownRequest},
+		{JSApiConsumerRemovePeer, s.jsConsumerRemovePeerRequest},
+		{JSApiConsumerEvacuatePeer, s.jsConsumerEvacuatePeerRequest},
 		{JSApiMsgDelete, s.jsMsgDeleteRequest},
 		{JSApiMsgGet, s.jsMsgGetRequest},
 		{JSApiConsumerCreateEx, s.jsConsumerCreateRequest},
@@ -2575,7 +2615,7 @@ func (s *Server) jsStreamRemapPeerRequest(_ *subscription, c *client, _ *Account
 	}
 
 	js.mu.RLock()
-	isLeader, sa := cc.isLeader(), js.streamAssignmentOrInflight(acc.Name, name)
+	isLeader := cc.isLeader()
 	js.mu.RUnlock()
 
 	// Make sure we are meta leader.
@@ -2613,6 +2653,10 @@ func (s *Server) jsStreamRemapPeerRequest(_ *subscription, c *client, _ *Account
 		return
 	}
 
+	js.mu.Lock()
+	defer js.mu.Unlock()
+
+	sa := js.streamAssignmentOrInflight(acc.Name, name)
 	if sa == nil {
 		// No stream present.
 		resp.setError(NewJSStreamNotFoundError())
@@ -2620,8 +2664,6 @@ func (s *Server) jsStreamRemapPeerRequest(_ *subscription, c *client, _ *Account
 		return
 	}
 
-	js.mu.Lock()
-	defer js.mu.Unlock()
 	isGroupMember := func(peer string) bool {
 		return sa.Group.isMember(peer) || (sa.Group.Desired != nil && slices.Contains(sa.Group.Desired.Peers, peer))
 	}
@@ -2644,6 +2686,160 @@ func (s *Server) jsStreamRemapPeerRequest(_ *subscription, c *client, _ *Account
 
 	// If we are here we have a valid peer member set for removal.
 	if !js.removePeerFromStreamLocked(sa, nodeName, peerRemoval{remove: remove, requireReplicas: true}) {
+		resp.setError(NewJSPeerRemapError())
+		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(resp))
+		return
+	}
+
+	resp.setSuccess()
+	s.sendAPIResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(resp))
+}
+
+// consumerRemapPeerRequest is implemented by the consumer remove and evacuate peer
+// requests. They are distinct models carrying the same content.
+type consumerRemapPeerRequest interface {
+	// peer returns the server name or peer ID the request targets.
+	peer() string
+}
+
+func (r *JSApiConsumerRemovePeerRequest) peer() string   { return r.Peer }
+func (r *JSApiConsumerEvacuatePeerRequest) peer() string { return r.Peer }
+
+// consumerRemapPeerResponse is implemented by the consumer remove and evacuate peer
+// responses. They are distinct models carrying the same content.
+type consumerRemapPeerResponse interface {
+	setError(err *ApiError)
+	setSuccess()
+}
+
+func (r *JSApiConsumerRemovePeerResponse) setError(err *ApiError) { r.Error = err }
+func (r *JSApiConsumerRemovePeerResponse) setSuccess()            { r.Success = true }
+
+func (r *JSApiConsumerEvacuatePeerResponse) setError(err *ApiError) { r.Error = err }
+func (r *JSApiConsumerEvacuatePeerResponse) setSuccess()            { r.Success = true }
+
+// Request to remove a peer from a single clustered consumer.
+func (s *Server) jsConsumerRemovePeerRequest(_ *subscription, c *client, _ *Account, subject, reply string, rmsg []byte) {
+	req := &JSApiConsumerRemovePeerRequest{}
+	resp := &JSApiConsumerRemovePeerResponse{ApiResponse: ApiResponse{Type: JSApiConsumerRemovePeerResponseType}}
+	s.jsConsumerRemapPeerRequest(nil, c, nil, subject, reply, rmsg, req, resp, true)
+}
+
+// Request to evacuate a peer from a single clustered consumer.
+func (s *Server) jsConsumerEvacuatePeerRequest(_ *subscription, c *client, _ *Account, subject, reply string, rmsg []byte) {
+	req := &JSApiConsumerEvacuatePeerRequest{}
+	resp := &JSApiConsumerEvacuatePeerResponse{ApiResponse: ApiResponse{Type: JSApiConsumerEvacuatePeerResponseType}}
+	s.jsConsumerRemapPeerRequest(nil, c, nil, subject, reply, rmsg, req, resp, false)
+}
+
+func (s *Server) jsConsumerRemapPeerRequest(_ *subscription, c *client, _ *Account, subject, reply string, rmsg []byte, req consumerRemapPeerRequest, resp consumerRemapPeerResponse, remove bool) {
+	if c == nil || !s.JetStreamEnabled() {
+		return
+	}
+	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
+	if err != nil {
+		s.Warnf(badAPIRequestT, msg)
+		return
+	}
+
+	// If we are not in clustered mode this is a failed request.
+	if !s.JetStreamIsClustered() {
+		resp.setError(NewJSClusterRequiredError())
+		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(resp))
+		return
+	}
+
+	js, cc := s.getJetStreamCluster()
+	if js == nil || cc == nil {
+		return
+	}
+	if js.isLeaderless() {
+		resp.setError(NewJSClusterNotAvailError())
+		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(resp))
+		return
+	}
+
+	// Have extra tokens for this one.
+	stream := tokenAt(subject, 6)
+	consumer := tokenAt(subject, 7)
+
+	js.mu.RLock()
+	isLeader := cc.isLeader()
+	js.mu.RUnlock()
+
+	// Only the metaleader can change assignments.
+	if !isLeader {
+		return
+	}
+
+	if errorOnRequiredApiLevel(hdr) {
+		resp.setError(NewJSRequiredApiLevelError())
+		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(resp))
+		return
+	}
+
+	if hasJS, doErr := acc.checkJetStream(); !hasJS {
+		if doErr {
+			resp.setError(NewJSNotEnabledForAccountError())
+			s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(resp))
+		}
+		return
+	}
+	if isEmptyRequest(msg) {
+		resp.setError(NewJSBadRequestError())
+		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(resp))
+		return
+	}
+
+	if err := s.unmarshalRequest(c, acc, subject, msg, req); err != nil {
+		resp.setError(NewJSInvalidJSONError(err))
+		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(resp))
+		return
+	}
+	if req.peer() == _EMPTY_ {
+		resp.setError(NewJSBadRequestError())
+		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(resp))
+		return
+	}
+
+	js.mu.Lock()
+	defer js.mu.Unlock()
+
+	sa := js.streamAssignmentOrInflight(acc.Name, stream)
+	if sa == nil {
+		resp.setError(NewJSStreamNotFoundError())
+		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(resp))
+		return
+	}
+	ca := js.consumerAssignmentOrInflight(acc.Name, stream, consumer)
+	if ca == nil || ca.Config == nil {
+		resp.setError(NewJSConsumerNotFoundError())
+		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(resp))
+		return
+	}
+
+	isGroupMember := func(peer string) bool {
+		return ca.Group.isMember(peer) || (ca.Group.Desired != nil && slices.Contains(ca.Group.Desired.Peers, peer))
+	}
+
+	// Check to see if we are a member of the group.
+	// Peer here is either a peer ID or a server name, convert to node name.
+	nodeName := getHash(req.peer())
+	isMember := isGroupMember(nodeName)
+	if !isMember {
+		nodeName = req.peer()
+		isMember = isGroupMember(nodeName)
+	}
+
+	// Make sure we are a member.
+	if !isMember {
+		resp.setError(NewJSClusterPeerNotMemberError())
+		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(resp))
+		return
+	}
+
+	// If we are here we have a valid peer member set for removal.
+	if !js.remapPeerFromConsumerLocked(sa, ca, nodeName, remove) {
 		resp.setError(NewJSPeerRemapError())
 		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(resp))
 		return

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -3228,6 +3228,135 @@ func (js *jetStream) removePeerFromStreamLocked(sa *streamAssignment, peer strin
 	return true
 }
 
+// Removes or evacuates the given peer from the consumer's group.
+// Reports whether the removal was applied.
+// Lock should be held.
+func (js *jetStream) remapPeerFromConsumerLocked(sa *streamAssignment, ca *consumerAssignment, peer string, remove bool) bool {
+	cc := js.cluster
+	if cc == nil || cc.meta == nil || sa == nil || ca == nil {
+		return false
+	}
+	cca := cc.remapConsumerAssignment(sa, ca, peer, remove)
+	if cca == nil {
+		return false
+	}
+	accName := ca.Client.serviceAccount()
+	if err := cc.meta.Propose(cc.term, encodeAddConsumerAssignment(cca)); err != nil {
+		return false
+	}
+	cc.trackInflightConsumerProposal(accName, sa.Config.Name, cca, false)
+	return true
+}
+
+// Removes or evacuates the given peer from a single consumer, replacing it with one of the
+// stream's other peers. The stream's own group is left alone, so the replacement can only
+// come from where the stream already is.
+// Returns nil if nothing changes, or if the consumer would be left short.
+// Lock should be held.
+func (cc *jetStreamCluster) remapConsumerAssignment(sa *streamAssignment, ca *consumerAssignment, peer string, remove bool) *consumerAssignment {
+	// A single peer stream has nowhere to hand this consumer to.
+	streamPeers := sa.targetPeers()
+	if len(streamPeers) < 2 {
+		return nil
+	}
+
+	// The peer must exist in the actual or desired peer set, otherwise there's nothing to do.
+	if !ca.Group.isMember(peer) && (ca.Group.Desired == nil || !slices.Contains(ca.Group.Desired.Peers, peer)) {
+		return nil
+	}
+
+	// A group that's already converging is driven by its desired peers, so base on those.
+	// The actual peers would hand back the ones the migration is dropping.
+	basePeers := ca.Group.Peers
+	if d := ca.Group.Desired; d != nil {
+		basePeers = d.Peers
+	}
+
+	// A scale down that's already pending stays pending, its leader picks which peers remain.
+	scaleDown := ca.Group.Desired != nil && ca.Group.Desired.ScaleDown
+
+	// The count the consumer must come out at, interest/workqueue require peer parity.
+	replicas := ca.Config.replicas(sa.Config)
+	if sa.Config.Retention != LimitsPolicy {
+		replicas = sa.Config.Replicas
+	}
+
+	retain := make([]string, 0, len(basePeers))
+	for _, p := range basePeers {
+		if p != peer {
+			retain = append(retain, p)
+		}
+	}
+
+	// The replacement must be a stream peer this consumer is not on yet. Prefer one that's
+	// up, but take one that's down over none at all.
+	var online, offline []string
+	for _, p := range streamPeers {
+		if p == peer || slices.Contains(retain, p) {
+			continue
+		}
+		if si, ok := cc.s.nodeToInfo.Load(p); ok && si != nil && si.(nodeInfo).offline {
+			offline = append(offline, p)
+			continue
+		}
+		online = append(online, p)
+	}
+	candidates := online
+	if len(candidates) == 0 {
+		candidates = offline
+	}
+
+	newPeers := retain
+	if len(retain) < len(basePeers) && len(candidates) > 0 {
+		rand.Shuffle(len(candidates), func(i, j int) { candidates[i], candidates[j] = candidates[j], candidates[i] })
+		newPeers = append(retain, candidates[0])
+	}
+	// Reject if the consumer would be left short. A pending scale down is no exception, its
+	// desired peers are what the leader still has to pick a full replica set out of.
+	if len(newPeers) < replicas {
+		return nil
+	}
+
+	cca := ca.copyGroup()
+	cca.Group.Peers = newPeers
+	// Always use desired state, so peers and where they converge to can never diverge.
+	// Reconciling that state renames a single node group once it lands.
+	cca.Group = ca.Group.withDesired(cca.Group)
+	cca.Group.Desired.ScaleDown = scaleDown
+
+	if remove {
+		removeFrom := func(from []string) []string {
+			return slices.DeleteFunc(from, func(p string) bool { return p == peer })
+		}
+		cca.Group.Peers = removeFrom(cca.Group.Peers)
+		cca.Group.Desired.Peers = removeFrom(cca.Group.Desired.Peers)
+		cca.Group.Desired.addRemoved([]string{peer})
+	}
+	// Don't allow moving to an empty set.
+	if len(cca.Group.Desired.Peers) == 0 {
+		return nil
+	}
+	// Don't carry a stale preferred into the remaining group.
+	isMember := func(p string) bool {
+		return slices.Contains(cca.Group.Peers, p) || slices.Contains(cca.Group.Desired.Peers, p)
+	}
+	if cca.Group.Preferred != _EMPTY_ && !isMember(cca.Group.Preferred) {
+		cca.Group.Preferred = _EMPTY_
+	}
+	if cca.Group.Desired.Preferred != _EMPTY_ && !isMember(cca.Group.Desired.Preferred) {
+		cca.Group.Desired.Preferred = _EMPTY_
+	}
+	// Nothing actually changes, don't propose a no-op migration.
+	if slices.Equal(cca.Group.Peers, ca.Group.Peers) && slices.Equal(cca.Group.Desired.Peers, basePeers) {
+		return nil
+	}
+	// If no peers remain, immediately jump to the desired set.
+	if len(cca.Group.Peers) == 0 {
+		cca.Group.Peers = copyStrings(cca.Group.Desired.Peers)
+	}
+	return cca
+}
+
 // Check if we have peer related entries.
 func (js *jetStream) hasPeerEntries(entries []*Entry) bool {
 	for _, e := range entries {
@@ -9428,6 +9557,10 @@ func (cc *jetStreamCluster) reassignStreamPeers(sa *streamAssignment, peers []st
 		csa.Group.Desired.Peers = removeFrom(csa.Group.Desired.Peers)
 		csa.Group.Desired.addRemoved(peers)
 	}
+	// Don't allow moving to an empty set.
+	if len(csa.Group.Desired.Peers) == 0 {
+		return nil, false
+	}
 	// Don't carry a stale preferred into the remaining group.
 	isMember := func(peer string) bool {
 		return slices.Contains(csa.Group.Peers, peer) || slices.Contains(csa.Group.Desired.Peers, peer)
@@ -9437,10 +9570,6 @@ func (cc *jetStreamCluster) reassignStreamPeers(sa *streamAssignment, peers []st
 	}
 	if csa.Group.Desired.Preferred != _EMPTY_ && !isMember(csa.Group.Desired.Preferred) {
 		csa.Group.Desired.Preferred = _EMPTY_
-	}
-	// Don't allow moving to an empty set.
-	if len(csa.Group.Desired.Peers) == 0 {
-		return nil, false
 	}
 	// Preserve excluded peer set only if the group is still missing peers.
 	csa.Group.Excluded = excluded

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -1075,8 +1075,8 @@ func (js *jetStream) isStreamHealthy(acc *Account, sa *streamAssignment) error {
 }
 
 // isConsumerHealthy will determine if the consumer is up to date.
-// For R1 it will make sure the consunmer is present on this server.
-func (js *jetStream) isConsumerHealthy(mset *stream, consumer string, ca *consumerAssignment) error {
+// For R1 it will make sure the consumer is present on this server.
+func (js *jetStream) isConsumerHealthy(mset *stream, sa *streamAssignment, consumer string, ca *consumerAssignment) error {
 	js.mu.RLock()
 	if ca != nil && ca.unsupported != nil {
 		js.mu.RUnlock()
@@ -1106,6 +1106,13 @@ func (js *jetStream) isConsumerHealthy(mset *stream, consumer string, ca *consum
 	}
 	created := ca.Created
 	node := ca.Group.node
+	// The stream may be running at its origin while its config already carries the
+	// target replica count. A consumer that has not been mapped onto the new peers
+	// yet inherits that target, so fall back on the origin count below.
+	var originReplicas int
+	if o := sa.desiredOrigin(); o != nil {
+		originReplicas = o.Replicas
+	}
 	js.mu.RUnlock()
 
 	// Check if not running at all.
@@ -1131,6 +1138,12 @@ func (js *jetStream) isConsumerHealthy(mset *stream, consumer string, ca *consum
 		return nil // No further checks for R=1 consumers
 
 	case node == nil:
+		// Not mapped onto the new peers yet, so still running at the stream's origin
+		// count. Only evaluated here, a consumer that does have a node must be checked
+		// as usual for the rest of the migration.
+		if originReplicas > 0 && originReplicas < rc {
+			return nil
+		}
 		return errors.New("group node missing")
 
 	case oNode == nil:

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -10376,11 +10376,12 @@ func (s *Server) jsClusteredStreamUpdateRequestLocked(ci *ClientInfo, acc *Accou
 		isMoveRequest = newCfg.Placement != nil && !reflect.DeepEqual(osa.Config.Placement, newCfg.Placement)
 	}
 
-	// Check for replica changes.
+	// Check for replica or retention changes.
 	isReplicaChange := newCfg.Replicas != osa.Config.Replicas
+	isRetentionChange := newCfg.Retention != osa.Config.Retention
 
 	// Combining a move and a scale in a single update is not allowed.
-	if isMoveRequest && isReplicaChange {
+	if isMoveRequest && (isReplicaChange || isRetentionChange) {
 		resp.Error = NewJSStreamMoveAndScaleError()
 		s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
 		return
@@ -10404,7 +10405,7 @@ func (s *Server) jsClusteredStreamUpdateRequestLocked(ci *ClientInfo, acc *Accou
 			s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
 			return
 		}
-	} else if isReplicaChange && moveInFlight {
+	} else if (isReplicaChange || isRetentionChange) && moveInFlight {
 		// A scale can't combine with an inflight move either. Scales may freely stack
 		// onto an inflight scale or retention change, but not with a move.
 		resp.Error = NewJSStreamMoveInProgressError()

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -3446,6 +3446,8 @@ func (js *jetStream) createRaftGroup(accName string, rg *raftGroup, recovering b
 		return nil, NewJSClusterNotActiveError()
 	}
 
+	// While a desired state is pending the group keeps a node even at a single peer, so
+	// scaling down doesn't lose the Raft term a newer server resumes the migration from.
 	// If this is a single peer raft group or we are not a member return.
 	if (rg.Desired == nil && len(rg.Peers) <= 1) || !rg.isMember(cc.meta.ID()) {
 		// Nothing to do here.
@@ -4636,7 +4638,7 @@ func (js *jetStream) runStreamMigration(mset *stream, sa *streamAssignment, n Ra
 
 	// Before publishing a stable R1 assignment, make the store independently durable
 	// because applying the assignment will remove the Raft node and its WAL.
-	if exactMatch && replicas == 1 {
+	if exactMatch && len(current) == 1 {
 		if err := mset.flushForScaleDown(); err != nil {
 			if errors.Is(err, ErrStoreClosed) {
 				return mstat(MigrationStatusUnavailable, "shutting down")
@@ -5908,7 +5910,8 @@ func (js *jetStream) processUpdateStreamAssignment(sa *streamAssignment) {
 	sa.err = osa.err
 
 	// If we detect we are scaling down to 1, non-clustered, and we had a previous node, clear it here.
-	if sa.Config.Replicas == 1 && sa.Group.node != nil && sa.Group.Desired == nil {
+	// Note the group can converge onto one peer without the config scaling down based on peer-removes.
+	if len(sa.Group.Peers) == 1 && sa.Group.node != nil && sa.Group.Desired == nil {
 		sa.Group.node = nil
 	}
 
@@ -6018,6 +6021,9 @@ func (js *jetStream) processClusterUpdateStream(acc *Account, osa, sa *streamAss
 	s, rg, desired := js.srv, sa.Group, sa.Group.Desired
 	client, subject, reply := sa.Client, sa.Subject, sa.Reply
 	alreadyRunning, numReplicas := osa.Group.node != nil, len(rg.Peers)
+	// A remap below clears alreadyRunning, but we must still know whether we were
+	// running clustered before, or we'd skip the cleanup we owe on a downgrade.
+	wasRunning := alreadyRunning
 	wasClustered := len(osa.Group.Peers) > 1 || osa.Group.Desired != nil
 	needsNode := rg.node == nil
 	storage, cfg := sa.Config.Storage, sa.Config
@@ -6076,7 +6082,7 @@ func (js *jetStream) processClusterUpdateStream(acc *Account, osa, sa *streamAss
 			if !started {
 				mset.monitorWg.Done()
 			}
-		} else if numReplicas == 1 && desired == nil && alreadyRunning {
+		} else if numReplicas == 1 && desired == nil && wasRunning {
 			// We downgraded to R1. Make sure we cleanup the raft node and the stream monitor.
 			mset.removeNode()
 			mset.stopMonitoring()

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -2870,17 +2870,22 @@ func (sa *streamAssignment) missingPeers() bool {
 // The peer set this stream, and its consumers, must end up on.
 // Lock should be held.
 func (sa *streamAssignment) targetPeers() []string {
-	targetPeers := sa.Group.Peers
-	if sa.Group.Desired != nil {
-		// Peers are only known if not scaling down.
-		if !sa.Group.Desired.ScaleDown {
-			targetPeers = sa.Group.Desired.Peers
-		}
-	} else if len(targetPeers) > sa.Config.Replicas {
+	targetPeers := sa.Group.targetPeers()
+	if sa.Group.Desired == nil && len(targetPeers) > sa.Config.Replicas {
 		// If the stream is already moving, without desired state, the last N peers are the target.
 		targetPeers = targetPeers[len(targetPeers)-sa.Config.Replicas:]
 	}
 	return targetPeers
+}
+
+// The peer set this group must end up on. Peers are only known if not scaling
+// down, the group leader selects which peers to scale down to.
+// Lock should be held.
+func (rg *raftGroup) targetPeers() []string {
+	if rg.Desired != nil && !rg.Desired.ScaleDown {
+		return rg.Desired.Peers
+	}
+	return rg.Peers
 }
 
 // Returns the group's peers that are no longer part of the meta peer set.
@@ -9465,17 +9470,24 @@ func (js *jetStream) remapConsumerAssignments(accName string, sa *streamAssignme
 		if ca.Config == nil || ca.unsupported != nil {
 			continue
 		}
-		consumerPeers := ca.Group.Peers
-		if ca.Group.Desired != nil {
-			// Still moving toward its desired peer set.
-			done = false
-			consumerPeers = ca.Group.Desired.Peers
-		}
 		// Determine the desired replica count.
 		r := ca.Config.replicas(sa.Config)
 		// If stream is interest or workqueue policy always remaps since they require peer parity with stream.
 		if sa.Config.Retention != LimitsPolicy {
 			r = sa.Config.Replicas
+		}
+		consumerPeers := ca.Group.targetPeers()
+		target := r
+		var scaleDown bool
+		if ca.Group.Desired != nil {
+			// Still moving toward its desired peer set.
+			done = false
+			// A pending scale down must not shrink here, only drop peers that are no
+			// longer part of the stream. The group leader selects which peers remain.
+			if ca.Group.Desired.ScaleDown {
+				target = len(consumerPeers)
+				scaleDown = true
+			}
 		}
 		// Perform a quick check, without allocating, whether this consumer needs to be remapped.
 		kept := 0
@@ -9486,10 +9498,10 @@ func (js *jetStream) remapConsumerAssignments(accName string, sa *streamAssignme
 		}
 		// Backfill can only draw from the target peer set, so that bounds how far we can grow.
 		size := kept
-		if size < r {
-			size = min(r, max(kept, len(targetPeers)))
-		} else if size > r {
-			size = r
+		if size < target {
+			size = min(target, max(kept, len(targetPeers)))
+		} else if size > target {
+			size = target
 		}
 		// Leave the consumer alone if its peer set is unaffected.
 		if kept == len(consumerPeers) && kept == size {
@@ -9514,19 +9526,19 @@ func (js *jetStream) remapConsumerAssignments(accName string, sa *streamAssignme
 			}
 		}
 		// Backfill from the shuffled target set until the consumer has its desired number of target peers.
-		if len(newPeers) < r {
+		if len(newPeers) < target {
 			backfill := copyStrings(targetPeers)
 			rand.Shuffle(len(backfill), func(i, j int) { backfill[i], backfill[j] = backfill[j], backfill[i] })
 			for _, p := range backfill {
-				if len(newPeers) >= r {
+				if len(newPeers) >= target {
 					break
 				}
 				if !slices.Contains(newPeers, p) {
 					newPeers = append(newPeers, p)
 				}
 			}
-		} else if len(newPeers) > r {
-			newPeers = newPeers[:r]
+		} else if len(newPeers) > target {
+			newPeers = newPeers[:target]
 		}
 		cca := ca.copyGroup()
 		// Adjust preferred as needed.
@@ -9549,23 +9561,23 @@ func (js *jetStream) remapConsumerAssignments(accName string, sa *streamAssignme
 			cfg.Replicas = r
 			cca.Config = &cfg
 		}
-		// Only use desired state if the stream did as well.
-		if sa.Group.Desired != nil {
-			cca.Group = ca.Group.withDesired(cca.Group)
-			// Scaled down if we kept at least one peer, but removed others.
-			cca.Group.Desired.ScaleDown = kept > 0 && kept != len(consumerPeers)
+		// Always use desired state, so the peers and where they must
+		// converge to can never diverge.
+		cca.Group = ca.Group.withDesired(cca.Group)
+		// Scaled down if we kept at least one peer, but removed others.
+		// A scale down that was already pending stays pending.
+		cca.Group.Desired.ScaleDown = scaleDown || (kept > 0 && kept != len(consumerPeers))
 
-			// Drop any peers that are no longer part of the stream's peer set.
-			var dropped []string
-			cca.Group.Peers = slices.DeleteFunc(cca.Group.Peers, func(peer string) bool {
-				if slices.Contains(sa.Group.Peers, peer) {
-					return false
-				}
-				dropped = append(dropped, peer)
-				return true
-			})
-			cca.Group.Desired.addRemoved(dropped)
-		}
+		// Drop any peers that are no longer part of the stream's peer set.
+		var dropped []string
+		cca.Group.Peers = slices.DeleteFunc(cca.Group.Peers, func(peer string) bool {
+			if slices.Contains(sa.Group.Peers, peer) {
+				return false
+			}
+			dropped = append(dropped, peer)
+			return true
+		})
+		cca.Group.Desired.addRemoved(dropped)
 		// If a consumer lost all of its peers to removal.
 		if len(cca.Group.Peers) == 0 {
 			// Delete it if ephemeral.

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -205,7 +205,8 @@ type raftGroup struct {
 // desiredGroupPlacement specifies the desired peer set.
 // A stream or consumer raftGroup can be scaled or moved safely based on this desired state.
 type desiredRaftGroup struct {
-	ID string `json:"id"`
+	Created time.Time `json:"created"`
+	ID      string    `json:"id"`
 	// Term is the raft term of the group leader driving this desired state. It acts as a
 	// fencing token; reconcile requests from older leadership terms are rejected.
 	Term      uint64   `json:"term,omitempty"`
@@ -305,21 +306,21 @@ func (rg *raftGroup) withDesired(target *raftGroup) *raftGroup {
 		// Don't carry a stale preferred into the desired group.
 		target.Preferred = _EMPTY_
 	}
-	var term uint64
-	if target.Desired != nil {
-		term = target.Desired.Term
-	}
 	ng := rg.copyGroup()
 	ng.Name = target.Name
 	ng.Desired = &desiredRaftGroup{
+		Created:   time.Now().UTC(),
 		ID:        nuid.Next(),
-		Term:      term,
+		Term:      0,
 		Peers:     target.Peers,
 		Cluster:   target.Cluster,
 		Preferred: target.Preferred,
 	}
 	if rg.Desired != nil {
-		// Must preserve whether an in-flight move is being retargeted.
+		// Must preserve the original created timestamp, term,
+		// and whether an in-flight move is being retargeted.
+		ng.Desired.Created = rg.Desired.Created
+		ng.Desired.Term = rg.Desired.Term
 		ng.Desired.Move = rg.Desired.Move
 		// Must preserve the prior origin (if any).
 		if rg.Desired.Origin != nil {
@@ -12900,7 +12901,8 @@ func (js *jetStream) clusterInfo(rg *raftGroup) *ClusterInfo {
 	)
 	if d := rg.Desired; d != nil {
 		desired = &DesiredClusterInfo{
-			Name: d.Cluster,
+			Created: d.Created,
+			Name:    d.Cluster,
 		}
 		// If desired state can be rolled back, include what can be rolled back to.
 		// Must copy, the origin is owned by the meta layer but reported without its lock.

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -4559,6 +4559,13 @@ func (js *jetStream) runStreamMigration(mset *stream, sa *streamAssignment, n Ra
 			js.mu.RUnlock()
 			return mstat(MigrationStatusMeta, "desired state changed, reassessing")
 		}
+		// Peers that were already in the group before this desired state began. They have a
+		// copy of the stream data, which is what lets us shed the surplus before the peers
+		// we're moving to have caught up.
+		var originPeers []string
+		if o := sa.Group.Desired.Origin; o != nil {
+			originPeers = copyStrings(o.Peers)
+		}
 		var blockedBy string
 		for name, c := range sa.consumers {
 			if c.unsupported != nil {
@@ -4586,29 +4593,51 @@ func (js *jetStream) runStreamMigration(mset *stream, sa *streamAssignment, n Ra
 		// Remove old peers one at a time, the leader selected last.
 		remove := s.selectPeerToRemove(ourPeerId, actual, remaining)
 
-		// Only remove a peer if the group left after the removal retains a
-		// store-current majority; otherwise wait for catchups to complete.
-		var currentCount int
+		// Tally up what we can rely on before removing a peer.
+		// - currentDesired: desired peers that are current and caught up. We can only
+		//   transfer leadership to a peer that's current, so it's what we can step down to.
+		// - caughtUpDesired: desired peers that are caught up, they might not all be
+		//   current. We use this where we only need them to have the data.
+		// - copiesAfterRemoval: whether we have sufficient copies of the data after
+		//   having removed the peer, so it's tallied without it.
 		var currentDesired []string
+		var caughtUpDesired, copiesAfterRemoval int
 		for _, p := range actual {
-			if p.Current && p.Lag == 0 && !slices.Contains(catchups, p.ID) {
-				if p.ID != remove {
-					currentCount++
-				}
-				if slices.Contains(desiredPeers, p.ID) {
-					currentDesired = append(currentDesired, p.ID)
-				}
+			inCatchup := slices.Contains(catchups, p.ID)
+			isDesired := slices.Contains(desiredPeers, p.ID)
+			if isDesired && !inCatchup {
+				caughtUpDesired++
+			}
+			if p.Current && !inCatchup && isDesired {
+				currentDesired = append(currentDesired, p.ID)
+			}
+			if p.ID == remove {
+				continue
+			}
+			// A peer has the stream if it was in the group before this desired state
+			// began, or if it was added and has caught up since.
+			if !inCatchup && (slices.Contains(originPeers, p.ID) || p.Current) {
+				copiesAfterRemoval++
 			}
 		}
-		if quorum := (len(actual)-1)/2 + 1; currentCount < quorum {
-			return mstat(MigrationStatusCatchup, "waiting for peers to catch up")
+		// We only need to weigh the peers we're keeping, we already have Raft quorum, or
+		// we couldn't have grown the group to get here. Peers outside the desired set are
+		// on their way out, and we don't want them to block us.
+		if quorum := len(desiredPeers)/2 + 1; caughtUpDesired < quorum {
+			return mstat(MigrationStatusCatchup, "waiting for desired peers to catch up")
+		}
+		// The group left after the removal must still be able to commit.
+		if !s.canRemovePeer(ourPeerId, remove, actual) {
+			return mstat(MigrationStatusQuorum, "waiting for quorum to remove peer")
+		}
+		// Backstop for peers that are neither catching up nor caught up, they're down or
+		// haven't started. Origin peers still have a copy of the data, so this only bites
+		// once we get to removing the last of them.
+		if quorum := len(desiredPeers)/2 + 1; copiesAfterRemoval < quorum {
+			return mstat(MigrationStatusCatchup, "waiting for more peers to catch up")
 		}
 		// If we have current desired peers, and we're not a desired peer ourselves, step down.
 		if len(currentDesired) > 0 && !slices.Contains(desiredPeers, ourPeerId) {
-			// If desired peers are still catching up, we wait for a quorum of them to complete for now.
-			if quorum := len(desiredPeers)/2 + 1; len(currentDesired) < quorum {
-				return mstat(MigrationStatusCatchup, "waiting for desired peers to catch up")
-			}
 			preferred := s.selectStepDownPreferred(ourPeerId, actual, currentDesired)
 			if preferred == _EMPTY_ {
 				return mstat(MigrationStatusMembership, "waiting for a desired peer to step down to")
@@ -7775,6 +7804,10 @@ func (js *jetStream) runConsumerMigration(o *consumer, ca *consumerAssignment, n
 		// selected last, so leadership changes at most once, and every remaining
 		// member is already in the desired peer set so any successor works.
 		remove := s.selectPeerToRemove(ourPeerId, actual, remaining)
+		// The group left after the removal must still be able to commit.
+		if !s.canRemovePeer(ourPeerId, remove, actual) {
+			return mstat(MigrationStatusQuorum, "waiting for quorum to remove peer")
+		}
 		if remove == ourPeerId {
 			err := n.StepDown()
 			return mstat(MigrationStatusMembership, "stepping down before removing ourselves").withErr(err)
@@ -10703,6 +10736,25 @@ func (s *Server) selectPeerToRemove(curLeader string, current []*Peer, remaining
 		return _EMPTY_
 	}
 	return sorted[len(sorted)-1]
+}
+
+// canRemovePeer reports whether the group can still commit after removing the
+// given peer. Only current peers we've heard from recently are counted as
+// voters; we always count ourselves. This is the removal counterpart to the
+// quorum check in selectPeerToAdd.
+func (s *Server) canRemovePeer(ourPeerId, remove string, actual []*Peer) bool {
+	cutoff := time.Now().Add(-hbInterval * 3)
+	var voters int
+	for _, p := range actual {
+		if p.ID == remove {
+			continue
+		}
+		heard := p.ID == ourPeerId || (!p.Last.IsZero() && p.Last.After(cutoff))
+		if p.Current && heard {
+			voters++
+		}
+	}
+	return voters >= (len(actual)-1)/2+1
 }
 
 // selectPeerToAdd picks the peer from candidates that is most preferable to

--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -5174,6 +5174,485 @@ func TestJetStreamClusterPeerRemoveAndEvacuateConsumersMatrix(t *testing.T) {
 	}
 }
 
+func TestJetStreamClusterConsumerPeerRemoveAndEvacuateMatrix(t *testing.T) {
+	const clusterSize = 3
+	c := createJetStreamClusterExplicit(t, "R3S", clusterSize)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	for i, test := range []struct {
+		name             string
+		evacuate         bool
+		streamReplicas   int
+		consumerReplicas int
+	}{
+		{"Remove/StreamR1/ConsumerR1", false, 1, 1},
+		{"Remove/StreamR3/ConsumerR1", false, 3, 1},
+		{"Remove/StreamR3/ConsumerR3", false, 3, 3},
+		{"Evacuate/StreamR1/ConsumerR1", true, 1, 1},
+		{"Evacuate/StreamR3/ConsumerR1", true, 3, 1},
+		{"Evacuate/StreamR3/ConsumerR3", true, 3, 3},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			// The stream's group is left alone, so the replacement has to be a stream
+			// peer the consumer is not on yet. A consumer that already spans the stream
+			// has none, and neither does one on a single peer stream.
+			replaceable := test.consumerReplicas < test.streamReplicas
+
+			// Each case gets its own stream so that the cases stay independent.
+			stream := fmt.Sprintf("TEST_%d", i)
+			subject := fmt.Sprintf("foo.%d", i)
+			_, err := js.AddStream(&nats.StreamConfig{
+				Name:     stream,
+				Subjects: []string{subject},
+				Replicas: test.streamReplicas,
+			})
+			require_NoError(t, err)
+
+			_, err = js.AddConsumer(stream, &nats.ConsumerConfig{
+				Durable:           "CONSUMER",
+				AckPolicy:         nats.AckExplicitPolicy,
+				Replicas:          test.consumerReplicas,
+				InactiveThreshold: time.Hour,
+			})
+			require_NoError(t, err)
+
+			ml := c.leader()
+			require_NotNil(t, ml)
+
+			sjs := ml.getJetStream()
+			sjs.mu.RLock()
+			sa := sjs.streamAssignment(globalAccountName, stream)
+			streamPeers := append([]string(nil), sa.Group.Peers...)
+			sjs.mu.RUnlock()
+			require_Len(t, len(streamPeers), test.streamReplicas)
+
+			// Target a peer that hosts the consumer, so that every case actually
+			// exercises the consumer being taken off of the targeted peer. A
+			// replicated consumer sits on every stream peer, so any of them will do.
+			var rs *Server
+			if test.consumerReplicas == 1 {
+				rs = c.consumerLeader(globalAccountName, stream, "CONSUMER")
+			} else {
+				rs = c.randomNonStreamLeader(globalAccountName, stream)
+				if rs == nil {
+					rs = c.streamLeader(globalAccountName, stream)
+				}
+			}
+			require_NotNil(t, rs)
+			target := rs.Node()
+
+			subjT := JSApiConsumerRemovePeerT
+			if test.evacuate {
+				subjT = JSApiConsumerEvacuatePeerT
+			}
+			b, err := json.Marshal(JSApiConsumerRemovePeerRequest{Peer: target})
+			require_NoError(t, err)
+			msg, err := nc.Request(fmt.Sprintf(subjT, stream, "CONSUMER"), b, 10*time.Second)
+			require_NoError(t, err)
+			var resp JSApiConsumerRemovePeerResponse
+			require_NoError(t, json.Unmarshal(msg.Data, &resp))
+			require_Equal(t, resp.Success, replaceable)
+			if !replaceable {
+				// There was nowhere to move the consumer to, so the request is
+				// rejected and the consumer is left alone.
+				require_Error(t, resp.Error, NewJSPeerRemapError())
+			}
+
+			// The consumer moved off of the targeted peer onto another of the stream's
+			// peers, keeping its replica count. A rejected request leaves it where it was.
+			checkFor(t, 5*time.Second, 250*time.Millisecond, func() error {
+				sjs.mu.RLock()
+				defer sjs.mu.RUnlock()
+				ca := sjs.consumerAssignment(globalAccountName, stream, "CONSUMER")
+				if ca == nil || ca.Group == nil {
+					return fmt.Errorf("consumer not found")
+				}
+				if ca.Group.Desired != nil {
+					return fmt.Errorf("consumer still converging")
+				}
+				if len(ca.Group.Peers) != test.consumerReplicas {
+					return fmt.Errorf("expected %d consumer peers, got %v", test.consumerReplicas, ca.Group.Peers)
+				}
+				if got := slices.Contains(ca.Group.Peers, target); got != !replaceable {
+					return fmt.Errorf("peer %q in consumer peer set = %v, want %v (peers %v)", target, got, !replaceable, ca.Group.Peers)
+				}
+				for _, p := range ca.Group.Peers {
+					if !slices.Contains(streamPeers, p) {
+						return fmt.Errorf("consumer peer %q is not a stream peer %v", p, streamPeers)
+					}
+				}
+				return nil
+			})
+
+			// The consumer must still be usable.
+			_, err = js.Publish(subject, []byte("HELLO"))
+			require_NoError(t, err)
+			sub, err := js.PullSubscribe(subject, _EMPTY_, nats.Bind(stream, "CONSUMER"))
+			require_NoError(t, err)
+			defer sub.Unsubscribe()
+			msgs, err := sub.Fetch(1, nats.MaxWait(10*time.Second))
+			require_NoError(t, err)
+			require_Len(t, len(msgs), 1)
+		})
+	}
+}
+
+func TestJetStreamClusterConsumerPeerRemoveNoReplacementIsRejected(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		evacuate bool
+	}{
+		{"Remove", false},
+		{"Evacuate", true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			// An R3 consumer on an R3 stream has nowhere to hand a peer to.
+			c := createJetStreamClusterExplicit(t, "R3S", 3)
+			defer c.shutdown()
+
+			nc, js := jsClientConnect(t, c.randomServer())
+			defer nc.Close()
+
+			_, err := js.AddStream(&nats.StreamConfig{
+				Name:     "TEST",
+				Subjects: []string{"foo"},
+				Replicas: 3,
+			})
+			require_NoError(t, err)
+
+			_, err = js.AddConsumer("TEST", &nats.ConsumerConfig{
+				Durable:   "CONSUMER",
+				AckPolicy: nats.AckExplicitPolicy,
+				Replicas:  3,
+			})
+			require_NoError(t, err)
+
+			ml := c.leader()
+			require_NotNil(t, ml)
+
+			sjs := ml.getJetStream()
+			sjs.mu.RLock()
+			ca := sjs.consumerAssignment(globalAccountName, "TEST", "CONSUMER")
+			peers := append([]string(nil), ca.Group.Peers...)
+			sjs.mu.RUnlock()
+			require_Len(t, len(peers), 3)
+
+			rs := c.randomNonStreamLeader(globalAccountName, "TEST")
+			require_NotNil(t, rs)
+			target := rs.Node()
+
+			subjT := JSApiConsumerRemovePeerT
+			if test.evacuate {
+				subjT = JSApiConsumerEvacuatePeerT
+			}
+			b, err := json.Marshal(JSApiConsumerRemovePeerRequest{Peer: target})
+			require_NoError(t, err)
+			msg, err := nc.Request(fmt.Sprintf(subjT, "TEST", "CONSUMER"), b, 10*time.Second)
+			require_NoError(t, err)
+			var resp JSApiConsumerRemovePeerResponse
+			require_NoError(t, json.Unmarshal(msg.Data, &resp))
+			require_False(t, resp.Success)
+			require_Error(t, resp.Error, NewJSPeerRemapError())
+
+			checkPeers := func() {
+				t.Helper()
+				sjs := ml.getJetStream()
+				sjs.mu.RLock()
+				defer sjs.mu.RUnlock()
+				ca := sjs.consumerAssignment(globalAccountName, "TEST", "CONSUMER")
+				require_NotNil(t, ca)
+				require_True(t, ca.Group.Desired == nil)
+				require_True(t, slices.Equal(ca.Group.Peers, peers))
+			}
+			checkPeers()
+
+			// A meta leader change runs reconcilePeerAssignments, which must find
+			// nothing to heal.
+			require_NoError(t, ml.getJetStream().getMetaGroup().StepDown())
+			c.waitOnLeader()
+			ml = c.leader()
+			require_NotNil(t, ml)
+
+			time.Sleep(500 * time.Millisecond)
+			checkPeers()
+
+			// The consumer is untouched and still fully usable.
+			_, err = js.Publish("foo", []byte("HELLO"))
+			require_NoError(t, err)
+			sub, err := js.PullSubscribe("foo", _EMPTY_, nats.Bind("TEST", "CONSUMER"))
+			require_NoError(t, err)
+			defer sub.Unsubscribe()
+			msgs, err := sub.Fetch(1, nats.MaxWait(10*time.Second))
+			require_NoError(t, err)
+			require_Len(t, len(msgs), 1)
+		})
+	}
+}
+
+func TestJetStreamClusterConsumerPeerRemoveInvalidRequestIsRejected(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Replicas: 3,
+	})
+	require_NoError(t, err)
+
+	_, err = js.AddConsumer("TEST", &nats.ConsumerConfig{
+		Durable:   "CONSUMER",
+		AckPolicy: nats.AckExplicitPolicy,
+		Replicas:  1,
+	})
+	require_NoError(t, err)
+
+	ml := c.leader()
+	require_NotNil(t, ml)
+
+	sjs := ml.getJetStream()
+	sjs.mu.RLock()
+	ca := sjs.consumerAssignment(globalAccountName, "TEST", "CONSUMER")
+	peers := append([]string(nil), ca.Group.Peers...)
+	sjs.mu.RUnlock()
+	require_Len(t, len(peers), 1)
+
+	// A peer of the stream that the consumer does not sit on is not a member of the
+	// consumer's group, so it can not be taken out of it.
+	var notMember string
+	for _, s := range c.servers {
+		if n := s.Node(); n != peers[0] {
+			notMember = n
+			break
+		}
+	}
+	require_NotEqual(t, notMember, _EMPTY_)
+
+	for _, test := range []struct {
+		name     string
+		evacuate bool
+		stream   string
+		consumer string
+		peer     string
+		wantErr  *ApiError
+	}{
+		{"Remove/PeerNotMember", false, "TEST", "CONSUMER", notMember, NewJSClusterPeerNotMemberError()},
+		{"Remove/UnknownStream", false, "NO_STREAM", "CONSUMER", peers[0], NewJSStreamNotFoundError()},
+		{"Remove/UnknownConsumer", false, "TEST", "NO_CONSUMER", peers[0], NewJSConsumerNotFoundError()},
+		{"Remove/NoPeer", false, "TEST", "CONSUMER", _EMPTY_, NewJSBadRequestError()},
+		{"Evacuate/PeerNotMember", true, "TEST", "CONSUMER", notMember, NewJSClusterPeerNotMemberError()},
+		{"Evacuate/UnknownStream", true, "NO_STREAM", "CONSUMER", peers[0], NewJSStreamNotFoundError()},
+		{"Evacuate/UnknownConsumer", true, "TEST", "NO_CONSUMER", peers[0], NewJSConsumerNotFoundError()},
+		{"Evacuate/NoPeer", true, "TEST", "CONSUMER", _EMPTY_, NewJSBadRequestError()},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			subjT := JSApiConsumerRemovePeerT
+			if test.evacuate {
+				subjT = JSApiConsumerEvacuatePeerT
+			}
+			b, err := json.Marshal(JSApiConsumerRemovePeerRequest{Peer: test.peer})
+			require_NoError(t, err)
+			msg, err := nc.Request(fmt.Sprintf(subjT, test.stream, test.consumer), b, 10*time.Second)
+			require_NoError(t, err)
+			var resp JSApiConsumerRemovePeerResponse
+			require_NoError(t, json.Unmarshal(msg.Data, &resp))
+			require_False(t, resp.Success)
+			require_Error(t, resp.Error, test.wantErr)
+
+			// The consumer that was named is left where it was.
+			sjs.mu.RLock()
+			defer sjs.mu.RUnlock()
+			ca := sjs.consumerAssignment(globalAccountName, "TEST", "CONSUMER")
+			require_NotNil(t, ca)
+			require_True(t, slices.Equal(ca.Group.Peers, peers))
+		})
+	}
+}
+
+func TestJetStreamClusterConsumerPeerRemoveOfflinePeerIsReplaced(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	cnc, js := jsClientConnect(t, c.randomServer())
+	defer cnc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Replicas: 3,
+	})
+	require_NoError(t, err)
+
+	_, err = js.AddConsumer("TEST", &nats.ConsumerConfig{
+		Durable:   "CONSUMER",
+		AckPolicy: nats.AckExplicitPolicy,
+		Replicas:  1,
+	})
+	require_NoError(t, err)
+
+	// A single replica consumer can not be stepped down onto another server, its group has
+	// only the one peer. Move the meta leader instead, the server we take down must not be
+	// the one that has to serve the request once it is gone.
+	cl := c.consumerLeader(globalAccountName, "TEST", "CONSUMER")
+	require_NotNil(t, cl)
+	ml := c.leader()
+	if ml == cl {
+		require_NoError(t, ml.getJetStream().getMetaGroup().StepDown())
+		c.waitOnLeader()
+		ml = c.leader()
+	}
+	require_NotNil(t, ml)
+	require_NotEqual(t, ml, cl)
+	target := cl.Node()
+
+	// Connect to the meta leader, it is the one server we know stays up below.
+	nc, js := jsClientConnect(t, ml)
+	defer nc.Close()
+
+	// Take the consumer's only peer down and wait for the meta leader to see it go.
+	cl.Shutdown()
+	cl.WaitForShutdown()
+	checkFor(t, 5*time.Second, 250*time.Millisecond, func() error {
+		si, ok := ml.nodeToInfo.Load(target)
+		if !ok || si == nil || !si.(nodeInfo).offline {
+			return fmt.Errorf("peer %q not offline yet", target)
+		}
+		return nil
+	})
+
+	b, err := json.Marshal(JSApiConsumerRemovePeerRequest{Peer: target})
+	require_NoError(t, err)
+	msg, err := nc.Request(fmt.Sprintf(JSApiConsumerRemovePeerT, "TEST", "CONSUMER"), b, 2*time.Second)
+	require_NoError(t, err)
+	var resp JSApiConsumerRemovePeerResponse
+	require_NoError(t, json.Unmarshal(msg.Data, &resp))
+	require_True(t, resp.Success)
+
+	// It must move onto a server that is up. Handing it to the other downed peer would
+	// leave it exactly as unservable as it was.
+	checkFor(t, 5*time.Second, 250*time.Millisecond, func() error {
+		sjs := ml.getJetStream()
+		sjs.mu.RLock()
+		defer sjs.mu.RUnlock()
+		ca := sjs.consumerAssignment(globalAccountName, "TEST", "CONSUMER")
+		if ca == nil || ca.Group == nil {
+			return errors.New("consumer not found")
+		}
+		if slices.Contains(ca.Group.Peers, target) {
+			return fmt.Errorf("consumer still on removed peer %q", target)
+		}
+		if len(ca.Group.Peers) != 1 {
+			return fmt.Errorf("expected 1 consumer peer, got %v", ca.Group.Peers)
+		}
+		return nil
+	})
+
+	// And it must actually come back to life on its new peer.
+	c.waitOnConsumerLeader(globalAccountName, "TEST", "CONSUMER")
+	_, err = js.ConsumerInfo("TEST", "CONSUMER")
+	require_NoError(t, err)
+}
+
+func TestJetStreamClusterRemapConsumerPendingScaleDown(t *testing.T) {
+	const a, b, c = "A", "B", "C"
+
+	cc := &jetStreamCluster{s: &Server{}}
+	// The stream has scaled down onto A and B, so C is no longer one of its peers.
+	// The consumer is following it down, C is still one of its actual peers but the set it
+	// is converging to has already dropped it.
+	newAssignments := func(replicas int) (*streamAssignment, *consumerAssignment) {
+		sa := &streamAssignment{
+			Config: &StreamConfig{Name: "TEST", Replicas: 2, Retention: LimitsPolicy},
+			Group:  &raftGroup{Name: "S", Peers: []string{a, b}},
+		}
+		ca := &consumerAssignment{
+			Name:   "CONSUMER",
+			Stream: "TEST",
+			Config: &ConsumerConfig{Durable: "CONSUMER", Replicas: replicas},
+			Group: &raftGroup{
+				Name:  "C",
+				Peers: []string{a, b, c},
+				Desired: &desiredRaftGroup{
+					Peers:     []string{a, b},
+					ScaleDown: true,
+				},
+			},
+		}
+		sa.consumers = map[string]*consumerAssignment{ca.Name: ca}
+		return sa, ca
+	}
+
+	// Take A out of a consumer heading for a single peer. B alone still satisfies that, and
+	// the stream has nothing to replace A with.
+	sa, ca := newAssignments(1)
+	cca := cc.remapConsumerAssignment(sa, ca, a, true)
+	require_NotNil(t, cca)
+
+	// C must not come back into the set the consumer converges to, the stream is not on it.
+	require_False(t, slices.Contains(cca.Group.Desired.Peers, c))
+	require_True(t, slices.Equal(cca.Group.Desired.Peers, []string{b}))
+	require_True(t, cca.Group.Desired.ScaleDown)
+
+	// The removal itself is recorded, so a group below quorum can evict the peer.
+	require_False(t, slices.Contains(cca.Group.Peers, a))
+	require_True(t, slices.Contains(cca.Group.Desired.Removed, a))
+
+	// The group keeps its name. Renaming a single node group belongs to the reconcile,
+	// which does it once the desired state lands.
+	require_Equal(t, cca.Group.Name, ca.Group.Name)
+
+	// A pending scale down is no license to shrink. Those desired peers are what the group
+	// leader still has to choose from, so taking one out of a consumer heading for two
+	// peers would leave it unable to pick a full set, and is refused.
+	sa, ca = newAssignments(2)
+	require_True(t, cc.remapConsumerAssignment(sa, ca, a, true) == nil)
+
+	// Evacuating a peer that the consumer is already converging away from changes nothing,
+	// so it must not be proposed as a no-op migration.
+	sa, ca = newAssignments(1)
+	require_True(t, cc.remapConsumerAssignment(sa, ca, c, false) == nil)
+
+	// Removing that same peer is not a no-op, it still has to be recorded as removed.
+	sa, ca = newAssignments(1)
+	cca = cc.remapConsumerAssignment(sa, ca, c, true)
+	require_NotNil(t, cca)
+	require_False(t, slices.Contains(cca.Group.Peers, c))
+	require_True(t, slices.Contains(cca.Group.Desired.Removed, c))
+	require_True(t, slices.Equal(cca.Group.Desired.Peers, []string{a, b}))
+}
+
+func TestJetStreamClusterRemapConsumerOverReplicated(t *testing.T) {
+	const a, b, c = "A", "B", "C"
+
+	cc := &jetStreamCluster{s: &Server{}}
+	sa := &streamAssignment{
+		Config: &StreamConfig{Name: "TEST", Replicas: 3, Retention: LimitsPolicy},
+		Group:  &raftGroup{Name: "S", Peers: []string{a, b, c}},
+	}
+	// Assigned three peers while its config asks for two, for instance a replica count
+	// that was lowered but not reconciled yet.
+	ca := &consumerAssignment{
+		Name:   "CONSUMER",
+		Stream: "TEST",
+		Config: &ConsumerConfig{Durable: "CONSUMER", Replicas: 2},
+		Group:  &raftGroup{Name: "C", Peers: []string{a, b, c}},
+	}
+	sa.consumers = map[string]*consumerAssignment{ca.Name: ca}
+
+	// Every stream peer is taken, so there is no replacement, but dropping to two still
+	// satisfies the configured count.
+	cca := cc.remapConsumerAssignment(sa, ca, a, true)
+	require_NotNil(t, cca)
+	require_False(t, slices.Contains(cca.Group.Desired.Peers, a))
+	require_Len(t, len(cca.Group.Desired.Peers), 2)
+}
+
 func TestJetStreamClusterPeerExclusionTag(t *testing.T) {
 	c := createJetStreamClusterWithTemplateAndModHook(t, jsClusterTempl, "C", 3,
 		func(serverName, clusterName, storeDir, conf string) string {

--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -3794,11 +3794,11 @@ func TestJetStreamClusterPeerRemovalAndStreamReassignmentOnMetaLeaderChange(t *t
 
 	// Evacuate one of the stream's peers, no replacement can be selected for it. The
 	// server is going away, so this is applied even though the stream is left short.
-	jsreq, err := json.Marshal(&JSApiMetaServerRemoveRequest{Peer: member.Node()})
+	jsreq, err := json.Marshal(&JSApiMetaServerEvacuateRequest{Peer: member.Node()})
 	require_NoError(t, err)
 	rmsg, err := snc.Request(JSApiEvacuateServer, jsreq, 5*time.Second)
 	require_NoError(t, err)
-	var resp JSApiMetaServerRemoveResponse
+	var resp JSApiMetaServerEvacuateResponse
 	require_NoError(t, json.Unmarshal(rmsg.Data, &resp))
 	require_True(t, resp.Success)
 
@@ -3890,11 +3890,11 @@ func TestJetStreamClusterPeerRemovalAndStreamReassignmentOnNewServer(t *testing.
 	}
 	require_NotNil(t, member)
 
-	jsreq, err := json.Marshal(&JSApiMetaServerRemoveRequest{Peer: member.Node()})
+	jsreq, err := json.Marshal(&JSApiMetaServerEvacuateRequest{Peer: member.Node()})
 	require_NoError(t, err)
 	rmsg, err := snc.Request(JSApiEvacuateServer, jsreq, 5*time.Second)
 	require_NoError(t, err)
-	var resp JSApiMetaServerRemoveResponse
+	var resp JSApiMetaServerEvacuateResponse
 	require_NoError(t, json.Unmarshal(rmsg.Data, &resp))
 	require_True(t, resp.Success)
 
@@ -4810,11 +4810,11 @@ func TestJetStreamClusterEvacuateExclusionNotClearedByNoOpMigration(t *testing.T
 	require_NotNil(t, member)
 	target := member.Node()
 
-	b, err := json.Marshal(JSApiMetaServerRemoveRequest{Peer: target})
+	b, err := json.Marshal(JSApiMetaServerEvacuateRequest{Peer: target})
 	require_NoError(t, err)
 	msg, err := snc.Request(JSApiEvacuateServer, b, 10*time.Second)
 	require_NoError(t, err)
-	var resp JSApiMetaServerRemoveResponse
+	var resp JSApiMetaServerEvacuateResponse
 	require_NoError(t, json.Unmarshal(msg.Data, &resp))
 	require_True(t, resp.Success)
 
@@ -4936,11 +4936,11 @@ func TestJetStreamClusterEvacuateExclusionClearedByReplicaDecrease(t *testing.T)
 	require_NotNil(t, member)
 	target := member.Node()
 
-	b, err := json.Marshal(JSApiMetaServerRemoveRequest{Peer: target})
+	b, err := json.Marshal(JSApiMetaServerEvacuateRequest{Peer: target})
 	require_NoError(t, err)
 	msg, err := snc.Request(JSApiEvacuateServer, b, 10*time.Second)
 	require_NoError(t, err)
-	var resp JSApiMetaServerRemoveResponse
+	var resp JSApiMetaServerEvacuateResponse
 	require_NoError(t, json.Unmarshal(msg.Data, &resp))
 	require_True(t, resp.Success)
 
@@ -15930,11 +15930,11 @@ func TestJetStreamClusterStreamAddPeerConsumerRemap(t *testing.T) {
 	snc, _ := jsClientConnect(t, c.randomServer(), nats.UserInfo("admin", "s3cr3t!"))
 	defer snc.Close()
 
-	b, err := json.Marshal(JSApiMetaServerRemoveRequest{Server: toRemove})
+	b, err := json.Marshal(JSApiMetaServerEvacuateRequest{Server: toRemove})
 	require_NoError(t, err)
 	msg, err := snc.Request(JSApiEvacuateServer, b, 5*time.Second)
 	require_NoError(t, err)
-	var resp JSApiMetaServerRemoveResponse
+	var resp JSApiMetaServerEvacuateResponse
 	require_NoError(t, json.Unmarshal(msg.Data, &resp))
 	// The peer could not be replaced, but the server is going away so it is still
 	// taken out of the stream.

--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -15637,6 +15637,15 @@ func TestJetStreamClusterRetentionChangeMoveExclusion(t *testing.T) {
 	_, err := js.AddStream(cfg)
 	require_NoError(t, err)
 
+	// A retention change converges through desired state just like a scale does, so it
+	// can't combine with a move in a single update either. The guard fires before peer
+	// selection, so the placement doesn't need to resolve.
+	comboCfg := *cfg
+	comboCfg.Retention = nats.InterestPolicy
+	comboCfg.Placement = &nats.Placement{Tags: []string{"na"}}
+	_, err = js.UpdateStream(&comboCfg)
+	require_Error(t, err, NewJSStreamMoveAndScaleError())
+
 	// Block the meta leader from reconciling desired stream assignments, so the
 	// desired state below stays in flight deterministically.
 	ml := c.leader()

--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -9734,7 +9734,7 @@ func TestJetStreamClusterConsumerHealthCheckMustNotRecreate(t *testing.T) {
 	// The RAFT node should be closed. Checking health must not change that.
 	// Simulates a race condition where we're shutting down.
 	checkNodeIsClosed(sjs, ca)
-	require_Error(t, sjs.isConsumerHealthy(mset, "CONSUMER", ca), errors.New("monitor goroutine not running"))
+	require_Error(t, sjs.isConsumerHealthy(mset, sa, "CONSUMER", ca), errors.New("monitor goroutine not running"))
 	checkNodeIsClosed(sjs, ca)
 
 	// We create a new RAFT group, the health check should detect this skew.
@@ -9744,7 +9744,7 @@ func TestJetStreamClusterConsumerHealthCheckMustNotRecreate(t *testing.T) {
 	// We set creating to now, since previously it would delete all data but NOT restart if created within <10s.
 	ca.Created = time.Now()
 	sjs.mu.Unlock()
-	require_Error(t, sjs.isConsumerHealthy(mset, "CONSUMER", ca), errors.New("cluster node skew detected"))
+	require_Error(t, sjs.isConsumerHealthy(mset, sa, "CONSUMER", ca), errors.New("cluster node skew detected"))
 
 	err = js.DeleteConsumer("TEST", "CONSUMER")
 	require_NoError(t, err)
@@ -9764,7 +9764,7 @@ func TestJetStreamClusterConsumerHealthCheckMustNotRecreate(t *testing.T) {
 
 	// The underlying consumer has been deleted. Checking health must not recreate the consumer.
 	checkNodeIsClosed(sjs, ca)
-	require_Error(t, sjs.isConsumerHealthy(mset, "CONSUMER", ca), errors.New("consumer not found"))
+	require_Error(t, sjs.isConsumerHealthy(mset, sa, "CONSUMER", ca), errors.New("consumer not found"))
 	checkNodeIsClosed(sjs, ca)
 }
 
@@ -9844,7 +9844,7 @@ func TestJetStreamClusterConsumerHealthCheckMustNotDeleteEarly(t *testing.T) {
 	// The health check gets the Raft node of the assignment and checks it against the
 	// Raft node of the consumer. We simulate a race condition where the consumer's Raft node
 	// is not yet initialized. The health check MUST NOT delete the node.
-	sjs.isConsumerHealthy(mset, "CONSUMER", ca)
+	sjs.isConsumerHealthy(mset, nil, "CONSUMER", ca)
 	require_Equal(t, node.State(), Follower)
 }
 
@@ -9933,7 +9933,7 @@ func TestJetStreamClusterConsumerHealthCheckOnlyReportsSkew(t *testing.T) {
 	// Raft node of the consumer. We simulate a race condition where the assignment's Raft node
 	// is re-newed, but the consumer's node is still the old instance.
 	// The health check MUST NOT delete the node.
-	require_Error(t, sjs.isConsumerHealthy(mset, "CONSUMER", ca), errors.New("cluster node skew detected"))
+	require_Error(t, sjs.isConsumerHealthy(mset, nil, "CONSUMER", ca), errors.New("cluster node skew detected"))
 	require_NotEqual(t, node.State(), Closed)
 }
 
@@ -9973,14 +9973,14 @@ func TestJetStreamClusterConsumerHealthCheckDeleted(t *testing.T) {
 	// The health check gathers all assignments and does checking after.
 	// If the consumer was deleted in the meantime, it should not report an error.
 	require_NoError(t, js.DeleteConsumer("TEST", "CONSUMER"))
-	require_Error(t, sjs.isConsumerHealthy(mset, "CONSUMER", ca), errors.New("consumer not found"))
+	require_Error(t, sjs.isConsumerHealthy(mset, nil, "CONSUMER", ca), errors.New("consumer not found"))
 
 	// The health check could run earlier than we're able to create the consumer.
 	// In that case, wait before erroring.
 	sjs.mu.Lock()
 	ca.Created = time.Now()
 	sjs.mu.Unlock()
-	require_NoError(t, sjs.isConsumerHealthy(mset, "CONSUMER", ca))
+	require_NoError(t, sjs.isConsumerHealthy(mset, nil, "CONSUMER", ca))
 }
 
 func TestJetStreamClusterStreamHealthCheckSurfacesAssignmentErr(t *testing.T) {
@@ -10054,7 +10054,7 @@ func TestJetStreamClusterConsumerHealthCheckSurfacesAssignmentErr(t *testing.T) 
 	require_True(t, ca != nil)
 
 	// Baseline: healthy.
-	require_NoError(t, sjs.isConsumerHealthy(mset, "CONSUMER", ca))
+	require_NoError(t, sjs.isConsumerHealthy(mset, nil, "CONSUMER", ca))
 
 	// Persisted assignment-level error must surface via the health check.
 	wantErr := errors.New("synthetic consumer assignment failure")
@@ -10062,7 +10062,7 @@ func TestJetStreamClusterConsumerHealthCheckSurfacesAssignmentErr(t *testing.T) 
 	ca.err = wantErr
 	sjs.mu.Unlock()
 
-	err = sjs.isConsumerHealthy(mset, "CONSUMER", ca)
+	err = sjs.isConsumerHealthy(mset, nil, "CONSUMER", ca)
 	require_Error(t, err)
 	require_Contains(t, err.Error(), wantErr.Error())
 
@@ -10070,13 +10070,13 @@ func TestJetStreamClusterConsumerHealthCheckSurfacesAssignmentErr(t *testing.T) 
 	sjs.mu.Lock()
 	ca.err = nil
 	sjs.mu.Unlock()
-	require_NoError(t, sjs.isConsumerHealthy(mset, "CONSUMER", ca))
+	require_NoError(t, sjs.isConsumerHealthy(mset, nil, "CONSUMER", ca))
 }
 
 func TestJetStreamClusterConsumerHealthCheckStreamMissingNoLockLeak(t *testing.T) {
 	js := &jetStream{}
 	ca := &consumerAssignment{}
-	err := js.isConsumerHealthy(nil, "consumer", ca)
+	err := js.isConsumerHealthy(nil, nil, "consumer", ca)
 	require_Error(t, err, errors.New("stream missing"))
 
 	// The JS lock must have been released. Attempt to acquire the write lock
@@ -10340,6 +10340,120 @@ func TestJetStreamClusterStreamHealthCheckRecoversAfterSuccessfulUpdate(t *testi
 	require_NoError(t, sjs.isStreamHealthy(acc, cur))
 }
 
+func TestJetStreamClusterConsumerHealthCheckUnmappedDuringMigration(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Replicas: 1,
+	})
+	require_NoError(t, err)
+	// No explicit replica count, so it inherits the stream's.
+	_, err = js.AddConsumer("TEST", &nats.ConsumerConfig{
+		Durable:   "CONSUMER",
+		AckPolicy: nats.AckExplicitPolicy,
+	})
+	require_NoError(t, err)
+
+	// The single server hosting the R1 stream.
+	var s *Server
+	for _, cs := range c.servers {
+		if _, err := cs.globalAccount().lookupStream("TEST"); err == nil {
+			s = cs
+			break
+		}
+	}
+	require_NotNil(t, s)
+	mset, err := s.globalAccount().lookupStream("TEST")
+	require_NoError(t, err)
+
+	sjs := s.getJetStream()
+	sjs.mu.RLock()
+	sa := sjs.streamAssignment(globalAccountName, "TEST")
+	ca := sjs.consumerAssignment(globalAccountName, "TEST", "CONSUMER")
+	sjs.mu.RUnlock()
+	require_NotNil(t, sa)
+	require_NotNil(t, ca)
+
+	// Healthy to start with.
+	require_NoError(t, sjs.isConsumerHealthy(mset, sa, "CONSUMER", ca))
+
+	// Record desired state to scale up to R3, as the meta leader would: the config
+	// holds the target while the group stays at its origin. The consumer is left
+	// untouched, it is only mapped onto the new peers later in the migration.
+	peers := []string{sa.Group.Peers[0]}
+	for _, cs := range c.servers {
+		if id := cs.Node(); id != sa.Group.Peers[0] {
+			peers = append(peers, id)
+		}
+	}
+	sjs.mu.Lock()
+	sa.Config.Replicas = 3
+	sa.Group.Desired = &desiredRaftGroup{
+		Created: time.Now().UTC(),
+		ID:      "DESIRED",
+		Peers:   peers,
+		Cluster: sa.Group.Cluster,
+		Origin: &desiredRaftGroupOrigin{
+			Peers:    copyStrings(sa.Group.Peers),
+			Cluster:  sa.Group.Cluster,
+			Replicas: 1,
+		},
+	}
+	sjs.mu.Unlock()
+	// The stream runs at its origin, but its replica count is the target already.
+	mset.cfgMu.Lock()
+	mset.cfg.Replicas = 3
+	mset.cfgMu.Unlock()
+
+	// The consumer is unmapped: still on the origin peer, with no desired state and
+	// no Raft node of its own, while inheriting the stream's target replica count.
+	sjs.mu.RLock()
+	require_Len(t, len(ca.Group.Peers), 1)
+	require_True(t, ca.Group.Desired == nil)
+	require_True(t, ca.Group.node == nil)
+	sjs.mu.RUnlock()
+	rc, err := mset.lookupConsumer("CONSUMER").replica()
+	require_NoError(t, err)
+	require_Equal(t, rc, 3)
+
+	// It must not be reported unhealthy for that.
+	require_NoError(t, sjs.isConsumerHealthy(mset, sa, "CONSUMER", ca))
+
+	// The stream can scale up while the consumer remap lags behind. The group is no
+	// longer R1, but the consumer still is and must remain healthy.
+	sjs.mu.Lock()
+	groupPeers := sa.Group.Peers
+	sa.Group.Peers = copyStrings(peers)
+	sjs.mu.Unlock()
+	sjs.mu.RLock()
+	require_Len(t, len(ca.Group.Peers), 1)
+	require_True(t, ca.Group.node == nil)
+	sjs.mu.RUnlock()
+	require_NoError(t, sjs.isConsumerHealthy(mset, sa, "CONSUMER", ca))
+	sjs.mu.Lock()
+	sa.Group.Peers = groupPeers
+	sjs.mu.Unlock()
+
+	// Without the recorded origin to fall back on, the inherited target count is all
+	// we have, and the missing node is reported. Confirms the check above is not
+	// passing for some other reason.
+	sjs.mu.Lock()
+	origin := sa.Group.Desired.Origin
+	sa.Group.Desired.Origin = nil
+	sjs.mu.Unlock()
+	require_Error(t, sjs.isConsumerHealthy(mset, sa, "CONSUMER", ca), errors.New("group node missing"))
+	sjs.mu.Lock()
+	sa.Group.Desired.Origin = origin
+	sjs.mu.Unlock()
+	require_NoError(t, sjs.isConsumerHealthy(mset, sa, "CONSUMER", ca))
+}
+
 func TestJetStreamClusterConsumerHealthCheckRecoversAfterSuccessfulUpdate(t *testing.T) {
 	c := createJetStreamClusterExplicit(t, "R3S", 3)
 	defer c.shutdown()
@@ -10376,7 +10490,7 @@ func TestJetStreamClusterConsumerHealthCheckRecoversAfterSuccessfulUpdate(t *tes
 	sjs.mu.Lock()
 	ca.err = wantErr
 	sjs.mu.Unlock()
-	err = sjs.isConsumerHealthy(mset, "CONSUMER", ca)
+	err = sjs.isConsumerHealthy(mset, nil, "CONSUMER", ca)
 	require_Error(t, err)
 	require_Contains(t, err.Error(), wantErr.Error())
 
@@ -10397,7 +10511,7 @@ func TestJetStreamClusterConsumerHealthCheckRecoversAfterSuccessfulUpdate(t *tes
 	sjs.mu.RUnlock()
 	require_True(t, cur != nil)
 	require_NoError(t, gotErr)
-	require_NoError(t, sjs.isConsumerHealthy(mset, "CONSUMER", cur))
+	require_NoError(t, sjs.isConsumerHealthy(mset, nil, "CONSUMER", cur))
 }
 
 func TestJetStreamClusterRespectConsumerStartSeq(t *testing.T) {
@@ -15055,7 +15169,7 @@ func TestJetStreamClusterMalformedConsumerEntrySetsWriteErr(t *testing.T) {
 
 	cjs := cl.getJetStream()
 	ca := o.consumerAssignment()
-	require_NoError(t, cjs.isConsumerHealthy(mset, "CONS", ca))
+	require_NoError(t, cjs.isConsumerHealthy(mset, nil, "CONS", ca))
 
 	// Craft a malformed consumer entry using an unknown op, this must surface as a consumer write error.
 	bad := []byte{255, 1, 2, 3}
@@ -15068,7 +15182,7 @@ func TestJetStreamClusterMalformedConsumerEntrySetsWriteErr(t *testing.T) {
 			return fmt.Errorf("consumer write error not set yet")
 		}
 		// Healthz must now reflect the broken state.
-		if err := cjs.isConsumerHealthy(mset, "CONS", ca); err == nil {
+		if err := cjs.isConsumerHealthy(mset, nil, "CONS", ca); err == nil {
 			return fmt.Errorf("consumer still reported healthy")
 		}
 		return nil

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -2127,11 +2127,11 @@ func TestJetStreamClusterReplacementPolicyAfterPeerRemoveNoPlace(t *testing.T) {
 	// eligible replacement, so go through the server scoped endpoint which is best effort.
 	snc, _ := jsClientConnect(t, s, nats.UserInfo("admin", "s3cr3t!"))
 	defer snc.Close()
-	ereq, err := json.Marshal(JSApiMetaServerRemoveRequest{Server: osi.Cluster.Replicas[0].Name})
+	ereq, err := json.Marshal(JSApiMetaServerEvacuateRequest{Server: osi.Cluster.Replicas[0].Name})
 	require_NoError(t, err)
 	emsg, err := snc.Request(JSApiEvacuateServer, ereq, time.Second*10)
 	require_NoError(t, err)
-	var eresp JSApiMetaServerRemoveResponse
+	var eresp JSApiMetaServerEvacuateResponse
 	require_NoError(t, json.Unmarshal(emsg.Data, &eresp))
 	require_True(t, eresp.Success)
 

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -14120,6 +14120,192 @@ func TestJetStreamClusterMetaRescueSingleSurvivor(t *testing.T) {
 	require_NoError(t, err)
 }
 
+// A two-node meta cluster that permanently loses one node needs the rescue API
+// to regain a meta leader, after which a peer-remove reconciles the assets down
+// onto the survivor. The stream must stay available throughout as a single peer,
+// and once the lost server returns both the meta group and the stream must take
+// it back on their own.
+func TestJetStreamClusterMetaRescueTwoNodeRecovery(t *testing.T) {
+	lqi := lostQuorumInterval
+	lostQuorumInterval = 2 * time.Second
+	defer func() { lostQuorumInterval = lqi }()
+	// So the returning server can rejoin the meta peer set without waiting
+	// out the full removal timeout.
+	prt := peerRemoveTimeout
+	peerRemoveTimeout = 2 * time.Second
+	defer func() { peerRemoveTimeout = prt }()
+
+	c := createJetStreamClusterExplicit(t, "R2S", 2)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{Name: "TEST", Subjects: []string{"foo"}, Replicas: 2})
+	require_NoError(t, err)
+	for range 5 {
+		_, err = js.Publish("foo", []byte("hello"))
+		require_NoError(t, err)
+	}
+	nc.Close()
+
+	// Lose one of the two nodes, which takes quorum with it. Keep the first
+	// server, it seeds the routes the restarted server rejoins through.
+	survivor, dead := c.servers[0], c.servers[1]
+	deadName := dead.Name()
+
+	// Remember the R2 group, it gets renamed once the stream converges onto the
+	// single surviving peer.
+	sjs := survivor.getJetStream()
+	sjs.mu.RLock()
+	origGroup := sjs.streamAssignment(globalAccountName, "TEST").Group.Name
+	sjs.mu.RUnlock()
+
+	dead.Shutdown()
+	dead.WaitForShutdown()
+
+	checkFor(t, 10*time.Second, 250*time.Millisecond, func() error {
+		if leader := survivor.getJetStream().getMetaGroup().GroupLeader(); leader != _EMPTY_ {
+			return fmt.Errorf("survivor still sees meta leader %q", leader)
+		}
+		return nil
+	})
+
+	// Make sure the stream becomes leaderless as well, so it'll need to perform
+	// the leaderless eviction after peer-remove.
+	mset, err := survivor.globalAccount().lookupStream("TEST")
+	require_NoError(t, err)
+	err = mset.raftNode().StepDown()
+	require_True(t, err == nil || err == errNotLeader)
+
+	nc, err = nats.Connect(survivor.ClientURL(), nats.UserInfo("admin", "s3cr3t!"))
+	require_NoError(t, err)
+	defer nc.Close()
+
+	// Rescue the meta group so the survivor can elect itself.
+	req, err := json.Marshal(&JSApiMetaRescueRequest{QuorumNeeded: 1})
+	require_NoError(t, err)
+	rmsg, err := nc.Request(JSApiMetaRescue, req, time.Second)
+	require_NoError(t, err)
+	var rescueResp JSApiMetaRescueResponse
+	require_NoError(t, json.Unmarshal(rmsg.Data, &rescueResp))
+	require_True(t, rescueResp.Error == nil)
+	require_Equal(t, rescueResp.PrevQuorum, 2)
+	require_Equal(t, rescueResp.NewQuorum, 1)
+	c.waitOnLeader()
+
+	// Peer-remove the lost server, which clears the rescue and reconciles the
+	// stream down onto the survivor.
+	removeReq, err := json.Marshal(&JSApiMetaServerRemoveRequest{Server: deadName})
+	require_NoError(t, err)
+	rmsg, err = nc.Request(JSApiRemoveServer, removeReq, time.Second)
+	require_NoError(t, err)
+	var removeResp JSApiMetaServerRemoveResponse
+	require_NoError(t, json.Unmarshal(rmsg.Data, &removeResp))
+	require_True(t, removeResp.Error == nil)
+	require_True(t, removeResp.Success)
+	nc.Close()
+
+	checkFor(t, 10*time.Second, 250*time.Millisecond, func() error {
+		meta := survivor.getJetStream().getMetaGroup()
+		if cs := meta.ClusterSize(); cs != 1 {
+			return fmt.Errorf("expected meta cluster size 1, got %d", cs)
+		}
+		if meta.InRescue() {
+			return fmt.Errorf("expected rescue to be stopped")
+		}
+		return nil
+	})
+
+	// The group is renamed once it converges onto the single peer, and the stream
+	// is restarted under the new group. That is where it used to be left without
+	// a leader, so wait for the rename to land before checking it is usable.
+	checkFor(t, 5*time.Second, 100*time.Millisecond, func() error {
+		js := survivor.getJetStream()
+		js.mu.RLock()
+		defer js.mu.RUnlock()
+		sa := js.streamAssignment(globalAccountName, "TEST")
+		if sa == nil {
+			return fmt.Errorf("no stream assignment")
+		}
+		if len(sa.Group.Peers) != 1 || sa.Group.Desired != nil {
+			return fmt.Errorf("stream has not converged onto a single peer yet, peers %+v", sa.Group.Peers)
+		}
+		if sa.Group.Name == origGroup {
+			return fmt.Errorf("stream group has not been renamed yet, still %q", origGroup)
+		}
+		return nil
+	})
+
+	// The stream must be usable again on the survivor alone. It stays configured
+	// as R2, it is only under-replicated until the lost server comes back.
+	nc, js = jsClientConnect(t, survivor)
+	defer nc.Close()
+	checkFor(t, 5*time.Second, 100*time.Millisecond, func() error {
+		si, err := js.StreamInfo("TEST")
+		if err != nil {
+			return err
+		}
+		if si.Cluster == nil || si.Cluster.Leader == _EMPTY_ {
+			return fmt.Errorf("no stream leader")
+		}
+		if len(si.Cluster.Replicas) != 0 {
+			return fmt.Errorf("expected no replicas, got %d", len(si.Cluster.Replicas))
+		}
+		if si.Config.Replicas != 2 {
+			return fmt.Errorf("expected the stream to stay configured as R2, got R%d", si.Config.Replicas)
+		}
+		if si.State.Msgs != 5 {
+			return fmt.Errorf("expected 5 messages, got %d", si.State.Msgs)
+		}
+		return nil
+	})
+	_, err = js.Publish("foo", []byte("after-recovery"))
+	require_NoError(t, err)
+
+	// Now the lost server comes back, under the same name and with its old state.
+	c.restartServer(dead)
+	c.checkClusterFormed()
+
+	// The meta group must take it back into the peer set.
+	c.waitOnPeerCount(2)
+	checkFor(t, 5*time.Second, 100*time.Millisecond, func() error {
+		meta := survivor.getJetStream().getMetaGroup()
+		if cs := meta.ClusterSize(); cs != 2 {
+			return fmt.Errorf("expected meta cluster size 2, got %d", cs)
+		}
+		if qn := meta.QuorumNeeded(); qn != 2 {
+			return fmt.Errorf("expected quorum 2, got %d", qn)
+		}
+		return nil
+	})
+
+	// And the stream must heal back up to its configured replica count.
+	checkFor(t, 5*time.Second, 100*time.Millisecond, func() error {
+		si, err := js.StreamInfo("TEST")
+		if err != nil {
+			return err
+		}
+		if si.Cluster == nil || si.Cluster.Leader == _EMPTY_ {
+			return fmt.Errorf("no stream leader")
+		}
+		if len(si.Cluster.Replicas) != 1 {
+			return fmt.Errorf("expected 1 replica, got %d", len(si.Cluster.Replicas))
+		}
+		if !si.Cluster.Replicas[0].Current {
+			return fmt.Errorf("replica %q is not current", si.Cluster.Replicas[0].Name)
+		}
+		state, err := checkStateAndErr(t, c, globalAccountName, "TEST")
+		if err != nil {
+			return err
+		}
+		if state.Msgs != 6 {
+			return fmt.Errorf("expected 6 messages, got %d", state.Msgs)
+		}
+		return nil
+	})
+}
+
 func TestJetStreamClusterMetaReplicasInJsz(t *testing.T) {
 	c := createJetStreamClusterExplicit(t, "R3S", 3)
 	defer c.shutdown()

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -14806,3 +14806,126 @@ func TestJetStreamClusterScaleDownCancelsCatchup(t *testing.T) {
 	waitReplicas(3)
 	require_NoError(t, checkState(t, c, globalAccountName, "TEST"))
 }
+
+func TestJetStreamClusterConsumerScaleDownDesiredAfterMetaLeaderChange(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R5S", 5)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Replicas: 3,
+	})
+	require_NoError(t, err)
+
+	_, err = js.AddConsumer("TEST", &nats.ConsumerConfig{
+		Durable:   "CONSUMER",
+		AckPolicy: nats.AckExplicitPolicy,
+		Replicas:  3,
+	})
+	require_NoError(t, err)
+
+	ml := c.leader()
+	require_NotNil(t, ml)
+	mjs := ml.getJetStream()
+
+	mjs.mu.RLock()
+	ca := mjs.consumerAssignment(globalAccountName, "TEST", "CONSUMER")
+	require_NotNil(t, ca)
+	peers := copyStrings(ca.Group.Peers)
+	mjs.mu.RUnlock()
+	require_Len(t, len(peers), 3)
+
+	// Stop two of the consumer's peers, but keep the meta leader running. The
+	// consumer group loses quorum, the meta group keeps it.
+	var down int
+	for _, s := range c.servers {
+		if s == ml || !slices.Contains(peers, s.Node()) {
+			continue
+		}
+		s.Shutdown()
+		s.WaitForShutdown()
+		if down++; down == 2 {
+			break
+		}
+	}
+	require_Len(t, down, 2)
+
+	// Only its leader can resolve a scale down, wait for it to lose it.
+	checkFor(t, 10*time.Second, 200*time.Millisecond, func() error {
+		if cl := c.consumerLeader(globalAccountName, "TEST", "CONSUMER"); cl != nil {
+			return fmt.Errorf("consumer still has leader %q", cl.Name())
+		}
+		return nil
+	})
+
+	// Scale the consumer down R3->R1. Nothing can select which peer remains,
+	// so the scale down stays pending and the request times out.
+	nc.Close()
+	nc, js = jsClientConnect(t, ml)
+	defer nc.Close()
+
+	_, err = js.UpdateConsumer("TEST", &nats.ConsumerConfig{
+		Durable:   "CONSUMER",
+		AckPolicy: nats.AckExplicitPolicy,
+		Replicas:  1,
+	}, nats.MaxWait(time.Second))
+	require_Error(t, err, context.DeadlineExceeded)
+
+	// Confirm the scale down is registered, and still pending.
+	checkFor(t, 5*time.Second, 200*time.Millisecond, func() error {
+		mjs.mu.RLock()
+		defer mjs.mu.RUnlock()
+		ca := mjs.consumerAssignment(globalAccountName, "TEST", "CONSUMER")
+		if ca == nil {
+			return errors.New("no consumer assignment")
+		}
+		if ca.Group.Desired == nil || !ca.Group.Desired.ScaleDown {
+			return fmt.Errorf("expected pending scale down, got: %+v", ca.Group.Desired)
+		}
+		if len(ca.Group.Peers) != 3 {
+			return fmt.Errorf("expected 3 peers, got: %v", ca.Group.Peers)
+		}
+		return nil
+	})
+
+	// Now change the meta leader, which reconciles all peer assignments on election.
+	meta := mjs.getMetaGroup()
+	require_NoError(t, meta.StepDown())
+	c.waitOnLeader()
+
+	nml := c.leader()
+	require_NotNil(t, nml)
+	njs := nml.getJetStream()
+
+	// Reconciling and applying meta entries happen on the same goroutine. So once a
+	// stream we only add now is applied, the new meta leader must have reconciled.
+	nc.Close()
+	nc, js = jsClientConnect(t, nml)
+	defer nc.Close()
+	_, err = js.AddStream(&nats.StreamConfig{Name: "MARKER", Replicas: 1})
+	require_NoError(t, err)
+	checkFor(t, 5*time.Second, 100*time.Millisecond, func() error {
+		njs.mu.RLock()
+		defer njs.mu.RUnlock()
+		if njs.streamAssignment(globalAccountName, "MARKER") == nil {
+			return errors.New("marker stream not applied yet")
+		}
+		return nil
+	})
+
+	// The peers must not be scaled down already, while desired state still says to.
+	njs.mu.RLock()
+	defer njs.mu.RUnlock()
+	ca = njs.consumerAssignment(globalAccountName, "TEST", "CONSUMER")
+	require_NotNil(t, ca)
+	require_NotNil(t, ca.Group.Desired)
+	require_True(t, ca.Group.Desired.ScaleDown)
+	if len(ca.Group.Peers) != len(ca.Group.Desired.Peers) {
+		t.Fatalf("Consumer assignment scaled down to peers=%v, while desired state is still a scale down from %v",
+			ca.Group.Peers, ca.Group.Desired.Peers)
+	}
+}

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -13226,6 +13226,60 @@ func TestJetStreamClusterDesiredStateCarriesRemoved(t *testing.T) {
 	require_False(t, slices.Contains(rg.Desired.Removed, c))
 }
 
+func TestJetStreamClusterDesiredStatePreservedOnRetarget(t *testing.T) {
+	const a, b, c, d = "A", "B", "C", "D"
+
+	created := time.Now().UTC().Add(-time.Hour)
+	origin := &desiredRaftGroupOrigin{Peers: []string{a, b, c}, Cluster: "C1", Replicas: 3}
+
+	rg := &raftGroup{
+		Name:  "G",
+		Peers: []string{a, b, c},
+		Desired: &desiredRaftGroup{
+			ID:      "ID",
+			Peers:   []string{a, c, d},
+			Created: created,
+			Term:    7,
+			Move:    true,
+			Origin:  origin,
+		},
+	}
+	ng := rg.withDesired(&raftGroup{Name: "G", Peers: []string{a, c, d}})
+
+	// Reconciliation has been ongoing since the first desired state, so the clock must not
+	// restart, or the elapsed time reported for the migration resets on every retarget.
+	require_True(t, ng.Desired.Created.Equal(created))
+	// The leader already driving keeps its term, so it can act on the new desired state
+	// without waiting for its term to be re-recorded. Dropping to zero would also lower the
+	// fence that keeps a stale leader from acting.
+	require_Equal(t, ng.Desired.Term, 7)
+	// A move that is retargeted is still a move in flight.
+	require_True(t, ng.Desired.Move)
+	// The origin is what a cancel rolls back to, and must survive as a copy rather than be
+	// shared with the group we replaced.
+	require_NotNil(t, ng.Desired.Origin)
+	require_Equal(t, ng.Desired.Origin.Cluster, "C1")
+	require_Equal(t, ng.Desired.Origin.Replicas, 3)
+	require_NotEqual(t, ng.Desired.Origin, rg.Desired.Origin)
+	// It is new desired state though, so it gets its own identity and the group leader knows
+	// to reassess against it.
+	require_NotEqual(t, ng.Desired.ID, _EMPTY_)
+	require_NotEqual(t, ng.Desired.ID, "ID")
+	// And none of this may have mutated the group we replaced.
+	require_True(t, rg.Desired.Created.Equal(created))
+	require_Equal(t, rg.Desired.Term, 7)
+	require_Equal(t, rg.Desired.ID, "ID")
+
+	// A group entering desired state for the first time starts its own clock, with nobody
+	// driving it yet and nothing to roll back to.
+	fresh := &raftGroup{Name: "G", Peers: []string{a, b, c}}
+	ng = fresh.withDesired(&raftGroup{Name: "G", Peers: []string{a, b, d}})
+	require_False(t, ng.Desired.Created.IsZero())
+	require_Equal(t, ng.Desired.Term, 0)
+	require_False(t, ng.Desired.Move)
+	require_True(t, ng.Desired.Origin == nil)
+}
+
 // A consumer already scaling down can hold a peer-removed peer only in its actual
 // peer set, with its desired peers untouched by the removal. Remapping must still
 // record that removal, or the group could never evict the peer and stay leaderless

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -14636,3 +14636,119 @@ func TestJetStreamClusterNoResetClusteredStateAfterStreamRemap(t *testing.T) {
 		mset.mu.Unlock()
 	})
 }
+
+// A scale down is an explicit request to shrink the group. Peers being removed do
+// not need the data, so a catchup to them must not hold up the scale down, even
+// when that catchup can't complete on its own.
+func TestJetStreamClusterScaleDownCancelsCatchup(t *testing.T) {
+	// Speed up catchup stall/retry cycles.
+	streamCatchupActivityInterval = 2 * time.Second
+	t.Cleanup(func() {
+		streamCatchupActivityInterval = defaultStreamCatchupActivityInterval
+	})
+
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Replicas: 1,
+	})
+	require_NoError(t, err)
+
+	toSend := 1_000
+	for range toSend {
+		_, err = js.Publish("foo", []byte("HELLO WORLD"))
+		require_NoError(t, err)
+	}
+
+	sl := c.streamLeader(globalAccountName, "TEST")
+	require_NotNil(t, sl)
+	mset, err := sl.globalAccount().lookupStream("TEST")
+	require_NoError(t, err)
+
+	scale := func(r int) {
+		t.Helper()
+		_, err := js.UpdateStream(&nats.StreamConfig{
+			Name:     "TEST",
+			Subjects: []string{"foo"},
+			Replicas: r,
+		})
+		require_NoError(t, err)
+	}
+	// Waits for the group to settle at R, with every replica store-current.
+	waitReplicas := func(r int) {
+		t.Helper()
+		checkFor(t, 5*time.Second, 100*time.Millisecond, func() error {
+			si, err := js.StreamInfo("TEST")
+			if err != nil {
+				return err
+			}
+			if si.Cluster == nil {
+				return fmt.Errorf("no cluster info")
+			}
+			if len(si.Cluster.Replicas) != r-1 {
+				return fmt.Errorf("expected %d replicas, got %d", r-1, len(si.Cluster.Replicas))
+			}
+			if si.Config.Replicas != r {
+				return fmt.Errorf("expected R%d config, got R%d", r, si.Config.Replicas)
+			}
+			for _, r := range si.Cluster.Replicas {
+				if !r.Current || r.Lag != 0 {
+					return fmt.Errorf("replica %s not store-current", r.Name)
+				}
+			}
+			return nil
+		})
+	}
+
+	// Exhaust the leader's outbound catchup budget, as if another large catchup
+	// holds all of it, so the new peers can't complete their store catchup.
+	hold := new(int64)
+	sl.gcbAdd(hold, int64(1)<<30)
+
+	// Scale up to R3. The new peers receive a raft snapshot and must pull the
+	// stream data through the (stalled) upper layer catchup.
+	scale(3)
+
+	// Wait for the group to grow with store catchups in flight.
+	checkFor(t, 5*time.Second, 100*time.Millisecond, func() error {
+		node := mset.raftNode()
+		if node == nil {
+			return fmt.Errorf("no raft node yet")
+		}
+		if peers := node.PeerNames(); len(peers) != 3 {
+			return fmt.Errorf("expected 3 peers, got %d", len(peers))
+		}
+		if !mset.hasCatchupPeers() {
+			return fmt.Errorf("no store catchups in flight yet")
+		}
+		return nil
+	})
+
+	// Now scale back down to R1 while those catchups can't make progress. This must
+	// complete without releasing the budget, canceling the catchups rather than
+	// waiting on them.
+	scale(1)
+	waitReplicas(1)
+
+	// The catchups must have been canceled.
+	checkFor(t, 5*time.Second, 100*time.Millisecond, func() error {
+		if mset.hasCatchupPeers() {
+			return fmt.Errorf("still tracking catchup peers")
+		}
+		return nil
+	})
+	require_NoError(t, checkState(t, c, globalAccountName, "TEST"))
+
+	// Release the budget and scale back up. The peers we just canceled must now be
+	// caught up as normal.
+	sl.gcbSubLast(hold)
+	scale(3)
+	waitReplicas(3)
+	require_NoError(t, checkState(t, c, globalAccountName, "TEST"))
+}

--- a/server/jetstream_super_cluster_test.go
+++ b/server/jetstream_super_cluster_test.go
@@ -6175,3 +6175,283 @@ func TestJetStreamSuperClusterConsumerAckSubjectWithStreamImportProtocolError(t 
 	require_Equal(t, msg.Subject, "TEST")
 	require_NoError(t, msg.AckSync())
 }
+
+// Canceling a move reverts to the peers we started on, which already hold the data,
+// so it must not wait on the catchup to the peers we're abandoning. Not even when
+// that catchup can't complete and one of the peers we're reverting to is down.
+func TestJetStreamClusterMoveCancelWithStalledCatchup(t *testing.T) {
+	// Speed up catchup stall/retry cycles.
+	streamCatchupActivityInterval = 2 * time.Second
+	t.Cleanup(func() {
+		streamCatchupActivityInterval = defaultStreamCatchupActivityInterval
+	})
+
+	sc := moveTestSuperCluster(t)
+	defer sc.shutdown()
+
+	c1 := sc.clusterForName("C1")
+	nc, js := jsClientConnect(t, c1.randomNonLeader())
+	defer nc.Close()
+
+	ncsys, err := nats.Connect(sc.randomServer().ClientURL(), nats.UserInfo("admin", "s3cr3t!"))
+	require_NoError(t, err)
+	defer ncsys.Close()
+
+	_, err = js.AddStream(&nats.StreamConfig{
+		Name:      "TEST",
+		Subjects:  []string{"foo"},
+		Placement: &nats.Placement{Tags: []string{"C1"}},
+		Replicas:  3,
+	})
+	require_NoError(t, err)
+
+	toSend := 1_000
+	for range toSend {
+		_, err = js.Publish("foo", []byte("HELLO WORLD"))
+		require_NoError(t, err)
+	}
+
+	si, err := js.StreamInfo("TEST")
+	require_NoError(t, err)
+	// Pick a peer we're reverting to that isn't the leader, we'll take it down.
+	victim := _EMPTY_
+	for _, r := range si.Cluster.Replicas {
+		if r.Name != si.Cluster.Leader && strings.HasPrefix(r.Name, "C1") {
+			victim = r.Name
+			break
+		}
+	}
+	require_NotEqual(t, victim, _EMPTY_)
+
+	sl := c1.streamLeader(globalAccountName, "TEST")
+	require_NotNil(t, sl)
+	mset, err := sl.globalAccount().lookupStream("TEST")
+	require_NoError(t, err)
+
+	// Exhaust the leader's outbound catchup budget, as if another large catchup holds
+	// all of it, so the peers we move to can never complete their store catchup. We
+	// never release it, canceling must not depend on it.
+	hold := new(int64)
+	sl.gcbAdd(hold, int64(1)<<30)
+	defer sl.gcbSubLast(hold)
+
+	// Compact the log, so the peers we move to must pull the data through the stalled
+	// upper layer catchup instead of replaying our Raft log.
+	node := mset.raftNode()
+	require_NotNil(t, node)
+	require_NoError(t, node.InstallSnapshot(mset.stateSnapshot(), true))
+
+	// Move to C2.
+	_, err = js.UpdateStream(&nats.StreamConfig{
+		Name:      "TEST",
+		Subjects:  []string{"foo"},
+		Placement: &nats.Placement{Tags: []string{"C2"}},
+		Replicas:  3,
+	})
+	require_NoError(t, err)
+
+	// Wait for the combined group, with store catchups in flight.
+	checkFor(t, 5*time.Second, 100*time.Millisecond, func() error {
+		if peers := node.PeerNames(); len(peers) != 6 {
+			return fmt.Errorf("expected 6 peers, got %d", len(peers))
+		}
+		if !mset.hasCatchupPeers() {
+			return fmt.Errorf("no store catchups in flight yet")
+		}
+		return nil
+	})
+
+	// Take down one of the peers we'd be reverting to. The remaining two still hold
+	// all the data, and are a quorum of the peer set we're canceling back to.
+	vs := c1.serverByName(victim)
+	require_NotNil(t, vs)
+	vs.Shutdown()
+	vs.WaitForShutdown()
+
+	// The cancel must converge back onto C1, it can only wait on the peers it's
+	// reverting to, and those are caught up already.
+	moveTestCancelMove(t, ncsys, globalAccountName, "TEST")
+	checkFor(t, 5*time.Second, 100*time.Millisecond, func() error {
+		si, err := js.StreamInfo("TEST")
+		if err != nil {
+			return err
+		}
+		if si.Cluster == nil {
+			return fmt.Errorf("no cluster info")
+		}
+		if si.Cluster.Name != "C1" {
+			return fmt.Errorf("expected to be back on C1, got %q", si.Cluster.Name)
+		}
+		// One of the three peers is down, so only one replica reports.
+		if len(si.Cluster.Replicas) != 2 {
+			return fmt.Errorf("expected 2 replicas, got %d", len(si.Cluster.Replicas))
+		}
+		if si.State.Msgs != uint64(toSend) {
+			return fmt.Errorf("expected %d msgs, got %d", toSend, si.State.Msgs)
+		}
+		return nil
+	})
+}
+
+func TestJetStreamClusterConsumerMoveWaitsForQuorumUntilPeerRemoved(t *testing.T) {
+	// Five servers per cluster, so a peer-remove has a live peer to remap onto.
+	sc := createJetStreamSuperClusterWithTemplateAndModHook(t, jsClusterTempl, 5, 2,
+		func(serverName, clusterName, storeDir, conf string) string {
+			return fmt.Sprintf("%s\nserver_tags: [%s]", conf, clusterName)
+		}, nil)
+	defer sc.shutdown()
+
+	c1 := sc.clusterForName("C1")
+	// A server that stays up for the whole test, we only take C2 servers down.
+	probe := c1.randomServer()
+	nc, js := jsClientConnect(t, c1.randomNonLeader())
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:      "TEST",
+		Subjects:  []string{"foo"},
+		Placement: &nats.Placement{Tags: []string{"C1"}},
+		Replicas:  3,
+	})
+	require_NoError(t, err)
+
+	_, err = js.AddConsumer("TEST", &nats.ConsumerConfig{
+		Durable:   "CONSUMER",
+		AckPolicy: nats.AckExplicitPolicy,
+		Replicas:  3,
+	})
+	require_NoError(t, err)
+
+	for range 10 {
+		_, err = js.Publish("foo", []byte("HELLO WORLD"))
+		require_NoError(t, err)
+	}
+
+	// Reports the migration status and peer set of the stream and the consumer.
+	groupState := func(s *Server) (streamPeers, consumerPeers []string, streamStatus, consumerStatus *DesiredClusterInfoStatus) {
+		t.Helper()
+		sjs := s.getJetStream()
+		if sjs == nil {
+			return nil, nil, nil, nil
+		}
+		sjs.mu.RLock()
+		defer sjs.mu.RUnlock()
+		if sa := sjs.streamAssignment(globalAccountName, "TEST"); sa != nil && sa.Group != nil {
+			streamPeers, streamStatus = copyStrings(sa.Group.Peers), sa.Group.migration
+		}
+		if ca := sjs.consumerAssignment(globalAccountName, "TEST", "CONSUMER"); ca != nil && ca.Group != nil {
+			consumerPeers, consumerStatus = copyStrings(ca.Group.Peers), ca.Group.migration
+		}
+		return streamPeers, consumerPeers, streamStatus, consumerStatus
+	}
+	onC1 := func(peers []string) int {
+		t.Helper()
+		var n int
+		for _, p := range peers {
+			if strings.HasPrefix(probe.serverNameForNode(p), "C1") {
+				n++
+			}
+		}
+		return n
+	}
+
+	// Move to C2.
+	_, err = js.UpdateStream(&nats.StreamConfig{
+		Name:      "TEST",
+		Subjects:  []string{"foo"},
+		Placement: &nats.Placement{Tags: []string{"C2"}},
+		Replicas:  3,
+	})
+	require_NoError(t, err)
+
+	// Wait for the stream to grow onto C2, so we know which peers it's moving to.
+	c2 := sc.clusterForName("C2")
+	var target []string
+	checkFor(t, 10*time.Second, 100*time.Millisecond, func() error {
+		peers, _, _, _ := groupState(probe)
+		if len(peers) != 6 {
+			return fmt.Errorf("expected 6 stream peers, got %d", len(peers))
+		}
+		target = nil
+		for _, p := range peers {
+			if strings.HasPrefix(probe.serverNameForNode(p), "C2") {
+				target = append(target, p)
+			}
+		}
+		if len(target) != 3 {
+			return fmt.Errorf("expected 3 target peers, got %d", len(target))
+		}
+		return nil
+	})
+
+	// Take down two of the three peers we're moving to. The group can't shrink onto
+	// what's left without losing the ability to commit, so it must wait.
+	var down []string
+	for _, p := range target[:2] {
+		name := probe.serverNameForNode(p)
+		s := c2.serverByName(name)
+		require_NotNil(t, s)
+		s.Shutdown()
+		s.WaitForShutdown()
+		down = append(down, name)
+	}
+
+	// The consumer must refuse the removal outright. Proposing it instead would
+	// leave a membership change in flight that can never commit, since the group
+	// it'd be left with can't reach quorum.
+	checkFor(t, 5*time.Second, 100*time.Millisecond, func() error {
+		var cs *DesiredClusterInfoStatus
+		for _, c := range []*cluster{c1, c2} {
+			if cl := c.consumerLeader(globalAccountName, "TEST", "CONSUMER"); cl != nil {
+				_, _, _, cs = groupState(cl)
+			}
+		}
+		if cs == nil || cs.Type != MigrationStatusQuorum {
+			return fmt.Errorf("consumer not refusing the removal, status %+v", cs)
+		}
+		return nil
+	})
+
+	// And it must hold there, neither the consumer nor the stream behind it may
+	// shed the origin peers they still need.
+	for range 12 {
+		sp, cp, ss, _ := groupState(probe)
+		if n := onC1(cp); n < 2 {
+			t.Fatalf("consumer shed origin peers it needed for quorum, %d left", n)
+		}
+		if n := onC1(sp); n < 2 {
+			t.Fatalf("stream shed origin peers it needed for quorum, %d left, status %+v", n, ss)
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+
+	// The operator peer-removes the peers that aren't coming back, which remaps the
+	// stream and its consumers onto peers that are up.
+	for _, name := range down {
+		req, err := json.Marshal(&JSApiStreamRemovePeerRequest{Peer: name})
+		require_NoError(t, err)
+		resp, err := nc.Request(fmt.Sprintf(JSApiStreamRemovePeerT, "TEST"), req, 5*time.Second)
+		require_NoError(t, err)
+		var rpResp JSApiStreamRemovePeerResponse
+		require_NoError(t, json.Unmarshal(resp.Data, &rpResp))
+		if rpResp.Error != nil {
+			t.Fatalf("peer remove of %s failed: %+v", name, rpResp.Error)
+		}
+	}
+
+	// Both must now converge onto C2 and off the origin cluster.
+	checkFor(t, 10*time.Second, 100*time.Millisecond, func() error {
+		sp, cp, ss, cs := groupState(probe)
+		if len(sp) != 3 || onC1(sp) != 0 {
+			return fmt.Errorf("stream not converged: %d peers, %d on C1, status %+v", len(sp), onC1(sp), ss)
+		}
+		if len(cp) != 3 || onC1(cp) != 0 {
+			return fmt.Errorf("consumer not converged: %d peers, %d on C1, status %+v", len(cp), onC1(cp), cs)
+		}
+		return nil
+	})
+
+	si, err := js.StreamInfo("TEST")
+	require_NoError(t, err)
+	require_Equal(t, si.State.Msgs, uint64(10))
+}

--- a/server/jetstream_super_cluster_test.go
+++ b/server/jetstream_super_cluster_test.go
@@ -4395,10 +4395,11 @@ func TestJetStreamSuperClusterLegacyMoveCancel(t *testing.T) {
 	})
 }
 
-// A legacy move is inflight just like one expressed as desired state, so a move or scale
-// on top of it must be rejected. Retargeting instead would record the over-replicated peer
-// set as the origin to roll back to, growing the assignment the guard is meant to bound.
-func TestJetStreamSuperClusterLegacyMoveRejectsMoveAndScale(t *testing.T) {
+// A legacy move is inflight just like one expressed as desired state, so any other
+// reconfiguration on top of it must be rejected. Retargeting instead would record the
+// over-replicated peer set as the origin to roll back to, growing the assignment the
+// guard is meant to bound.
+func TestJetStreamSuperClusterLegacyMoveRejectsReconfigure(t *testing.T) {
 	sc := moveTestSuperCluster(t)
 	defer sc.shutdown()
 
@@ -4444,7 +4445,7 @@ func TestJetStreamSuperClusterLegacyMoveRejectsMoveAndScale(t *testing.T) {
 	mjs.mu.RUnlock()
 	require_False(t, hasDesired)
 
-	// Both a scale and a placement induced move must be rejected while it is in progress.
+	// A scale, placement induced move and retention change must be rejected while it is in progress.
 	scaled := *cfg
 	scaled.Replicas = 3
 	_, err = js.UpdateStream(&scaled)
@@ -4455,47 +4456,29 @@ func TestJetStreamSuperClusterLegacyMoveRejectsMoveAndScale(t *testing.T) {
 	_, err = js.UpdateStream(&moved)
 	require_Error(t, err, NewJSStreamMoveInProgressError())
 
-	// The peer set must be untouched by the rejected requests.
+	retention := *cfg
+	retention.Retention = nats.InterestPolicy
+	_, err = js.UpdateStream(&retention)
+	require_Error(t, err, NewJSStreamMoveInProgressError())
+
+	// The peer set must be untouched by the rejected requests, and none of them may
+	// have registered desired state or changed the config.
 	legacyPeers := append(copyStrings(originPeers), destPeers...)
 	peers, _, replicas := moveTestStreamGroup(t, sc.leader(), globalAccountName, "TEST")
 	require_Equal(t, replicas, 1)
 	require_True(t, moveTestSamePeers(peers, legacyPeers))
 
-	// A retention change does not retarget the peer set, so it is allowed and registers desired
-	// state. The origin it captures must be the peer set the legacy move started from, not the
-	// over-replicated set it is moving through, or a rollback would restore the enlarged set.
-	// The stream can't respond while its only peer is down, only the assignment matters here.
-	retention := *cfg
-	retention.Retention = nats.InterestPolicy
-	_, _ = js.UpdateStream(&retention, nats.MaxWait(time.Second))
-
-	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
-		mjs := sc.leader().getJetStream()
-		mjs.mu.RLock()
-		defer mjs.mu.RUnlock()
-		sa := mjs.streamAssignment(globalAccountName, "TEST")
-		if sa == nil || sa.Group == nil {
-			return errors.New("no stream assignment")
-		}
-		if sa.Config == nil || sa.Config.Retention != InterestPolicy {
-			return fmt.Errorf("retention change not applied yet: %+v", sa.Config)
-		}
-		d := sa.Group.Desired
-		if d == nil || d.Origin == nil {
-			return fmt.Errorf("no desired origin yet: %+v", d)
-		}
-		if !moveTestSamePeers(d.Origin.Peers, originPeers) {
-			return fmt.Errorf("expected origin peers %+v, got %+v", originPeers, d.Origin.Peers)
-		}
-		if d.Origin.Cluster != "C1" {
-			return fmt.Errorf("expected origin cluster %q, got %q", "C1", d.Origin.Cluster)
-		}
-		// The move itself is still in progress, so the assignment keeps both peer sets.
-		if !moveTestSamePeers(sa.Group.Peers, legacyPeers) {
-			return fmt.Errorf("expected peers %+v, got %+v", legacyPeers, sa.Group.Peers)
-		}
-		return nil
-	})
+	mjs = sc.leader().getJetStream()
+	mjs.mu.RLock()
+	sa = mjs.streamAssignment(globalAccountName, "TEST")
+	require_NotNil(t, sa)
+	require_NotNil(t, sa.Group)
+	require_NotNil(t, sa.Config)
+	hasDesired = sa.Group.Desired != nil
+	retentionPolicy := sa.Config.Retention
+	mjs.mu.RUnlock()
+	require_False(t, hasDesired)
+	require_Equal(t, retentionPolicy, LimitsPolicy)
 }
 
 // A legacy move that is stalled must remain cancellable. Only the stream's group leader

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -4128,7 +4128,7 @@ func (s *Server) healthz(opts *HealthzOptions) *HealthStatus {
 			mset, _ := acc.lookupStream(stream)
 			// Now check consumers.
 			for consumer, ca := range sa.consumers {
-				if err := js.isConsumerHealthy(mset, consumer, ca); err != nil {
+				if err := js.isConsumerHealthy(mset, sa, consumer, ca); err != nil {
 					if !details {
 						health.Status = na
 						health.Error = fmt.Sprintf("JetStream consumer '%s > %s > %s' is not current: %s", acc, stream, consumer, err)

--- a/server/raft.go
+++ b/server/raft.go
@@ -4112,7 +4112,7 @@ func (n *raft) trackPeer(peer string) error {
 				n.observed = nil
 			}
 		}
-	} else if n.managed && !isRemoved {
+	} else if n.managed {
 		// For managed groups the meta layer can assign peers before they've been
 		// added to our peer set. Track when we hear from them, so the upper layer
 		// can prefer adding peers that are demonstrably up.

--- a/server/raft.go
+++ b/server/raft.go
@@ -3631,13 +3631,7 @@ func (n *raft) runCatchup(ar *appendEntryResponse, indexUpdatesQ *ipQueue[uint64
 				n.progress = nil
 			}
 		}
-		// Check if this is a new peer and if so go ahead and propose adding them.
-		_, exists := n.peers[peer]
 		n.Unlock()
-		if !exists {
-			n.debug("Catchup done for %q, will add into peers", peer)
-			n.ProposeAddPeer(peer)
-		}
 		indexUpdatesQ.unregister()
 	}()
 

--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -7901,11 +7901,26 @@ func TestNRGCatchupRerequestDoesNotOrphanProgressQueue(t *testing.T) {
 
 	// Follower requests a catchup, which starts a catchup run that blocks
 	// waiting for index updates after sending up to 2MB of entries.
+	nc, err := nats.Connect(n.s.ClientURL(), nats.UserInfo("admin", "s3cr3t!"))
+	require_NoError(t, err)
+	defer nc.Close()
+	sub, err := nc.SubscribeSync("$NRG.CR.TEST.1")
+	require_NoError(t, err)
+	defer sub.Drain()
+	require_NoError(t, nc.Flush())
+
 	n.catchupFollower(&appendEntryResponse{term: 1, index: 0, peer: nats1, reply: "$NRG.CR.TEST.1"})
 	n.RLock()
 	q1 := n.progress[nats1]
 	n.RUnlock()
 	require_True(t, q1 != nil)
+
+	// Grab the progress inbox of the first run, its subscription going away is
+	// how we know the run's deferred cleanup has completed.
+	pmsg, err := sub.NextMsg(time.Second)
+	require_NoError(t, err)
+	progressInbox := pmsg.Reply
+	require_True(t, strings.HasPrefix(progressInbox, "$NRG.CP."))
 
 	// Wait for the first run to consume the initial index update, so we know
 	// it has started and captured its view of the last index (4) before we
@@ -7932,11 +7947,9 @@ func TestNRGCatchupRerequestDoesNotOrphanProgressQueue(t *testing.T) {
 	require_True(t, q2 != nil)
 	require_True(t, q1 != q2)
 
-	// Wait for the first run's deferred cleanup. On exit it proposes adding
-	// the (unknown) peer, which is observable on the proposal queue since the
-	// run loop isn't started in this test.
-	checkFor(t, 2*time.Second, 10*time.Millisecond, func() error {
-		if n.prop.len() == 0 {
+	// Wait for the first run's deferred cleanup, which unsubscribes its progress inbox.
+	checkFor(t, 5*time.Second, 10*time.Millisecond, func() error {
+		if r := n.s.SystemAccount().sl.Match(progressInbox); len(r.psubs) > 0 {
 			return errors.New("first catchup run still active")
 		}
 		return nil
@@ -7949,6 +7962,71 @@ func TestNRGCatchupRerequestDoesNotOrphanProgressQueue(t *testing.T) {
 	q := n.progress[nats1]
 	n.RUnlock()
 	require_True(t, q == q2)
+}
+
+func TestNRGCatchupDoesNotAddPeerOnCompletion(t *testing.T) {
+	nats0 := "S1Nunr6R" // "nats-0"
+	nats1 := "yrzKKRBu" // "nats-1"
+
+	for _, test := range []struct {
+		title   string
+		prepare func(n *raft)
+	}{
+		{
+			title: "Managed",
+			// The meta layer owns membership, the group must never add peers itself.
+			prepare: func(n *raft) { n.managed = true },
+		},
+		{
+			title: "Removed",
+			// The peer was just removed, catching it up must not bring it back.
+			prepare: func(n *raft) { n.removed = map[string]time.Time{nats1: time.Now()} },
+		},
+		{
+			title: "Unmanaged",
+			// Even here the catchup itself doesn't add, hearing from the peer does.
+			prepare: func(n *raft) {},
+		},
+	} {
+		t.Run(test.title, func(t *testing.T) {
+			n, cleanup := initSingleMemRaftNode(t)
+			defer cleanup()
+
+			// Create a sample entry, the content doesn't matter, just that it's stored.
+			esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true)
+			entries := []*Entry{newEntry(EntryNormal, esm)}
+			aeMsg := encode(t, &appendEntry{leader: nats0, term: 1, commit: 0, pterm: 0, pindex: 0, entries: entries})
+			require_NoError(t, n.storeToWAL(aeMsg))
+
+			n.Lock()
+			test.prepare(n)
+			n.term = 1
+			n.Unlock()
+			n.switchToLeader()
+
+			// The run loop isn't started in this test, so proposals stay observable.
+			n.prop.drain()
+
+			// Catch up a peer that is not a member of the group. The catchup has the
+			// whole WAL available, so it runs to completion on its own.
+			n.catchupFollower(&appendEntryResponse{term: 1, index: 0, peer: nats1, reply: "$NRG.CR.TEST.1"})
+			checkFor(t, 5*time.Second, 10*time.Millisecond, func() error {
+				n.RLock()
+				defer n.RUnlock()
+				if n.progress[nats1] != nil {
+					return errors.New("catchup still running")
+				}
+				return nil
+			})
+
+			// Finishing the catchup must not have proposed the peer into the group.
+			require_Equal(t, n.prop.len(), 0)
+			n.RLock()
+			_, isPeer := n.peers[nats1]
+			n.RUnlock()
+			require_False(t, isPeer)
+		})
+	}
 }
 
 func TestNRGCatchupFollowerNoWaitGroupLeakWhenGoRoutineFails(t *testing.T) {

--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -3945,10 +3945,11 @@ func TestNRGTrackPeerObserved(t *testing.T) {
 	require_Len(t, len(n.observed), 0)
 	require_False(t, n.LastHeardFromPeer("B").IsZero())
 
-	// Removed peers are not observed.
+	// Removed peers are still observed, as otherwise a peer that's removed
+	// and re-added shortly after will stall until the timer expires.
 	n.removed = map[string]time.Time{"C": time.Now()}
 	require_NoError(t, n.trackPeer("C"))
-	require_True(t, n.LastHeardFromPeer("C").IsZero())
+	require_False(t, n.LastHeardFromPeer("C").IsZero())
 }
 
 func TestNRGTrackPeerAutoAddOnlyUnmanaged(t *testing.T) {

--- a/server/stream.go
+++ b/server/stream.go
@@ -382,6 +382,7 @@ type ClusterInfo struct {
 // DesiredClusterInfo shows information of the desired set of servers
 // that should make up the stream or consumer.
 type DesiredClusterInfo struct {
+	Created  time.Time                 `json:"created"`
 	Name     string                    `json:"name,omitempty"`
 	Replicas []*PeerInfo               `json:"replicas,omitempty"`
 	Origin   *DesiredClusterInfoOrigin `json:"origin,omitempty"`

--- a/server/stream.go
+++ b/server/stream.go
@@ -1266,6 +1266,7 @@ func (mset *stream) streamAssignment() *streamAssignment {
 
 func (mset *stream) setStreamAssignment(sa *streamAssignment) {
 	var node RaftNode
+	var peers []string
 
 	mset.mu.RLock()
 	js := mset.js
@@ -1275,6 +1276,7 @@ func (mset *stream) setStreamAssignment(sa *streamAssignment) {
 		js.mu.RLock()
 		if sa.Group != nil {
 			node = sa.Group.node
+			peers = copyStrings(sa.Group.Peers)
 		}
 		js.mu.RUnlock()
 	}
@@ -1289,6 +1291,18 @@ func (mset *stream) setStreamAssignment(sa *streamAssignment) {
 
 	// Set our node.
 	mset.node = node
+
+	// Stop tracking peers for catchup if they're no longer part of the group.
+	if len(mset.catchups) > 0 {
+		for peer := range mset.catchups {
+			if !slices.Contains(peers, peer) {
+				delete(mset.catchups, peer)
+			}
+		}
+		if len(mset.catchups) == 0 {
+			mset.catchups = nil
+		}
+	}
 
 	// Setup our info sub here as well for all stream members. This is now by design.
 	if mset.infoSub == nil {


### PR DESCRIPTION
This PR resolves some remaining loose ends with the desired state approach:
- Fix an issue where a stream's Raft node would only be cleared if the replica count was decreased to 1. However, it's possible for an under-replicated group to get to only 1 peer, even though it's configured to host more replicas. Additionally, the Raft node would not be closed/removed after a remap.
- Scaling or moving a stream and then scaling down or canceling the move while catchups are ongoing would prevent this scale down/cancel to begin until the catchup was completed. This could result in being stuck in this state indefinitely, if the reason for scaling down/canceling was due to the catchups not completing. We now only weigh "caught up" for peers that remain and are not being removed.
- Add a `Created` timestamp to the desired state to know how long it has been ongoing, and fix a bug where `withDesired` would not properly preserve the leader's `Term`.
- The server/stream evacuate request and response models reused the peer-remove models. The evacuate request/response now has its own models, to allow later extension not tied to the peer-remove models (although they currently are still equal).
- Fix a bug where a peer that was caught up on the Raft layer would automatically be added as a peer, which would wrongly bypass the meta layer managed reconciliation. Now all automatic peer additions are only done as part of `trackPeer`, improving consistency.
- Combining a scale with a move or while another is ongoing is not allowed. But retention changes were still allowed to bypass this if the stream was moving. This has now been made consistent: scaling and retention changes never combine with a move.
- Scaling up a R1 stream could result in "node missing" healthz errors on consumers, since they are only remapped later. They are now aware of the stream being scaled up and don't return an error.
- If the meta leader changed while a consumer had not yet chosen which peers to scale down to, it would reconcile the consumer to a single replica outside of desired state, making it be stuck.
- Add consumer peer-remove and evacuate endpoints, allowing to move consumers and resolve any out of quorum issues through peer-remove.