### PR TITLE
Fix potential underflow in `SkipMsgs` delete map accounting

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -5649,16 +5649,20 @@ func (fs *fileStore) SkipMsgs(seq uint64, num uint64) error {
 		}
 		seq = fs.state.LastSeq + 1
 	}
+	// Make sure the last sequence leaves room for the next message.
+	if num == 0 || seq == 0 || num > math.MaxUint64-seq {
+		return ErrSequenceMismatch
+	}
 
 	// Limit number of dmap entries
 	const maxDeletes = 64 * 1024
 	mb := fs.lmb
 
 	var msgs uint64
-	numDeletes := int(num)
+	numDeletes := num
 	if mb != nil {
 		mb.mu.RLock()
-		numDeletes += mb.dmap.Size()
+		numDeletes = addSaturate(numDeletes, uint64(mb.dmap.Size()))
 		msgs = mb.msgs
 		mb.mu.RUnlock()
 	}

--- a/server/util.go
+++ b/server/util.go
@@ -385,14 +385,16 @@ func parallelTaskQueue(mp int) chan<- func() {
 	return tq
 }
 
-// addSaturate returns a + b, saturating at math.MaxInt64.
-// Both a and b must be non-negative.
-func addSaturate(a, b int64) int64 {
-	sum, carry := bits.Add64(uint64(a), uint64(b), 0)
-	if carry != 0 || sum > uint64(math.MaxInt64) {
-		return math.MaxInt64
+// addSaturate returns a + b, saturating at the maximum value of T.
+// Signed inputs must be non-negative.
+func addSaturate[T ~int64 | ~uint64](a, b T) T {
+	if c := a + b; c >= a {
+		return c
 	}
-	return int64(sum)
+	if ^T(0) < 0 {
+		return T(^uint64(0) >> 1)
+	}
+	return ^T(0)
 }
 
 // mulSaturate returns a * b, saturating at math.MaxInt64.


### PR DESCRIPTION
Without this, we can in some cases miss the `maxDeletes` gate from underflowing and then burn CPU and memory writing endlessly into `dmap`.