### PR TITLE
Fix stale comment in removeMsgFromBlock about cache loading

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -6176,7 +6176,7 @@ func (fs *fileStore) removeMsgFromBlock(mb *msgBlock, seq uint64, secure, viaLim
 	isEmpty := mb.msgs == 1 // ... about to be zero though.
 
 	// We used to not have to load in the messages except with callbacks or the filtered subject state (which is now always on).
-	// Now just load regardless.
+	// Only load from disk if the cache is not already in memory, cacheNotLoaded will also revive a weakly held cache.
 	// TODO(dlc) - Figure out a way not to have to load it in, we need subject tracking outside main data block.
 	needsCleanup := mb.cache == nil
 	if mb.cacheNotLoaded() {


### PR DESCRIPTION
## What

Updates a stale comment in `removeMsgFromBlock`. The comment said "Now just load regardless", but the code first checks `cacheNotLoaded()` — which checks the strong reference and revives a weakly held cache via the elastic pointer — and only loads the block from disk when the cache is genuinely gone. `loadMsgsWithLock` also re-checks `cacheAlreadyLoaded()` before reading disk.

The `TODO(dlc)` about subject tracking outside the main data block is left in place, since a full block load (and decompress under the block lock) is still paid whenever the cache is not resident.

## Why

The "load regardless" wording suggests an unconditional full-block load on every removal, which misreads the current behavior after the cache-reference weakening work (#8380 / #8395).

🤖 Generated with [Claude Code](https://claude.com/claude-code)