### PR TITLE
[FIXED] Do not force-expire cache of active eviction target block

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -271,6 +271,12 @@ type msgBlock struct {
 	needSync    bool
 	needKeySync bool // Key file is written once and immutable, cleared after its one sync.
 	noCompact   bool
+	// Set once this block becomes the target of a limits-based FIFO removal,
+	// i.e. the head block of a stream evicting under DiscardOld. Scan paths
+	// will then skip force-expiring its cache, since the next eviction would
+	// have to reload and decompress the block while holding the write lock.
+	// The regular cache expiry timer still applies.
+	evictTarget bool
 	closed      bool
 	ttls        uint64 // How many msgs have TTLs?
 	schedules   uint64 // How many msgs have schedules?
@@ -6175,6 +6181,14 @@ func (fs *fileStore) removeMsgFromBlock(mb *msgBlock, seq uint64, secure, viaLim
 	isLastBlock := mb == fs.lmb
 	isEmpty := mb.msgs == 1 // ... about to be zero though.
 
+	// Removing the first message via limits means this block is the active
+	// eviction target (e.g. head block under DiscardOld at the byte or msg cap),
+	// so it will be touched again on subsequent removals. Mark it so scan paths
+	// do not force-expire its cache out from underneath us.
+	if viaLimits && fifo {
+		mb.evictTarget = true
+	}
+
 	// We used to not have to load in the messages except with callbacks or the filtered subject state (which is now always on).
 	// Now just load regardless.
 	// TODO(dlc) - Figure out a way not to have to load it in, we need subject tracking outside main data block.
@@ -7076,6 +7090,13 @@ func (mb *msgBlock) tryForceExpireCache() {
 
 // We will attempt to force expire this by temporarily clearing the last load time.
 func (mb *msgBlock) tryForceExpireCacheLocked() {
+	// If this block is the active target of limits-based removals, keep the
+	// cache around, otherwise the next eviction pays a full block reload and
+	// decompress while holding the write lock. The regular expiry timer will
+	// still reclaim the cache once the block goes idle.
+	if mb.evictTarget {
+		return
+	}
 	llts := mb.llts
 	mb.llts = 0
 	mb.tryExpireCacheLocked()

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -6181,11 +6181,15 @@ func (fs *fileStore) removeMsgFromBlock(mb *msgBlock, seq uint64, secure, viaLim
 	isLastBlock := mb == fs.lmb
 	isEmpty := mb.msgs == 1 // ... about to be zero though.
 
-	// Removing the first message via limits means this block is the active
-	// eviction target (e.g. head block under DiscardOld at the byte or msg cap),
-	// so it will be touched again on subsequent removals. Mark it so scan paths
-	// do not force-expire its cache out from underneath us.
-	if viaLimits && fifo {
+	// Removing the stream's first message via limits means this block is the
+	// active eviction target (the head block under DiscardOld at the byte or
+	// msg cap, or age expiry), so it will be touched again on subsequent
+	// removals. Mark it so scan paths do not force-expire its cache out from
+	// underneath us. This deliberately checks the stream's first seq and not
+	// the block's: per-subject limit removals scatter across interior blocks,
+	// where keeping the cache warm does not help the next removal and the
+	// flag would never be cleared.
+	if viaLimits && seq == fs.state.FirstSeq {
 		mb.evictTarget = true
 	}
 

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -16348,3 +16348,53 @@ func TestFileStoreEncodedStreamStateWithSources(t *testing.T) {
 	require_NotNil(t, seeded)
 	require_Equal(t, seeded.Seq, 0)
 }
+
+func TestFileStoreEvictionTargetCacheNotForceExpired(t *testing.T) {
+	fs, err := newFileStore(
+		FileStoreConfig{StoreDir: t.TempDir(), BlockSize: 256},
+		StreamConfig{Name: "zzz", Subjects: []string{"*"}, Storage: FileStorage},
+	)
+	require_NoError(t, err)
+	defer fs.Stop()
+
+	msg := bytes.Repeat([]byte("Z"), 64)
+	for i := 0; i < 20; i++ {
+		_, _, err := fs.StoreMsg("A", nil, msg, 0)
+		require_NoError(t, err)
+	}
+	require_True(t, fs.numMsgBlocks() > 2)
+
+	// Remove the first message via limits, as DiscardOld does at the cap.
+	fs.mu.Lock()
+	_, err = fs.removeMsgViaLimits(fs.state.FirstSeq)
+	fs.mu.Unlock()
+	require_NoError(t, err)
+
+	// The head block is now the active eviction target, so a scan-path
+	// force-expire should leave its cache alone.
+	mb := fs.getFirstBlock()
+	require_NotNil(t, mb)
+	mb.mu.Lock()
+	evictTarget := mb.evictTarget
+	err = mb.loadMsgsWithLock()
+	mb.tryForceExpireCacheLocked()
+	loaded := mb.cacheAlreadyLoaded()
+	mb.mu.Unlock()
+	require_True(t, evictTarget)
+	require_NoError(t, err)
+	require_True(t, loaded)
+
+	// A block not involved in limits-based removals still force-expires.
+	fs.mu.RLock()
+	mb2 := fs.blks[1]
+	fs.mu.RUnlock()
+	mb2.mu.Lock()
+	evictTarget = mb2.evictTarget
+	err = mb2.loadMsgsWithLock()
+	mb2.tryForceExpireCacheLocked()
+	loaded = mb2.cacheAlreadyLoaded()
+	mb2.mu.Unlock()
+	require_True(t, !evictTarget)
+	require_NoError(t, err)
+	require_True(t, !loaded)
+}

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -16398,3 +16398,37 @@ func TestFileStoreEvictionTargetCacheNotForceExpired(t *testing.T) {
 	require_NoError(t, err)
 	require_True(t, !loaded)
 }
+
+func TestFileStorePerSubjectLimitRemovalDoesNotMarkEvictTarget(t *testing.T) {
+	fs, err := newFileStore(
+		FileStoreConfig{StoreDir: t.TempDir(), BlockSize: 256},
+		StreamConfig{Name: "zzz", Subjects: []string{"*"}, Storage: FileStorage, MaxMsgsPer: 1},
+	)
+	require_NoError(t, err)
+	defer fs.Stop()
+
+	msg := bytes.Repeat([]byte("Z"), 64)
+	for i := 1; i <= 20; i++ {
+		_, _, err := fs.StoreMsg(fmt.Sprintf("%d", i), nil, msg, 0)
+		require_NoError(t, err)
+	}
+	require_True(t, fs.numMsgBlocks() > 2)
+
+	// Pick the subject whose only message is the first message of an interior
+	// block, then store it again so the per-subject limit removes that message.
+	fs.mu.RLock()
+	mb := fs.blks[1]
+	fs.mu.RUnlock()
+	fseq := atomic.LoadUint64(&mb.first.seq)
+	_, _, err = fs.StoreMsg(fmt.Sprintf("%d", fseq), nil, msg, 0)
+	require_NoError(t, err)
+
+	mb.mu.Lock()
+	evictTarget := mb.evictTarget
+	fseqAfter := atomic.LoadUint64(&mb.first.seq)
+	mb.mu.Unlock()
+	// Confirm the removal actually happened in this block, but that it was
+	// not marked as an eviction target since it is not the head block.
+	require_True(t, fseqAfter != fseq)
+	require_True(t, !evictTarget)
+}


### PR DESCRIPTION
## What

Skips scan-path force-expiry of a block's cache once that block has become the active target of limits-based FIFO removals (the head block of a stream evicting under `DiscardOld` at its byte or message cap). A new `evictTarget` flag is set in `removeMsgFromBlock` when a via-limits removal deletes the block's first message, and `tryForceExpireCacheLocked` becomes a no-op for flagged blocks. The regular cache expiry timer is untouched and still reclaims the cache once the block goes idle, so the memory cost is bounded to one block cache per stream while it is actively evicting.

Includes a regression test covering both the exempted head block and the unchanged behavior for other blocks.

## Why

See #8552.

🤖 Generated with [Claude Code](https://claude.com/claude-code)