### PR TITLE
(2.15) NRG: Don't campaign if isolated

### DIFF
--- a/server/raft.go
+++ b/server/raft.go
@@ -5863,6 +5863,16 @@ func (n *raft) switchToCandidate() {
 		return
 	}
 
+	// If no one is going to hear our campaign, don't bother initiating it. It is
+	// possible that we may become unisolated, hear the current leader again and
+	// continue participating in the current term without another election.
+	if !n.t.HasPeerInterest(n.vsubj) {
+		n.debug("Not switching to candidate, currently isolated")
+		n.updateLeader(noLeader)
+		n.resetElect(minElectionTimeout)
+		return
+	}
+
 	if n.State() != Candidate {
 		n.debug("Switching to candidate")
 	} else {

--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -8116,6 +8116,71 @@ func TestNRGPartitionedPeerRemove(t *testing.T) {
 	})
 }
 
+func TestNRGIsolatedNodeDoesNotCampaign(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	hub, rg := c.createMockMemRaftGroup("MOCK", 3, newStateAdder)
+	defer hub.healPartitions()
+
+	leader := rg.waitOnLeader()
+	require_NotNil(t, leader)
+	isolated := rg.followers()[0].node().(*raft)
+	require_NotEqual(t, isolated.ID(), leader.node().ID())
+	require_False(t, isolated.Leader())
+	require_Equal(t, isolated.State(), Follower)
+	leaderTerm := leader.node().Term()
+	require_Equal(t, isolated.Term(), leaderTerm)
+	hub.partition(isolated.ID(), 1)
+
+	var requests atomic.Int64
+	hub.setAfterMsgHook(func(subject, reply string, msg []byte) {
+		if subject != isolated.vsubj {
+			return
+		}
+		vr := decodeVoteRequest(msg, reply)
+		if vr != nil && vr.candidate == isolated.ID() {
+			requests.Add(1)
+		}
+	})
+
+	initialTerm := isolated.Term()
+	require_NoError(t, isolated.CampaignImmediately())
+	isolated.RLock()
+	campaignReset := isolated.etlr
+	isolated.RUnlock()
+	checkFor(t, time.Second, 10*time.Millisecond, func() error {
+		isolated.RLock()
+		retried := isolated.etlr.After(campaignReset)
+		isolated.RUnlock()
+		if !retried {
+			return errors.New("isolated node has not handled its campaign timeout")
+		}
+		return nil
+	})
+	require_Equal(t, isolated.State(), Follower)
+	require_Equal(t, isolated.Term(), initialTerm)
+	require_Equal(t, requests.Load(), int64(0))
+
+	// Heal the node and have the current leader contact it. Since the isolated
+	// node never campaigned, it should rejoin as a follower in the same term.
+	hub.heal(isolated.ID())
+	leader.node().(*raft).sendHeartbeat()
+	checkFor(t, time.Second, 10*time.Millisecond, func() error {
+		if isolated.GroupLeader() != leader.node().ID() {
+			return errors.New("healed node has not recognized the current leader")
+		}
+		return nil
+	})
+	require_True(t, leader.node().Leader())
+	require_Equal(t, leader.node().Term(), leaderTerm)
+	require_Equal(t, isolated.State(), Follower)
+	require_Equal(t, isolated.Term(), leaderTerm)
+
+	leader.(*stateAdder).proposeDelta(1)
+	rg.waitOnTotal(t, 1)
+}
+
 func TestNRGPeerAddAndPartitionLeader(t *testing.T) {
 	c := createJetStreamClusterExplicit(t, "R3S", 3)
 	defer c.shutdown()

--- a/server/raft_transport.go
+++ b/server/raft_transport.go
@@ -22,6 +22,9 @@ type raftTransport interface {
 	// Account returns the NATS Account this transport operates within.
 	Account() *Account
 
+	// HasPeerInterest reports whether another node can receive this subject.
+	HasPeerInterest(subject string) bool
+
 	// Reset reconfigures the transport for a new account.
 	// This involves tearing down existing client resources and
 	// setting up new ones for the provided account.
@@ -63,6 +66,15 @@ func (t *defaultTransport) Node() RaftNode {
 
 func (t *defaultTransport) Account() *Account {
 	return t.acc
+}
+
+func (t *defaultTransport) HasPeerInterest(subject string) bool {
+	if t.acc == nil || t.acc.sl == nil {
+		return false
+	}
+	np, _ := t.acc.sl.NumInterest(subject)
+	// The Raft node itself owns one subscription for the vote subject.
+	return np > 1
 }
 
 func (t *defaultTransport) Reset(acc *Account) {

--- a/server/raft_transport_helpers_test.go
+++ b/server/raft_transport_helpers_test.go
@@ -84,6 +84,18 @@ func (h *raftTransportHub) healPartitions() {
 	clear(h.partitions)
 }
 
+func (h *raftTransportHub) hasPeerInterest(nodeID, subject string) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	partition := h.partitions[nodeID]
+	for id, transport := range h.transports {
+		if id != nodeID && h.partitions[id] == partition && transport.sub != nil && transport.sub.HasInterest(subject) {
+			return true
+		}
+	}
+	return false
+}
+
 // Set a hook that is called back after a message is published. The after
 // message hook can expect the raftTransportHub to be unlocked. It is OK
 // to interact with the raftTransportHub inside the message hook. On the
@@ -154,6 +166,10 @@ func (t *mockTransport) Node() RaftNode {
 
 func (t *mockTransport) Account() *Account {
 	return t.acc
+}
+
+func (t *mockTransport) HasPeerInterest(subject string) bool {
+	return t.hub.hasPeerInterest(t.Node().ID(), subject)
 }
 
 func (t *mockTransport) Publish(subject string, reply string, msg []byte) {


### PR DESCRIPTION
A node that is fully isolated and can't reach other nodes for a vote request will no longer campaign. If the isolation ends and the current leader comes back into contact, this gives us an opportunity to continue participating in the current term without causing unnecessary elections.

This doesn't address the case of a partition that isn't complete but can't achieve quorum. That needs addressing separately.