### PR TITLE
Fix nil mb.cache dereference in secure removeMsgFromBlock

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -6250,6 +6250,14 @@ func (fs *fileStore) removeMsgFromBlock(mb *msgBlock, seq uint64, secure, viaLim
 
 	// Must always perform the erase, even if the block is empty as it could contain tombstones.
 	if secure {
+		// The cache may have been expired or recycled while we dropped mb.mu above.
+		if mb.cacheNotLoaded() {
+			if err := mb.loadMsgsWithLock(); err != nil {
+				finishedWithCache()
+				mb.mu.Unlock()
+				return false, err
+			}
+		}
 		// Grab record info, but use the pre-computed record length.
 		ri, _, _, err := mb.slotInfo(int(seq - mb.cache.fseq))
 		if err != nil {

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -16348,3 +16348,64 @@ func TestFileStoreEncodedStreamStateWithSources(t *testing.T) {
 	require_NotNil(t, seeded)
 	require_Equal(t, seeded.Seq, 0)
 }
+
+// https://github.com/nats-io/nats-server/issues/8547
+// A secure remove drops mb.mu while it writes the delete tombstone into the last block.
+// If the block cache expires in that window, the secure branch used to dereference a nil mb.cache.
+func TestFileStoreEraseMsgCacheExpiredDuringTombstoneWrite(t *testing.T) {
+	defer require_NoPanic(t)
+
+	fs, err := newFileStore(
+		FileStoreConfig{StoreDir: t.TempDir(), BlockSize: 1024},
+		StreamConfig{Name: "zzz", Storage: FileStorage})
+	require_NoError(t, err)
+
+	msg := []byte("Hello World")
+	for i := 0; i < 200; i++ {
+		_, _, err = fs.StoreMsg("foo", nil, msg, 0)
+		require_NoError(t, err)
+	}
+	// We need more than one block so tombstones land in the last block, not the one we erase from.
+	require_True(t, fs.numMsgBlocks() > 1)
+
+	fs.mu.RLock()
+	mb := fs.blks[0]
+	fs.mu.RUnlock()
+	mb.mu.Lock()
+	first, last := atomic.LoadUint64(&mb.first.seq), atomic.LoadUint64(&mb.last.seq)
+	// Pretend the last write was long ago so a forced expire actually drops the cache.
+	mb.lwts = 0
+	mb.mu.Unlock()
+
+	// Expire the cache as fast as we can, like the expiration timer or a linear scan ending on this block.
+	// TryLock so a panicking erase that still holds mb.mu cannot hang the test on wg.Wait.
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				if mb.mu.TryLock() {
+					mb.tryForceExpireCacheLocked()
+					mb.mu.Unlock()
+				}
+			}
+		}
+	}()
+	defer func() {
+		close(stop)
+		wg.Wait()
+	}()
+
+	// Keep one message so the block is not removed as empty.
+	for seq := first; seq < last; seq++ {
+		removed, err := fs.EraseMsg(seq)
+		require_NoError(t, err)
+		require_True(t, removed)
+	}
+	fs.Stop()
+}


### PR DESCRIPTION
Resolves #8547

`removeMsgFromBlock` releases `mb.mu` to write the delete tombstone into the last block (`fs.checkLastBlock` + `lmb.writeTombstone`) and takes it back afterwards. In that window the block cache can be expired by the cache timer (`tryExpireCache`) or by a linear scan ending on the block (`msgForSeqLocked` -> `tryForceExpireCache`), both of which set `mb.cache = nil` via `clearCache`. The secure branch then read `mb.cache.fseq` with no guard and passed `mb.cache.buf` into `eraseMsg`, so a secure `STREAM.MSG.DELETE` racing with cache expiry took the server down with a nil dereference. The fault address in the report, `0x38`, is the offset of `fseq` in the `cache` struct.

The non-secure path never dereferences `mb.cache` after the window, which matches the report that only erase deletes crashed.

### Fix

After re-acquiring `mb.mu`, the secure branch now re-checks `cacheNotLoaded()` and reloads, mirroring the guard at the top of the function. Eight lines, no behaviour change for the non-secure path.

### Test

`TestFileStoreEraseMsgCacheExpiredDuringTombstoneWrite` erases every message but one from a non-last block while a goroutine force-expires that block's cache. Without the fix it panics 20/20 runs:

```
--- FAIL: TestFileStoreEraseMsgCacheExpiredDuringTombstoneWrite (0.02s)
    filestore_test.go:16397: EraseMsg panicked: runtime error: invalid memory address or nil pointer dereference
```

With the fix it passes 20/20 under `-race`. `go test -run TestFileStore` and `go test -race -run 'TestFileStore(Erase|Remove|AtomicErase|IndexCacheBufErase)'` are green.

### Not changed here

`isLastBlock` is computed before the unlock and can be stale if `checkLastBlock` rolled a new block in the window. Its only effect is `atomicOverwriteFile(..., !isLastBlock)`, so the formerly-last block gets rewritten uncompressed. Pre-existing and harmless, so I left it out of this diff.
