### PR TITLE
[IMPROVED] Aggregate SyncDeleted batch callbacks into one

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -5867,7 +5867,7 @@ func (fs *fileStore) enforceMsgLimit() error {
 			msgs := fmb.msgs
 			fmb.mu.RUnlock()
 			if nmsgs-msgs > uint64(fs.cfg.MaxMsgs) {
-				if err := fs.purgeMsgBlock(fmb); err != nil {
+				if err := fs.purgeMsgBlock(fmb, nil); err != nil {
 					return err
 				}
 				continue
@@ -5899,7 +5899,7 @@ func (fs *fileStore) enforceBytesLimit() error {
 			bytes := fmb.bytes
 			fmb.mu.RUnlock()
 			if bs-bytes > uint64(fs.cfg.MaxBytes) {
-				if err := fs.purgeMsgBlock(fmb); err != nil {
+				if err := fs.purgeMsgBlock(fmb, nil); err != nil {
 					return err
 				}
 				continue
@@ -6379,8 +6379,9 @@ func (fs *fileStore) removeMsgFromBlock(mb *msgBlock, seq uint64, secure, viaLim
 }
 
 // Remove all messages in the range [first, last]
+// If agg is set the storage updates for fully removed blocks are aggregated.
 // Lock should be held.
-func (fs *fileStore) removeMsgsInRange(first, last uint64, viaLimits bool) error {
+func (fs *fileStore) removeMsgsInRange(first, last uint64, viaLimits bool, agg *storeUpdateAgg) error {
 	last = min(last, fs.state.LastSeq)
 	if first > last {
 		return nil
@@ -6407,7 +6408,7 @@ func (fs *fileStore) removeMsgsInRange(first, last uint64, viaLimits bool) error
 			// purgeMgsBlock, which also removes the block from fs.blks.
 			// After purgeMsgBlock, i will be the index of the following
 			// msgBlock, if any. Therefore, continue without incrementing i.
-			if err := fs.purgeMsgBlock(mb); err != nil {
+			if err := fs.purgeMsgBlock(mb, agg); err != nil {
 				return err
 			}
 		} else {
@@ -11522,8 +11523,9 @@ func (fs *fileStore) forceRemoveMsgBlock(mb *msgBlock) error {
 }
 
 // Purges and removes the msgBlock from the store.
+// If agg is set the storage updates for fully removed blocks are aggregated.
 // Lock should be held.
-func (fs *fileStore) purgeMsgBlock(mb *msgBlock) error {
+func (fs *fileStore) purgeMsgBlock(mb *msgBlock, agg *storeUpdateAgg) error {
 	mb.mu.Lock()
 	// Adjust per-subject tracking if present.
 	if err := mb.ensurePerSubjectInfoLoaded(); err != nil {
@@ -11583,7 +11585,10 @@ func (fs *fileStore) purgeMsgBlock(mb *msgBlock) error {
 		return err
 	}
 
-	if cb := fs.scb; cb != nil {
+	if agg != nil {
+		// Aggregating, so no callback and no need to release fs.mu.
+		agg.md, agg.bd = agg.md-int64(msgs), agg.bd-int64(bytes)
+	} else if cb := fs.scb; cb != nil {
 		// If we have a callback registered, we need to release lock regardless since consumers will recalculate pending.
 		fs.mu.Unlock()
 		// Storage updates.
@@ -13153,6 +13158,13 @@ func deleteMap(blks []*msgBlock) *interiorDeletes {
 	return &v
 }
 
+// storeUpdateAgg aggregates storage update deltas, so removing multiple blocks
+// fires one storage callback instead of one per block.
+// fs lock should be held for all access.
+type storeUpdateAgg struct {
+	md, bd int64
+}
+
 // SyncDeleted will make sure this stream has same deleted state as dbs.
 // This will only process deleted state within our current state.
 func (fs *fileStore) SyncDeleted(dbs DeleteBlocks) error {
@@ -13171,6 +13183,21 @@ func (fs *fileStore) SyncDeleted(dbs DeleteBlocks) error {
 	if err := fs.werr; err != nil {
 		return err
 	}
+
+	// Removing a block has all consumers recalculate their pending state, so
+	// aggregate those into one callback at the end. Single message removals
+	// keep NumPending up to date incrementally, which is cheaper.
+	agg := &storeUpdateAgg{}
+	defer func() {
+		if agg.md == 0 && agg.bd == 0 {
+			return
+		}
+		if cb := fs.scb; cb != nil {
+			fs.mu.Unlock()
+			cb(agg.md, agg.bd, 0, _EMPTY_)
+			fs.mu.Lock()
+		}
+	}()
 
 	lseq := fs.state.LastSeq
 	fs.readLockAllMsgBlocks()
@@ -13197,7 +13224,7 @@ func (fs *fileStore) SyncDeleted(dbs DeleteBlocks) error {
 
 		var err error
 		if _, ok := db.(*DeleteRange); ok {
-			err = fs.removeMsgsInRange(first, last, true)
+			err = fs.removeMsgsInRange(first, last, true, agg)
 		} else {
 			db.Range(func(dseq uint64) bool {
 				_, err = fs.removeMsg(dseq, false, true, false)

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -9109,7 +9109,7 @@ func benchmarkFileStoreSyncDeletedPartialBlocks(b *testing.B, msgSize int) {
 	for b.Loop() {
 		b.StopTimer()
 		if len(fs.blks) > 1 {
-			fs.removeMsgsInRange(fs.state.FirstSeq, fs.blks[1].last.seq, true)
+			fs.removeMsgsInRange(fs.state.FirstSeq, fs.blks[1].last.seq, true, nil)
 		}
 		for len(fs.blks) <= numBlocks {
 			fs.StoreMsg(subj, nil, msg, 0)
@@ -12455,7 +12455,7 @@ func TestFileStorePurgeMsgBlock(t *testing.T) {
 		// Purging the block should both remove the block and do the accounting.
 		fmb := fs.getFirstBlock()
 		fs.mu.Lock()
-		fs.purgeMsgBlock(fmb)
+		fs.purgeMsgBlock(fmb, nil)
 		blks = len(fs.blks)
 		fs.mu.Unlock()
 
@@ -12486,7 +12486,7 @@ func TestFileStorePurgeMsgBlockUpdatesSubjects(t *testing.T) {
 
 		fmb := fs.getFirstBlock()
 		fs.mu.Lock()
-		fs.purgeMsgBlock(fmb)
+		fs.purgeMsgBlock(fmb, nil)
 		fs.mu.Unlock()
 
 		state := fs.State()
@@ -12535,7 +12535,7 @@ func TestFileStorePurgeMsgBlockRemovesSchedules(t *testing.T) {
 
 		fmb := fs.getFirstBlock()
 		fs.mu.Lock()
-		fs.purgeMsgBlock(fmb)
+		fs.purgeMsgBlock(fmb, nil)
 		fs.mu.Unlock()
 
 		state := fs.State()
@@ -14346,31 +14346,31 @@ func TestFileStoreRemoveMsgsInRange(t *testing.T) {
 	require_Equal(t, len(fs.blks), 20)
 
 	// Remove range [1,1]
-	fs.removeMsgsInRange(1, 1, true)
+	fs.removeMsgsInRange(1, 1, true, nil)
 	require_Equal(t, len(fs.blks), 19)
 	require_Equal(t, atomic.LoadUint64(&fs.blks[0].first.seq), 2)
 
 	// Removing range [1,1] again is a noop
 	// We are left with blocks [2,20]
-	fs.removeMsgsInRange(1, 1, true)
+	fs.removeMsgsInRange(1, 1, true, nil)
 	require_Equal(t, len(fs.blks), 19)
 	require_Equal(t, atomic.LoadUint64(&fs.blks[0].first.seq), 2)
 
 	// Remove the range [1,2] should remove block with sequence 2
 	// We are left with blocks [3,20]
-	fs.removeMsgsInRange(1, 2, true)
+	fs.removeMsgsInRange(1, 2, true, nil)
 	require_Equal(t, len(fs.blks), 18)
 	require_Equal(t, atomic.LoadUint64(&fs.blks[0].first.seq), 3)
 
 	// Remove the first two blocks [3,4]
 	// We are left with blocks [5,20]
-	fs.removeMsgsInRange(3, 4, true)
+	fs.removeMsgsInRange(3, 4, true, nil)
 	require_Equal(t, len(fs.blks), 16)
 	require_Equal(t, atomic.LoadUint64(&fs.blks[0].first.seq), 5)
 
 	// Remove range [9, 13]
 	// We are left with [5,8] [14,20]
-	fs.removeMsgsInRange(9, 13, true)
+	fs.removeMsgsInRange(9, 13, true, nil)
 	require_Equal(t, len(fs.blks), 11)
 	checkDeleteBlocks(DeleteBlocks{
 		&DeleteRange{First: 9, Num: 5},
@@ -14378,7 +14378,7 @@ func TestFileStoreRemoveMsgsInRange(t *testing.T) {
 
 	// Make the gap larger by removing range [8 8]
 	// We are left with [5,7] [14, 20]
-	fs.removeMsgsInRange(8, 8, true)
+	fs.removeMsgsInRange(8, 8, true, nil)
 	require_Equal(t, len(fs.blks), 10)
 	checkDeleteBlocks(DeleteBlocks{
 		&DeleteRange{First: 8, Num: 6},
@@ -14386,7 +14386,7 @@ func TestFileStoreRemoveMsgsInRange(t *testing.T) {
 
 	// Make another gap by removing range [17, 17]
 	// We are left with [5,7] [14,16] [18,20]
-	fs.removeMsgsInRange(17, 17, true)
+	fs.removeMsgsInRange(17, 17, true, nil)
 	require_Equal(t, len(fs.blks), 9)
 	checkDeleteBlocks(DeleteBlocks{
 		&DeleteRange{First: 8, Num: 6},
@@ -14395,7 +14395,7 @@ func TestFileStoreRemoveMsgsInRange(t *testing.T) {
 
 	// Remove the last block
 	// We are left with [5,7] [14,16] [18,19] (empty block 21-20)
-	fs.removeMsgsInRange(20, 20, true)
+	fs.removeMsgsInRange(20, 20, true, nil)
 	checkDeleteBlocks(DeleteBlocks{
 		&DeleteRange{First: 8, Num: 6},
 		&DeleteRange{First: 17, Num: 1},
@@ -14404,7 +14404,7 @@ func TestFileStoreRemoveMsgsInRange(t *testing.T) {
 
 	// Make a big gap removing range [7, 18]
 	// We are left with [5,6] [19]
-	fs.removeMsgsInRange(7, 18, true)
+	fs.removeMsgsInRange(7, 18, true, nil)
 	require_Equal(t, len(fs.blks), 4)
 	checkDeleteBlocks(DeleteBlocks{
 		&DeleteRange{First: 7, Num: 12},
@@ -14413,7 +14413,7 @@ func TestFileStoreRemoveMsgsInRange(t *testing.T) {
 
 	// Remove everything
 	// We are left with an empty block
-	fs.removeMsgsInRange(1, 20, true)
+	fs.removeMsgsInRange(1, 20, true, nil)
 	require_Equal(t, len(fs.blks), 1)
 	require_Equal(t, fs.blks[0].msgs, 0)
 }
@@ -14450,7 +14450,7 @@ func TestFileStoreRemoveMsgsInRangePartialBlocks(t *testing.T) {
 	// block 1 [ 9,10]
 	// block 2 [11,15]
 	// block 3 [16,20]
-	fs.removeMsgsInRange(5, 6, true)
+	fs.removeMsgsInRange(5, 6, true, nil)
 	fs.blks[0].compact()
 
 	require_Equal(t, len(fs.blks), 4)
@@ -14464,7 +14464,7 @@ func TestFileStoreRemoveMsgsInRangePartialBlocks(t *testing.T) {
 	// block 1 [12,15]
 	// block 2 [16,20]
 	// empty block 21 20
-	fs.removeMsgsInRange(4, 11, true)
+	fs.removeMsgsInRange(4, 11, true, nil)
 	fs.blks[0].compact()
 
 	require_Equal(t, len(fs.blks), 3)
@@ -14477,7 +14477,7 @@ func TestFileStoreRemoveMsgsInRangePartialBlocks(t *testing.T) {
 	// block 0 [ 1, 3]
 	// block 1 12 and 15
 	// block 2 [16,20]
-	fs.removeMsgsInRange(13, 14, true)
+	fs.removeMsgsInRange(13, 14, true, nil)
 	fs.blks[1].compact()
 
 	require_Equal(t, len(fs.blks), 3)
@@ -14491,7 +14491,7 @@ func TestFileStoreRemoveMsgsInRangePartialBlocks(t *testing.T) {
 	// block 0 [ 1, 3]
 	// block 1 12
 	// empty block 21 20
-	fs.removeMsgsInRange(13, 20, true)
+	fs.removeMsgsInRange(13, 20, true, nil)
 	fs.blks[1].compact()
 
 	require_Equal(t, len(fs.blks), 3)
@@ -14504,12 +14504,12 @@ func TestFileStoreRemoveMsgsInRangePartialBlocks(t *testing.T) {
 	// Remove [10,20] leaves:
 	// block 0 [ 1, 3]
 	// empty block 21 20
-	fs.removeMsgsInRange(10, 20, true)
+	fs.removeMsgsInRange(10, 20, true, nil)
 	require_Equal(t, len(fs.blks), 2)
 
 	// Remove everything
 	// empty block 21 20
-	fs.removeMsgsInRange(1, 30, true)
+	fs.removeMsgsInRange(1, 30, true, nil)
 
 	require_Equal(t, len(fs.blks), 1)
 	require_Equal(t, atomic.LoadUint64(&fs.blks[0].first.seq), 21)
@@ -14602,19 +14602,19 @@ func TestFileStoreRemoveMsgsInRangeWithTombstones(t *testing.T) {
 	// Block 3: has prior tombs, should be preserved
 	// Block 4: has "internal" tombs, can be purged entirely
 	// Block 5: updates mb first
-	fs.removeMsgsInRange(4, 17, false)
+	fs.removeMsgsInRange(4, 17, false, nil)
 
 	checkBlock(fs.blks[0], 1, 4, nil)
 	checkBlock(fs.blks[1], 13, 12, []uint64{4, 3, 2, 10})
 	checkBlock(fs.blks[2], 18, 20, []uint64{9, 11, 17})
 
 	// Remove everything (past the last sequence)
-	fs.removeMsgsInRange(1, 100, false)
+	fs.removeMsgsInRange(1, 100, false, nil)
 	require_Equal(t, len(fs.blks), 1)
 	checkBlock(fs.blks[0], 21, 20, []uint64{20})
 
 	// Attempt to remove the empty block
-	fs.removeMsgsInRange(1, 100, false)
+	fs.removeMsgsInRange(1, 100, false, nil)
 	require_Equal(t, len(fs.blks), 1)
 	checkBlock(fs.blks[0], 21, 20, []uint64{20})
 }
@@ -15645,6 +15645,184 @@ func TestFileStoreSyncDeletedDmapAliasRace(t *testing.T) {
 
 	// Sanity: store still usable.
 	_ = fs.State()
+}
+
+// SyncDeleted collects the storage callbacks for removed blocks and only fires
+// a single aggregated callback at the end. Confirm that stream/account
+// accounting and consumer NumPending are unaffected by that, for single message
+// removals, for bulk block removals, and for a range that mixes both.
+func TestFileStoreSyncDeletedAccountingAndNumPending(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		// Returns the delete blocks to sync, and the first and last sequence they cover.
+		dbs func(fseq, lseq uint64) (DeleteBlocks, uint64, uint64)
+		// Whether all removed messages are removed one by one, which is the only
+		// path that terminates outstanding pending messages for a consumer.
+		// Removing a block as a whole doesn't.
+		termsPending bool
+		// Expected number of aggregated callbacks for removed blocks, and of
+		// single message callbacks.
+		expBatchCBs, expMsgCBs int64
+	}{
+		{
+			// Single message removals only.
+			"SingleMsgs",
+			func(fseq, lseq uint64) (DeleteBlocks, uint64, uint64) {
+				last := fseq + (lseq-fseq)/2
+				set := &avl.SequenceSet{}
+				for seq := fseq; seq <= last; seq++ {
+					set.Insert(seq)
+				}
+				return DeleteBlocks{set}, fseq, last
+			},
+			true,
+			// Nothing is removed as a block, so all messages one by one.
+			0, 500,
+		},
+		{
+			// A range that's block aligned, so full blocks are removed.
+			"FullBlocks",
+			func(fseq, lseq uint64) (DeleteBlocks, uint64, uint64) {
+				return DeleteBlocks{&DeleteRange{First: fseq, Num: lseq - fseq + 1}}, fseq, lseq
+			},
+			false,
+			// All blocks are removed as a whole, so one aggregated callback.
+			1, 0,
+		},
+		{
+			// A range that starts and ends in the middle of a block, so the
+			// blocks at the edges are removed message by message, while the
+			// blocks in between are removed as a whole.
+			"MixedBlocks",
+			func(fseq, lseq uint64) (DeleteBlocks, uint64, uint64) {
+				first, last := fseq+3, lseq-3
+				return DeleteBlocks{&DeleteRange{First: first, Num: last - first + 1}}, first, last
+			},
+			false,
+			// Still only one aggregated callback for all removed blocks, plus the
+			// messages at the edges that are removed one by one.
+			1, 7,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			s := RunBasicJetStreamServer(t)
+			defer s.Shutdown()
+
+			acc := s.globalAccount()
+			mset, err := acc.addStreamWithStore(
+				&StreamConfig{Name: "TEST", Subjects: []string{"foo.>"}, Storage: FileStorage},
+				&FileStoreConfig{BlockSize: 1024},
+			)
+			require_NoError(t, err)
+
+			// Two consumers with a different filter, so they need to calculate
+			// NumPending differently.
+			for i, filter := range []string{"foo.*", "foo.1"} {
+				_, err = mset.addConsumer(&ConsumerConfig{
+					Durable:       fmt.Sprintf("d%d", i),
+					FilterSubject: filter,
+					AckPolicy:     AckExplicit,
+				})
+				require_NoError(t, err)
+			}
+
+			nc, js := jsClientConnect(t, s)
+			defer nc.Close()
+
+			for i := range 1000 {
+				_, err = js.Publish(fmt.Sprintf("foo.%d", i%10), make([]byte, 100))
+				require_NoError(t, err)
+			}
+
+			// Have one consumer with outstanding pending messages, those must be
+			// terminated when the messages underneath them are removed.
+			sub, err := js.PullSubscribe("foo.*", "d0")
+			require_NoError(t, err)
+			msgs, err := sub.Fetch(10)
+			require_NoError(t, err)
+			require_Equal(t, len(msgs), 10)
+
+			fs := mset.store.(*fileStore)
+			var before StreamState
+			fs.FastState(&before)
+			require_Equal(t, acc.JetStreamUsage().Store, before.Bytes)
+
+			// Count the callbacks that reach the stream, all removed blocks must
+			// result in one aggregated callback, no matter how many there were.
+			var msgCBs, batchCBs atomic.Int64
+			fs.mu.Lock()
+			ocb := fs.scb
+			fs.scb = func(md, bd int64, seq uint64, subj string) {
+				if md == -1 && seq > 0 && subj != _EMPTY_ {
+					msgCBs.Add(1)
+				} else {
+					batchCBs.Add(1)
+				}
+				ocb(md, bd, seq, subj)
+			}
+			fs.mu.Unlock()
+
+			dbs, first, last := test.dbs(before.FirstSeq, before.LastSeq)
+			require_NoError(t, fs.SyncDeleted(dbs))
+
+			fs.mu.Lock()
+			fs.scb = ocb
+			fs.mu.Unlock()
+
+			require_Equal(t, batchCBs.Load(), test.expBatchCBs)
+			require_Equal(t, msgCBs.Load(), test.expMsgCBs)
+
+			var after StreamState
+			fs.FastState(&after)
+			require_Equal(t, after.Msgs, before.Msgs-(last-first+1))
+
+			// The aggregated callback is fired before SyncDeleted returns, so the
+			// stream state must match the store and the account usage must have
+			// been decremented by exactly the bytes we removed.
+			state := mset.state()
+			require_Equal(t, state.Msgs, after.Msgs)
+			require_Equal(t, state.Bytes, after.Bytes)
+			require_Equal(t, acc.JetStreamUsage().Store, after.Bytes)
+
+			// All consumers must have an accurate NumPending.
+			mset.clsMu.RLock()
+			cList := append([]*consumer(nil), mset.cList...)
+			mset.clsMu.RUnlock()
+			require_Equal(t, len(cList), 2)
+
+			for _, o := range cList {
+				o.mu.RLock()
+				npc, sseq, filter := o.npc, o.sseq, o.cfg.FilterSubject
+				o.mu.RUnlock()
+
+				expected, _, err := fs.NumPending(sseq, filter, false)
+				require_NoError(t, err)
+				require_Equal(t, npc, int64(expected))
+			}
+
+			if !test.termsPending {
+				return
+			}
+			// Terminating pending messages is done in a separate goroutine.
+			checkFor(t, 2*time.Second, 50*time.Millisecond, func() error {
+				for _, o := range cList {
+					o.mu.RLock()
+					var stillPending []uint64
+					for seq := range o.pending {
+						if seq >= first && seq <= last {
+							stillPending = append(stillPending, seq)
+						}
+					}
+					filter := o.cfg.FilterSubject
+					o.mu.RUnlock()
+					if len(stillPending) > 0 {
+						return fmt.Errorf("consumer %q still has removed msgs pending: %v", filter, stillPending)
+					}
+				}
+				return nil
+			})
+		})
+	}
 }
 
 func TestFileStoreEncryptionKeyFileSyncedBySyncBlocks(t *testing.T) {


### PR DESCRIPTION
`SyncDeleted` is called to sync deletes for replicated streams. Many blocks can be purged as part of `SyncDeleted`, and every single one would recalculate pending for all consumers. That's because `purgeMsgBlock` calls the storage update handler with only the totals, which recalculates pending for every consumer, whereas single message deletes call into `decStreamPending` only for the consumers that match the subject that's removed. This PR fixes that by aggregating all block removals to the end, and recalculating pending only once (if at least one block was purged).