### PR TITLE
(2.14) [ADDED] Compatibility for v2.15's desired state

### DIFF
--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -2015,7 +2015,8 @@ func (s *Server) jsStreamInfoRequest(sub *subscription, c *client, a *Account, s
 		return
 	}
 
-	config := mset.config()
+	// Report the config as requested, the stream can still be running at its origin.
+	config := js.targetStreamConfig(mset, mset.config())
 	resp.StreamInfo = &StreamInfo{
 		Created:    mset.createdTime(),
 		State:      mset.stateWithDetail(details),

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -117,6 +117,15 @@ type Placement struct {
 	Preferred string   `json:"preferred,omitempty"`
 }
 
+func (p *Placement) clone() *Placement {
+	if p == nil {
+		return nil
+	}
+	cp := *p
+	cp.Tags = copyStrings(p.Tags)
+	return &cp
+}
+
 // Define types of the entry.
 type entryOp uint8
 
@@ -163,8 +172,121 @@ type raftGroup struct {
 	Cluster   string      `json:"cluster,omitempty"`
 	Preferred string      `json:"preferred,omitempty"`
 	ScaleUp   bool        `json:"scale_up,omitempty"`
+	// Excluded peers are evacuated and can't be added to this group as part of the meta
+	// leader's reconciliation. Cleared when this group is at the configured replicas.
+	Excluded []string `json:"excluded,omitempty"`
+	// Desired holds the target placement while this group is being moved or
+	// scaled; it is nil when the group is stable.
+	Desired *desiredRaftGroup `json:"desired,omitempty"`
 	// Internal
 	node RaftNode
+	// migration reports what the group leader is currently doing to move this group
+	// toward its desired state. Local to the group leader and not replicated: only
+	// the leader drives the migration, and only the leader answers INFO requests.
+	migration *DesiredClusterInfoStatus
+}
+
+// desiredGroupPlacement specifies the desired peer set.
+// A stream or consumer raftGroup can be scaled or moved safely based on this desired state.
+type desiredRaftGroup struct {
+	Created time.Time `json:"created"`
+	ID      string    `json:"id"`
+	// Term is the raft term of the group leader driving this desired state. It acts as a
+	// fencing token; reconcile requests from older leadership terms are rejected.
+	Term      uint64   `json:"term,omitempty"`
+	Peers     []string `json:"peers"`
+	Cluster   string   `json:"cluster,omitempty"`
+	Preferred string   `json:"preferred,omitempty"`
+
+	// ScaleDown marks this desired state as a scale down. The Peers field is the
+	// total set that can be scaled down from.
+	ScaleDown bool `json:"scale_down,omitempty"`
+
+	// Move marks this desired state as retargeting placement.
+	Move bool `json:"move,omitempty"`
+
+	// CancelMove marks this desired state as a rollback to the recorded origin, proposed
+	// by a cancel move request. The assignment it is proposed with is responded to as a
+	// cancel move rather than a stream update.
+	CancelMove bool `json:"cancel_move,omitempty"`
+
+	// Removed are peers an operator peer-removed from this group. A group that
+	// can't reach quorum may only evict what's recorded here.
+	Removed []string `json:"removed,omitempty"`
+
+	Origin *desiredRaftGroupOrigin `json:"origin,omitempty"`
+}
+
+// desiredRaftGroupOrigin specifies the original properties of the asset before any desired state changes were made.
+// Multiple desired state changes MUST NOT update these values, only the initial values must be set, allowing to
+// revert to before any changes were made.
+type desiredRaftGroupOrigin struct {
+	Peers     []string   `json:"peers"`
+	Cluster   string     `json:"cluster,omitempty"`
+	Replicas  int        `json:"replicas"`
+	Placement *Placement `json:"placement,omitempty"`
+	// When changing between retention policies, this retention remains active until unset.
+	Retention *RetentionPolicy `json:"retention,omitempty"`
+}
+
+// desiredOrigin returns the origin the asset is still running at while a desired
+// state is pending, or nil if there is none. This server persists and exposes
+// desired state, it never acts on it, so an asset stays at its origin until a
+// v2.15 server drives the migration.
+// Lock should be held.
+func (sa *streamAssignment) desiredOrigin() *desiredRaftGroupOrigin {
+	if sa == nil || sa.Group == nil || sa.Group.Desired == nil {
+		return nil
+	}
+	return sa.Group.Desired.Origin
+}
+
+// atDesiredOrigin returns a copy of the config with the desired origin applied (if any).
+func (cfg *StreamConfig) atDesiredOrigin(rg *raftGroup) *StreamConfig {
+	if rg.Desired == nil || rg.Desired.Origin == nil {
+		return cfg
+	}
+	newCfg := cfg.clone()
+	if rg.Desired.Origin.Placement != nil {
+		newCfg.Placement = rg.Desired.Origin.Placement.clone()
+	}
+	if rg.Desired.Origin.Retention != nil {
+		newCfg.Retention = *rg.Desired.Origin.Retention
+	}
+	return newCfg
+}
+
+// atDesiredTarget returns a copy of the running config with the fields that atDesiredOrigin can
+// hold back restored from target, which is the config as the user requested it. While the desired
+// state is pending the stream runs at its origin, but clients MUST be reported the config they
+// requested. Restoring unconditionally is safe, target always holds the requested values, whether
+// the desired state is still pending or was already reached.
+func (cfg StreamConfig) atDesiredTarget(target *StreamConfig) StreamConfig {
+	if target == nil {
+		return cfg
+	}
+	// Must copy, the target can be owned by the meta layer and outlive its lock here.
+	cfg.Placement = target.Placement.clone()
+	cfg.Retention = target.Retention
+	return cfg
+}
+
+// targetStreamConfig returns the stream's cfg as the user requested it, looking up the requested config
+// from the meta layer. Can differ from the running config while the desired state is still pending,
+// or while an update was committed but not applied onto the stream yet.
+func (js *jetStream) targetStreamConfig(mset *stream, cfg StreamConfig) StreamConfig {
+	// Only a clustered stream can differ from what was requested.
+	if js == nil || js.cluster == nil || mset == nil {
+		return cfg
+	}
+	accName := mset.accName()
+	js.mu.RLock()
+	defer js.mu.RUnlock()
+	sa := js.streamAssignment(accName, cfg.Name)
+	if sa == nil {
+		return cfg
+	}
+	return cfg.atDesiredTarget(sa.Config)
 }
 
 // streamAssignment is what the meta controller uses to assign streams to peers.
@@ -740,6 +862,13 @@ func (js *jetStream) isStreamHealthy(acc *Account, sa *streamAssignment) error {
 	}
 	streamName := sa.Config.Name
 	node := sa.Group.node
+	// The config holds the target replica count while a desired state is pending,
+	// but the group is still at its origin and we don't act on desired state, so
+	// judge the stream against the replica count it is actually running at.
+	var originReplicas int
+	if o := sa.desiredOrigin(); o != nil {
+		originReplicas = o.Replicas
+	}
 	js.mu.RUnlock()
 
 	// First lookup stream and make sure its there.
@@ -762,6 +891,11 @@ func (js *jetStream) isStreamHealthy(acc *Account, sa *streamAssignment) error {
 		return nil // No further checks for R=1 streams
 
 	case node == nil:
+		// Still running at an origin that needs no node. Only checked here, so a group
+		// that does have a node is checked as usual for the rest of the migration.
+		if originReplicas > 0 && originReplicas < replicas {
+			return nil
+		}
 		return errors.New("group node missing")
 
 	case msetNode == nil:
@@ -793,8 +927,8 @@ func (js *jetStream) isStreamHealthy(acc *Account, sa *streamAssignment) error {
 }
 
 // isConsumerHealthy will determine if the consumer is up to date.
-// For R1 it will make sure the consunmer is present on this server.
-func (js *jetStream) isConsumerHealthy(mset *stream, consumer string, ca *consumerAssignment) error {
+// For R1 it will make sure the consumer is present on this server.
+func (js *jetStream) isConsumerHealthy(mset *stream, sa *streamAssignment, consumer string, ca *consumerAssignment) error {
 	js.mu.RLock()
 	if ca != nil && ca.unsupported != nil {
 		js.mu.RUnlock()
@@ -824,6 +958,13 @@ func (js *jetStream) isConsumerHealthy(mset *stream, consumer string, ca *consum
 	}
 	created := ca.Created
 	node := ca.Group.node
+	// The stream may be running at its origin while its config already carries the
+	// target replica count. A consumer that has not been mapped onto the new peers
+	// yet inherits that target, so fall back on the origin count below.
+	var originReplicas int
+	if o := sa.desiredOrigin(); o != nil {
+		originReplicas = o.Replicas
+	}
 	js.mu.RUnlock()
 
 	// Check if not running at all.
@@ -848,6 +989,12 @@ func (js *jetStream) isConsumerHealthy(mset *stream, consumer string, ca *consum
 		return nil // No further checks for R=1 consumers
 
 	case node == nil:
+		// Not mapped onto the new peers yet, so still running at the stream's origin
+		// count. Only checked here, so a consumer that does have a node is checked as
+		// usual for the rest of the migration.
+		if originReplicas > 0 && originReplicas < rc {
+			return nil
+		}
 		return errors.New("group node missing")
 
 	case oNode == nil:
@@ -2435,7 +2582,11 @@ func (js *jetStream) setStreamAssignmentRecovering(sa *streamAssignment) {
 	sa.Restore = nil
 	if sa.Group != nil {
 		sa.Group.Preferred = _EMPTY_
-		sa.Group.ScaleUp = false
+		// Must be preserved while a migration is inflight, so peers that create
+		// their raft node late keep the empty-log protection.
+		if sa.Group.Desired == nil {
+			sa.Group.ScaleUp = false
+		}
 	}
 }
 
@@ -2447,7 +2598,11 @@ func (js *jetStream) setConsumerAssignmentRecovering(ca *consumerAssignment) {
 	ca.recovering = true
 	if ca.Group != nil {
 		ca.Group.Preferred = _EMPTY_
-		ca.Group.ScaleUp = false
+		// Must be preserved while a migration is inflight, so peers that create
+		// their raft node late keep the empty-log protection.
+		if ca.Group.Desired == nil {
+			ca.Group.ScaleUp = false
+		}
 	}
 }
 
@@ -2874,8 +3029,10 @@ func (js *jetStream) createRaftGroup(accName string, rg *raftGroup, recovering b
 		return nil, NewJSClusterNotActiveError()
 	}
 
+	// While a desired state is pending the group keeps a node even at a single peer, so
+	// scaling down doesn't lose the Raft term a newer server resumes the migration from.
 	// If this is a single peer raft group or we are not a member return.
-	if len(rg.Peers) <= 1 || !rg.isMember(cc.meta.ID()) {
+	if (rg.Desired == nil && len(rg.Peers) <= 1) || !rg.isMember(cc.meta.ID()) {
 		// Nothing to do here.
 		return nil, nil
 	}
@@ -3026,8 +3183,12 @@ retry:
 	}
 	// Need JS lock to be held for the assignment to avoid data-race reports
 	rg.node = n
+	preferred := rg.Preferred
+	if rg.Desired != nil {
+		preferred = rg.Desired.Preferred
+	}
 	// See if we are preferred and should start campaign immediately.
-	if n.ID() == rg.Preferred && n.Term() == 0 {
+	if n.ID() == preferred && n.Term() == 0 {
 		n.CampaignImmediately()
 	}
 	return n, nil
@@ -3901,6 +4062,12 @@ func (mset *stream) isMigrating() bool {
 	if sa == nil || sa.Group == nil || sa.Group.node == nil {
 		return false
 	}
+	// Desired state is driven by a v2.15 meta leader, which reconciles the group itself.
+	// We can't complete that migration, and the peer count deliberately lags the replica
+	// count while it's pending, so the legacy signature below would fire and never converge.
+	if sa.Group.Desired != nil {
+		return false
+	}
 	// The sign of migration is if our group peer count != configured replica count.
 	if sa.Config.Replicas != len(sa.Group.Peers) {
 		return true
@@ -4764,7 +4931,8 @@ func (js *jetStream) processStreamLeaderChange(mset *stream, isLeader bool, term
 		resp.Error = NewJSStreamCreateError(err, Unless(err))
 		s.sendAPIErrResponse(client, acc, subject, reply, _EMPTY_, s.jsonResponse(&resp))
 	} else {
-		msetCfg := mset.config()
+		// Report the config as requested, the stream can still be running at its origin.
+		msetCfg := js.targetStreamConfig(mset, mset.config())
 		resp.StreamInfo = &StreamInfo{
 			Created:   mset.createdTime(),
 			State:     mset.state(),
@@ -5114,7 +5282,8 @@ func (js *jetStream) processUpdateStreamAssignment(sa *streamAssignment) {
 	sa.err = osa.err
 
 	// If we detect we are scaling down to 1, non-clustered, and we had a previous node, clear it here.
-	if sa.Config.Replicas == 1 && sa.Group.node != nil {
+	// Note the group can converge onto one peer without the config scaling down based on peer-removes.
+	if len(sa.Group.Peers) == 1 && sa.Group.node != nil && sa.Group.Desired == nil {
 		sa.Group.node = nil
 	}
 
@@ -5221,11 +5390,16 @@ func (js *jetStream) processClusterUpdateStream(acc *Account, osa, sa *streamAss
 	}
 
 	js.mu.RLock()
-	s, rg := js.srv, sa.Group
+	s, rg, desired := js.srv, sa.Group, sa.Group.Desired
 	client, subject, reply := sa.Client, sa.Subject, sa.Reply
-	alreadyRunning, oldNumReplicas, numReplicas := osa.Group.node != nil, len(osa.Group.Peers), len(rg.Peers)
+	alreadyRunning, numReplicas := osa.Group.node != nil, len(rg.Peers)
+	// A remap below clears alreadyRunning, but we must still know whether we were
+	// running clustered before, or we'd skip the cleanup we owe on a downgrade.
+	wasRunning := alreadyRunning
+	wasClustered := len(osa.Group.Peers) > 1 || osa.Group.Desired != nil
 	needsNode := rg.node == nil
 	storage, cfg := sa.Config.Storage, sa.Config
+	newCfg := cfg.atDesiredOrigin(rg)
 	recovering := sa.recovering
 	hasResponded := sa.markResponded()
 	hadErr := sa.err != nil
@@ -5246,7 +5420,7 @@ func (js *jetStream) processClusterUpdateStream(acc *Account, osa, sa *streamAss
 			js.mu.Unlock()
 		}
 
-		if !alreadyRunning && numReplicas > 1 {
+		if !alreadyRunning && (numReplicas > 1 || desired != nil) {
 			if needsNode {
 				// Must run before startClusterSubs reads mset.sa.Sync.
 				mset.setStreamAssignment(sa)
@@ -5276,7 +5450,7 @@ func (js *jetStream) processClusterUpdateStream(acc *Account, osa, sa *streamAss
 			if !started {
 				mset.monitorWg.Done()
 			}
-		} else if numReplicas == 1 && alreadyRunning {
+		} else if numReplicas == 1 && desired == nil && wasRunning {
 			// We downgraded to R1. Make sure we cleanup the raft node and the stream monitor.
 			mset.removeNode()
 			mset.stopMonitoring()
@@ -5296,7 +5470,7 @@ func (js *jetStream) processClusterUpdateStream(acc *Account, osa, sa *streamAss
 		mset.setStreamAssignment(sa)
 
 		// Call update.
-		err = mset.updateWithAdvisory(cfg, !recovering, false)
+		err = mset.updateWithAdvisory(newCfg, !recovering, false)
 	}
 
 	// If not found we must be expanding into this node since if we are here we know we are a member.
@@ -5330,7 +5504,7 @@ func (js *jetStream) processClusterUpdateStream(acc *Account, osa, sa *streamAss
 	isLeader := mset.IsLeader()
 
 	// If the stream is scaled down, there is a chance we weren't already the leader.
-	if isLeader && numReplicas == 1 && oldNumReplicas > 1 {
+	if isLeader && numReplicas == 1 && desired == nil && wasClustered {
 		js.processStreamLeaderChange(mset, true, 0)
 	}
 
@@ -5354,7 +5528,9 @@ func (js *jetStream) processClusterUpdateStream(acc *Account, osa, sa *streamAss
 
 	// Send our response.
 	var resp = JSApiStreamUpdateResponse{ApiResponse: ApiResponse{Type: JSApiStreamUpdateResponseType}}
-	msetCfg := mset.config()
+	// Report the config as requested, the stream can still be running at its origin.
+	// Reading cfg without js.mu is safe, an assignment's config is never changed in place.
+	msetCfg := mset.config().atDesiredTarget(cfg)
 	resp.StreamInfo = &StreamInfo{
 		Created:   mset.createdTime(),
 		State:     mset.state(),
@@ -5378,6 +5554,7 @@ func (js *jetStream) processClusterCreateStream(acc *Account, sa *streamAssignme
 	js.mu.RLock()
 	s, rg, created := js.srv, sa.Group, sa.Created
 	alreadyRunning := rg.node != nil
+	newCfg := sa.Config.atDesiredOrigin(rg)
 	storage := sa.Config.Storage
 	restore := sa.Restore
 	recovering := sa.recovering
@@ -5416,7 +5593,8 @@ func (js *jetStream) processClusterCreateStream(acc *Account, sa *streamAssignme
 			// If we already have a stream assignment and they are the same exact config, short circuit here.
 			if osa != nil {
 				if reflect.DeepEqual(osa.Config, sa.Config) {
-					if sa.Group.Name == osa.Group.Name && reflect.DeepEqual(sa.Group.Peers, osa.Group.Peers) {
+					if sa.Group.Name == osa.Group.Name && reflect.DeepEqual(sa.Group.Peers, osa.Group.Peers) &&
+						reflect.DeepEqual(sa.Group.Desired, osa.Group.Desired) {
 						// Since this already exists we know it succeeded, just respond to this caller.
 						js.mu.RLock()
 						client, subject, reply, recovering := sa.Client, sa.Subject, sa.Reply, sa.recovering
@@ -5424,7 +5602,8 @@ func (js *jetStream) processClusterCreateStream(acc *Account, sa *streamAssignme
 
 						if !recovering {
 							var resp = JSApiStreamCreateResponse{ApiResponse: ApiResponse{Type: JSApiStreamCreateResponseType}}
-							msetCfg := mset.config()
+							// Report the config as requested, the stream can still be running at its origin.
+							msetCfg := js.targetStreamConfig(mset, mset.config())
 							resp.StreamInfo = &StreamInfo{
 								Created:   mset.createdTime(),
 								State:     mset.state(),
@@ -5437,11 +5616,13 @@ func (js *jetStream) processClusterCreateStream(acc *Account, sa *streamAssignme
 							s.sendAPIResponse(client, acc, subject, reply, _EMPTY_, s.jsonResponse(&resp))
 						}
 						return
-					} else {
+					} else if sa.Group.Name != osa.Group.Name {
 						// We had a bug where we could have multiple assignments for the same
 						// stream but with different group assignments, including multiple raft
 						// groups. So check for that here. We can only bet on the last one being
 						// consistent in the long run, so let it continue if we see this condition.
+						// Only a differing group name means a duplicate group; a differing peer
+						// set or desired state is a normal peer change and must fall through.
 						s.Warnf("JetStream cluster detected duplicate assignment for stream %q for account %q", sa.Config.Name, acc.Name)
 						if osa.Group.node != nil && osa.Group.node != sa.Group.node {
 							osa.Group.node.Delete()
@@ -5453,8 +5634,8 @@ func (js *jetStream) processClusterCreateStream(acc *Account, sa *streamAssignme
 			mset.setStreamAssignment(sa)
 			// Check if our config has really been updated.
 			cfg := mset.config()
-			if !reflect.DeepEqual(&cfg, sa.Config) {
-				if err = mset.updateWithAdvisory(sa.Config, false, false); err != nil {
+			if !reflect.DeepEqual(&cfg, newCfg) {
+				if err = mset.updateWithAdvisory(newCfg, false, false); err != nil {
 					if js.isShuttingDown() {
 						s.Debugf("Could not update stream, JetStream shutting down")
 						return
@@ -5476,7 +5657,7 @@ func (js *jetStream) processClusterCreateStream(acc *Account, sa *streamAssignme
 			}
 		} else if err == NewJSStreamNotFoundError() {
 			// Add in the stream here.
-			mset, err = acc.addStreamWithAssignment(sa.Config, nil, sa, false, true)
+			mset, err = acc.addStreamWithAssignment(newCfg, nil, sa, false, true)
 		}
 		if mset != nil {
 			mset.setCreatedTime(created)
@@ -6144,7 +6325,7 @@ func (js *jetStream) processClusterCreateConsumer(oca, ca *consumerAssignment, s
 				needsLocalResponse = true
 			}
 			// If we look like we are scaling up, let's send our current state to the group.
-			sendState = len(ca.Group.Peers) > len(oca.Group.Peers) && o.IsLeader() && n != nil
+			sendState = (len(ca.Group.Peers) > len(oca.Group.Peers) || ca.Group.Desired != nil) && o.IsLeader() && n != nil
 			// Signal that this is an update
 			if ca.Reply != _EMPTY_ {
 				isConfigUpdate = true
@@ -6239,7 +6420,7 @@ func (js *jetStream) processClusterCreateConsumer(oca, ca *consumerAssignment, s
 			o.setCreatedTime(ca.Created)
 		} else {
 			// Check for scale down to 1..
-			if node != nil && len(rg.Peers) == 1 {
+			if node != nil && len(rg.Peers) == 1 && rg.Desired == nil {
 				o.clearNode()
 				o.stopMonitoring()
 				// Need to clear from rg too.
@@ -6861,6 +7042,12 @@ func (o *consumer) isMigrating() bool {
 	// During migration we will always be R>1, even when we start R1.
 	// So if we do not have a group or node, we know we are not migrating.
 	if ca == nil || ca.Group == nil || ca.Group.node == nil {
+		return false
+	}
+	// Desired state is driven by a v2.15 meta leader, which reconciles the group itself.
+	// We can't complete that migration, and the peer count deliberately lags the replica
+	// count while it's pending, so the legacy signature below would fire and never converge.
+	if ca.Group.Desired != nil {
 		return false
 	}
 	// The sign of migration is if our group peer count != configured replica count.
@@ -7679,6 +7866,9 @@ func (js *jetStream) processLeaderChange(isLeader bool, term uint64) {
 
 // Lock should be held.
 func (cc *jetStreamCluster) remapStreamAssignment(sa *streamAssignment, removePeer string) bool {
+	// We're reassigning the peers ourselves, so any desired state is moot.
+	sa.Group.Desired = nil
+
 	// Invoke placement algo passing RG peers that stay (existing) and the peer that is being removed (ignore)
 	var retain, ignore []string
 	for _, v := range sa.Group.Peers {
@@ -8465,12 +8655,26 @@ func (s *Server) jsClusteredStreamUpdateRequest(ci *ClientInfo, acc *Account, su
 	// Make copy so to not change original.
 	rg := osa.copyGroup().Group
 
+	// We don't act on desired state recorded by a newer server, so the stream is still at
+	// its origin while the config already holds the target. Compare against where it
+	// actually is, or asking for the target it's reported to have would be a no-op, and
+	// drop the desired state so we reconcile the group ourselves.
+	oldReplicas, oldPlacement := osa.Config.Replicas, osa.Config.Placement
+	if d := rg.Desired; d != nil {
+		// The peer set is how far the migration got, not necessarily the origin.
+		oldReplicas = len(rg.Peers)
+		if d.Origin != nil {
+			oldPlacement = d.Origin.Placement
+		}
+		rg.Desired = nil
+	}
+
 	// Check for a move request.
 	var isMoveRequest, isMoveCancel bool
 	if lPeerSet := len(peerSet); lPeerSet > 0 {
 		isMoveRequest = true
 		// check if this is a cancellation
-		if lPeerSet == osa.Config.Replicas && lPeerSet <= len(rg.Peers) {
+		if lPeerSet == oldReplicas && lPeerSet <= len(rg.Peers) {
 			isMoveCancel = true
 			// can only be a cancellation if the peer sets overlap as expected
 			for i := 0; i < lPeerSet; i++ {
@@ -8481,17 +8685,17 @@ func (s *Server) jsClusteredStreamUpdateRequest(ci *ClientInfo, acc *Account, su
 			}
 		}
 	} else {
-		isMoveRequest = newCfg.Placement != nil && !reflect.DeepEqual(osa.Config.Placement, newCfg.Placement)
+		isMoveRequest = newCfg.Placement != nil && !reflect.DeepEqual(oldPlacement, newCfg.Placement)
 	}
 
 	// Check for replica changes.
-	isReplicaChange := newCfg.Replicas != osa.Config.Replicas
+	isReplicaChange := newCfg.Replicas != oldReplicas
 
 	// We stage consumer updates and do them after the stream update.
 	var consumers []*consumerAssignment
 
 	// Check if this is a move request, but no cancellation, and we are already moving this stream.
-	if isMoveRequest && !isMoveCancel && osa.Config.Replicas != len(rg.Peers) {
+	if isMoveRequest && !isMoveCancel && oldReplicas != len(rg.Peers) {
 		// obtain stats to include in error message
 		msg := _EMPTY_
 		if s.allPeersOffline(rg) {
@@ -8562,7 +8766,7 @@ func (s *Server) jsClusteredStreamUpdateRequest(ci *ClientInfo, acc *Account, su
 				return
 			}
 			// Single nodes are not recorded by the NRG layer so we can rename.
-			if len(peers) == 1 || osa.Config.Replicas == 1 {
+			if len(peers) == 1 || oldReplicas == 1 {
 				rg.Name = groupNameForStream(peers, rg.Storage)
 			}
 			if len(rg.Peers) == 1 {
@@ -9795,6 +9999,12 @@ func (s *Server) jsClusteredConsumerRequest(ci *ClientInfo, acc *Account, subjec
 		rBefore := nca.Config.replicas(sa.Config)
 		rAfter := cfg.replicas(sa.Config)
 
+		// Not acting on desired state, so the consumer is still at its own peer set.
+		if nca.Group.Desired != nil {
+			rBefore = len(nca.Group.Peers)
+			nca.Group.Desired = nil
+		}
+
 		var curLeader string
 		if rBefore != rAfter {
 			// We are modifying nodes here. We want to do our best to preserve the current leader.
@@ -10974,12 +11184,17 @@ func (js *jetStream) clusterInfo(rg *raftGroup) *ClusterInfo {
 	}
 	js.mu.RLock()
 	s := js.srv
-	if rg == nil || rg.node == nil {
+	if rg == nil || (rg.node == nil && rg.Desired == nil) {
 		js.mu.RUnlock()
 		return &ClusterInfo{
 			Name:   s.cachedClusterName(),
 			Leader: s.Name(),
 		}
+	}
+	// Use v2.15-compatible cluster info if desired state is known.
+	if rg.Desired != nil {
+		js.mu.RUnlock()
+		return js.clusterInfoDesired(rg)
 	}
 
 	// Capture what we need and let go of the lock to ensure that
@@ -11040,6 +11255,157 @@ func (js *jetStream) clusterInfo(rg *raftGroup) *ClusterInfo {
 			}
 			ci.Replicas = append(ci.Replicas, pi)
 		}
+	}
+	// Order the result based on the name so that we get something consistent
+	// when doing repeated stream info in the CLI, etc...
+	slices.SortFunc(ci.Replicas, func(i, j *PeerInfo) int { return cmp.Compare(i.Name, j.Name) })
+	return ci
+}
+
+// clusterInfoDesired returns v2.15-compatible cluster info based on desired state existing.
+func (js *jetStream) clusterInfoDesired(rg *raftGroup) *ClusterInfo {
+	if js == nil {
+		return nil
+	}
+	js.mu.RLock()
+	s := js.srv
+	if rg == nil || (rg.node == nil && rg.Desired == nil) {
+		js.mu.RUnlock()
+		return &ClusterInfo{
+			Name:   s.cachedClusterName(),
+			Leader: s.Name(),
+		}
+	}
+	// Capture what we need and let go of the lock to ensure that
+	// contention on Raft locks can't happen while holding JS lock.
+	n := rg.node
+	rgName := rg.Name
+	rgPeers := copyStrings(rg.Peers)
+	var (
+		desired      *DesiredClusterInfo
+		desiredPeers []string
+	)
+	if d := rg.Desired; d != nil {
+		desired = &DesiredClusterInfo{
+			Created: d.Created,
+			Name:    d.Cluster,
+			Status: &DesiredClusterInfoStatus{
+				Type:        MigrationStatusBlocked,
+				Description: "upgrade to v2.15 or higher",
+			},
+		}
+		// If desired state can be rolled back, include what can be rolled back to.
+		// Must copy, the origin is owned by the meta layer but reported without its lock.
+		if d.Origin != nil {
+			desired.Origin = &DesiredClusterInfoOrigin{
+				Replicas:  d.Origin.Replicas,
+				Placement: d.Origin.Placement.clone(),
+			}
+			if r := d.Origin.Retention; r != nil {
+				retention := *r
+				desired.Origin.Retention = &retention
+			}
+		}
+		// Don't populate peers if scaling down, since the peers aren't the desired set, it's
+		// the set that the group leader selects the peers to scale down to from.
+		if !d.ScaleDown {
+			desiredPeers = copyStrings(d.Peers)
+		}
+	}
+	// The group leader can have a status before desired state exists, most importantly
+	// when it's still requesting it from the meta leader. Report that on its own.
+	if status := rg.migration; status != nil {
+		if desired == nil {
+			desired = &DesiredClusterInfo{}
+		}
+		cp := *status
+		desired.Status = &cp
+	}
+	js.mu.RUnlock()
+
+	ci := &ClusterInfo{
+		Name:      s.cachedClusterName(),
+		RaftGroup: rgName,
+	}
+
+	id := s.Node()
+	if n != nil {
+		ci.Leader = s.serverNameForNode(n.GroupLeader())
+		ci.LeaderSince = n.LeaderSince()
+		ci.SystemAcc = n.IsSystemAccount()
+		ci.TrafficAcc = n.GetTrafficAccountName()
+
+		// If we are leaderless, do not suppress putting us in the peer list.
+		if ci.Leader == _EMPTY_ {
+			id = _EMPTY_
+		}
+
+		now := time.Now()
+		for _, rp := range n.Peers() {
+			// The peer is either in the actual or desired peer set.
+			if rp.ID != id && (slices.Contains(rgPeers, rp.ID) || slices.Contains(desiredPeers, rp.ID)) {
+				var lastSeen time.Duration
+				if now.After(rp.Last) && !rp.Last.IsZero() {
+					lastSeen = now.Sub(rp.Last)
+				}
+				current := rp.Current
+				if current && lastSeen > lostQuorumInterval {
+					current = false
+				}
+				// Create a peer info with common settings if the peer has not been seen
+				// yet (which can happen after the whole cluster is stopped and only some
+				// of the nodes are restarted).
+				pi := &PeerInfo{
+					Current: current,
+					Offline: true,
+					Active:  lastSeen,
+					Lag:     rp.Lag,
+					Peer:    rp.ID,
+				}
+				// If node is found, complete/update the settings.
+				if sir, ok := s.nodeToInfo.Load(rp.ID); ok && sir != nil {
+					si := sir.(nodeInfo)
+					pi.Name, pi.Offline, pi.cluster = si.name, si.offline, si.cluster
+				} else {
+					// If not, then add a name that indicates that the server name
+					// is unknown at this time, and clear the lag since it is misleading
+					// (the node may not have that much lag).
+					// Note: We return now the Peer ID in PeerInfo, so the "(peerID: %s)"
+					// would technically not be required, but keeping it for now.
+					pi.Name, pi.Lag = fmt.Sprintf("Server name unknown at this time (peerID: %s)", rp.ID), 0
+				}
+				ci.Replicas = append(ci.Replicas, pi)
+			}
+		}
+	}
+
+	generatePeer := func(peer string) *DesiredPeerInfo {
+		pi := &DesiredPeerInfo{Offline: true, Peer: peer}
+		if sir, ok := s.nodeToInfo.Load(peer); ok && sir != nil {
+			si := sir.(nodeInfo)
+			pi.Name, pi.Offline = si.name, si.offline
+		} else {
+			pi.Name = fmt.Sprintf("Server name unknown at this time (peerID: %s)", peer)
+		}
+		return pi
+	}
+	if desired != nil {
+		ci.Desired = desired
+		for _, peer := range desiredPeers {
+			ci.Desired.Replicas = append(ci.Desired.Replicas, generatePeer(peer))
+		}
+	}
+	for _, peer := range rgPeers {
+		// Skip if the peer is already present.
+		if peer == id || slices.ContainsFunc(ci.Replicas, func(info *PeerInfo) bool { return info.Peer == peer }) {
+			continue
+		}
+		pi := generatePeer(peer)
+		p := &PeerInfo{Name: pi.Name, Offline: pi.Offline, Peer: pi.Peer}
+		// We know the peer is part of the assignment, but if we have a Raft node it
+		// wasn't reported as one of its peers, so it hasn't joined the group (yet).
+		p.Pending = n != nil
+		ci.Replicas = append(ci.Replicas, p)
 	}
 	// Order the result based on the name so that we get something consistent
 	// when doing repeated stream info in the CLI, etc...
@@ -11133,6 +11499,9 @@ func (mset *stream) processClusterStreamInfoRequest(reply string) {
 	if !isLeader {
 		time.Sleep(500 * time.Millisecond)
 	}
+
+	// Report the config as requested, the stream can still be running at its origin.
+	config = js.targetStreamConfig(mset, config)
 
 	si := &StreamInfo{
 		Created:   mset.createdTime(),

--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -8359,7 +8359,7 @@ func TestJetStreamClusterConsumerHealthCheckMustNotRecreate(t *testing.T) {
 	// The RAFT node should be closed. Checking health must not change that.
 	// Simulates a race condition where we're shutting down.
 	checkNodeIsClosed(sjs, ca)
-	require_Error(t, sjs.isConsumerHealthy(mset, "CONSUMER", ca), errors.New("monitor goroutine not running"))
+	require_Error(t, sjs.isConsumerHealthy(mset, sa, "CONSUMER", ca), errors.New("monitor goroutine not running"))
 	checkNodeIsClosed(sjs, ca)
 
 	// We create a new RAFT group, the health check should detect this skew.
@@ -8369,7 +8369,7 @@ func TestJetStreamClusterConsumerHealthCheckMustNotRecreate(t *testing.T) {
 	// We set creating to now, since previously it would delete all data but NOT restart if created within <10s.
 	ca.Created = time.Now()
 	sjs.mu.Unlock()
-	require_Error(t, sjs.isConsumerHealthy(mset, "CONSUMER", ca), errors.New("cluster node skew detected"))
+	require_Error(t, sjs.isConsumerHealthy(mset, sa, "CONSUMER", ca), errors.New("cluster node skew detected"))
 
 	err = js.DeleteConsumer("TEST", "CONSUMER")
 	require_NoError(t, err)
@@ -8389,7 +8389,7 @@ func TestJetStreamClusterConsumerHealthCheckMustNotRecreate(t *testing.T) {
 
 	// The underlying consumer has been deleted. Checking health must not recreate the consumer.
 	checkNodeIsClosed(sjs, ca)
-	require_Error(t, sjs.isConsumerHealthy(mset, "CONSUMER", ca), errors.New("consumer not found"))
+	require_Error(t, sjs.isConsumerHealthy(mset, sa, "CONSUMER", ca), errors.New("consumer not found"))
 	checkNodeIsClosed(sjs, ca)
 }
 
@@ -8469,7 +8469,7 @@ func TestJetStreamClusterConsumerHealthCheckMustNotDeleteEarly(t *testing.T) {
 	// The health check gets the Raft node of the assignment and checks it against the
 	// Raft node of the consumer. We simulate a race condition where the consumer's Raft node
 	// is not yet initialized. The health check MUST NOT delete the node.
-	sjs.isConsumerHealthy(mset, "CONSUMER", ca)
+	sjs.isConsumerHealthy(mset, nil, "CONSUMER", ca)
 	require_Equal(t, node.State(), Follower)
 }
 
@@ -8558,7 +8558,7 @@ func TestJetStreamClusterConsumerHealthCheckOnlyReportsSkew(t *testing.T) {
 	// Raft node of the consumer. We simulate a race condition where the assignment's Raft node
 	// is re-newed, but the consumer's node is still the old instance.
 	// The health check MUST NOT delete the node.
-	require_Error(t, sjs.isConsumerHealthy(mset, "CONSUMER", ca), errors.New("cluster node skew detected"))
+	require_Error(t, sjs.isConsumerHealthy(mset, nil, "CONSUMER", ca), errors.New("cluster node skew detected"))
 	require_NotEqual(t, node.State(), Closed)
 }
 
@@ -8598,14 +8598,14 @@ func TestJetStreamClusterConsumerHealthCheckDeleted(t *testing.T) {
 	// The health check gathers all assignments and does checking after.
 	// If the consumer was deleted in the meantime, it should not report an error.
 	require_NoError(t, js.DeleteConsumer("TEST", "CONSUMER"))
-	require_Error(t, sjs.isConsumerHealthy(mset, "CONSUMER", ca), errors.New("consumer not found"))
+	require_Error(t, sjs.isConsumerHealthy(mset, nil, "CONSUMER", ca), errors.New("consumer not found"))
 
 	// The health check could run earlier than we're able to create the consumer.
 	// In that case, wait before erroring.
 	sjs.mu.Lock()
 	ca.Created = time.Now()
 	sjs.mu.Unlock()
-	require_NoError(t, sjs.isConsumerHealthy(mset, "CONSUMER", ca))
+	require_NoError(t, sjs.isConsumerHealthy(mset, nil, "CONSUMER", ca))
 }
 
 func TestJetStreamClusterStreamHealthCheckSurfacesAssignmentErr(t *testing.T) {
@@ -8679,7 +8679,7 @@ func TestJetStreamClusterConsumerHealthCheckSurfacesAssignmentErr(t *testing.T) 
 	require_True(t, ca != nil)
 
 	// Baseline: healthy.
-	require_NoError(t, sjs.isConsumerHealthy(mset, "CONSUMER", ca))
+	require_NoError(t, sjs.isConsumerHealthy(mset, nil, "CONSUMER", ca))
 
 	// Persisted assignment-level error must surface via the health check.
 	wantErr := errors.New("synthetic consumer assignment failure")
@@ -8687,7 +8687,7 @@ func TestJetStreamClusterConsumerHealthCheckSurfacesAssignmentErr(t *testing.T) 
 	ca.err = wantErr
 	sjs.mu.Unlock()
 
-	err = sjs.isConsumerHealthy(mset, "CONSUMER", ca)
+	err = sjs.isConsumerHealthy(mset, nil, "CONSUMER", ca)
 	require_Error(t, err)
 	require_Contains(t, err.Error(), wantErr.Error())
 
@@ -8695,13 +8695,13 @@ func TestJetStreamClusterConsumerHealthCheckSurfacesAssignmentErr(t *testing.T) 
 	sjs.mu.Lock()
 	ca.err = nil
 	sjs.mu.Unlock()
-	require_NoError(t, sjs.isConsumerHealthy(mset, "CONSUMER", ca))
+	require_NoError(t, sjs.isConsumerHealthy(mset, nil, "CONSUMER", ca))
 }
 
 func TestJetStreamClusterConsumerHealthCheckStreamMissingNoLockLeak(t *testing.T) {
 	js := &jetStream{}
 	ca := &consumerAssignment{}
-	err := js.isConsumerHealthy(nil, "consumer", ca)
+	err := js.isConsumerHealthy(nil, nil, "consumer", ca)
 	require_Error(t, err, errors.New("stream missing"))
 
 	// The JS lock must have been released. Attempt to acquire the write lock
@@ -9001,7 +9001,7 @@ func TestJetStreamClusterConsumerHealthCheckRecoversAfterSuccessfulUpdate(t *tes
 	sjs.mu.Lock()
 	ca.err = wantErr
 	sjs.mu.Unlock()
-	err = sjs.isConsumerHealthy(mset, "CONSUMER", ca)
+	err = sjs.isConsumerHealthy(mset, nil, "CONSUMER", ca)
 	require_Error(t, err)
 	require_Contains(t, err.Error(), wantErr.Error())
 
@@ -9022,7 +9022,7 @@ func TestJetStreamClusterConsumerHealthCheckRecoversAfterSuccessfulUpdate(t *tes
 	sjs.mu.RUnlock()
 	require_True(t, cur != nil)
 	require_NoError(t, gotErr)
-	require_NoError(t, sjs.isConsumerHealthy(mset, "CONSUMER", cur))
+	require_NoError(t, sjs.isConsumerHealthy(mset, nil, "CONSUMER", cur))
 }
 
 func TestJetStreamClusterRespectConsumerStartSeq(t *testing.T) {

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -11989,3 +11989,685 @@ func TestJetStreamClusterNoResetClusteredStateAfterStreamRemap(t *testing.T) {
 		mset.mu.Unlock()
 	})
 }
+
+// Mimics a v2.15 server (the meta leader) recording desired state to scale an R1
+// stream up to R3. This server is only expected to persist that desired state and
+// expose it, the group leader acting on it lands in a later release.
+func TestJetStreamClusterDesiredStateFromNewerServerScaleUp(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Replicas: 1,
+	})
+	require_NoError(t, err)
+
+	ml := c.leader()
+	mjs, cc := ml.getJetStreamCluster()
+
+	// The peer set a v2.15 meta leader would have selected, with the origin peer first.
+	mjs.mu.RLock()
+	osa := mjs.streamAssignment(globalAccountName, "TEST")
+	require_NotNil(t, osa)
+	require_Len(t, len(osa.Group.Peers), 1)
+	origin := osa.Group.Peers[0]
+	peers := []string{origin}
+	for _, s := range c.servers {
+		if id := s.Node(); id != origin {
+			peers = append(peers, id)
+		}
+	}
+	// Build the assignment as a v2.15 meta leader would: the group stays at its
+	// origin peer set and only the desired state holds the target.
+	nsa := osa.copyGroup()
+	// Must not mutate the live assignment's config, it's shared by the clone.
+	nsa.Config = osa.Config.clone()
+	nsa.Config.Replicas = 3
+	nsa.Group.Name = groupNameForStream(peers, nsa.Group.Storage)
+	nsa.Group.Desired = &desiredRaftGroup{
+		Created:   time.Now().UTC(),
+		ID:        "DESIRED",
+		Peers:     peers,
+		Cluster:   osa.Group.Cluster,
+		Preferred: origin,
+		Origin: &desiredRaftGroupOrigin{
+			Peers:     copyStrings(osa.Group.Peers),
+			Cluster:   osa.Group.Cluster,
+			Replicas:  osa.Config.Replicas,
+			Placement: osa.Config.Placement.clone(),
+		},
+	}
+	desired := nsa.Group.Desired
+	oGroupName := osa.Group.Name
+	mjs.mu.RUnlock()
+
+	require_NoError(t, cc.meta.Propose(cc.term, encodeUpdateStreamAssignment(nsa)))
+
+	// Every server must have persisted the desired state onto its local assignment,
+	// without the assignment itself having moved toward it.
+	checkFor(t, 5*time.Second, 100*time.Millisecond, func() error {
+		for _, s := range c.servers {
+			sjs := s.getJetStream()
+			sjs.mu.RLock()
+			sa := sjs.streamAssignment(globalAccountName, "TEST")
+			var (
+				cfg *StreamConfig
+				rg  *raftGroup
+				d   *desiredRaftGroup
+			)
+			if sa != nil {
+				cfg, rg = sa.Config, sa.Group
+				d = rg.Desired
+			}
+			sjs.mu.RUnlock()
+
+			if sa == nil {
+				return fmt.Errorf("no stream assignment on %s", s)
+			}
+			if d == nil {
+				return fmt.Errorf("desired state not persisted on %s", s)
+			}
+			if d.ID != desired.ID {
+				return fmt.Errorf("desired ID on %s, got %q, want %q", s, d.ID, desired.ID)
+			}
+			if !slices.Equal(d.Peers, peers) {
+				return fmt.Errorf("desired peers on %s, got %+v, want %+v", s, d.Peers, peers)
+			}
+			if d.Preferred != origin {
+				return fmt.Errorf("desired preferred on %s, got %q, want %q", s, d.Preferred, origin)
+			}
+			if d.Origin == nil {
+				return fmt.Errorf("desired origin not persisted on %s", s)
+			}
+			if d.Origin.Replicas != 1 || !slices.Equal(d.Origin.Peers, []string{origin}) {
+				return fmt.Errorf("desired origin on %s, got %d/%+v, want 1/%+v",
+					s, d.Origin.Replicas, d.Origin.Peers, []string{origin})
+			}
+			// The config is the requested target, while the group must be untouched:
+			// this server persists desired state, it doesn't act on it.
+			if cfg.Replicas != 3 {
+				return fmt.Errorf("config replicas on %s, got %d, want 3", s, cfg.Replicas)
+			}
+			if !slices.Equal(rg.Peers, []string{origin}) {
+				return fmt.Errorf("group peers on %s, got %+v, want %+v", s, rg.Peers, []string{origin})
+			}
+			if rg.Name == oGroupName {
+				return fmt.Errorf("group not renamed on %s, still %q", s, rg.Name)
+			}
+			// The group keeps a node while the desired state is pending, even at a single
+			// peer, so the Raft term a newer server resumes the migration from survives.
+			// Only the peers the group is actually at, we don't act on the desired set.
+			if isOrigin := s.Node() == origin; isOrigin != (rg.node != nil) {
+				if isOrigin {
+					return fmt.Errorf("no raft node on origin %s while desired state is pending", s)
+				}
+				return fmt.Errorf("raft node created on %s, must not act on the desired peer set", s)
+			}
+		}
+		return nil
+	})
+
+	// The group has a node now that a desired state is pending, so wait for it to have
+	// settled on a leader before asking, or the answering peer is not suppressed below.
+	c.waitOnStreamLeader(globalAccountName, "TEST")
+
+	// Stream info must expose the desired state as well.
+	var resp JSApiStreamInfoResponse
+	msg, err := nc.Request(fmt.Sprintf(JSApiStreamInfoT, "TEST"), nil, time.Second)
+	require_NoError(t, err)
+	require_NoError(t, json.Unmarshal(msg.Data, &resp))
+	require_True(t, resp.Error == nil)
+	require_NotNil(t, resp.StreamInfo)
+
+	ci := resp.StreamInfo.Cluster
+	require_NotNil(t, ci)
+	// Still only the origin peer, and it's the server answering, so it's not listed.
+	require_Len(t, len(ci.Replicas), 0)
+	require_NotNil(t, ci.Desired)
+	require_Equal(t, ci.Desired.Name, desired.Cluster)
+	require_True(t, ci.Desired.Created.Equal(desired.Created))
+	require_NotNil(t, ci.Desired.Origin)
+	require_Equal(t, ci.Desired.Origin.Replicas, 1)
+
+	// The desired replicas are the full target set, named after the servers.
+	var names []string
+	for _, pi := range ci.Desired.Replicas {
+		names = append(names, pi.Name)
+	}
+	slices.Sort(names)
+	var expected []string
+	for _, s := range c.servers {
+		expected = append(expected, s.Name())
+	}
+	slices.Sort(expected)
+	require_True(t, slices.Equal(names, expected))
+}
+
+func TestJetStreamClusterDesiredStateRetentionReportedInStreamInfo(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:      "TEST",
+		Subjects:  []string{"foo"},
+		Replicas:  3,
+		Retention: nats.LimitsPolicy,
+	})
+	require_NoError(t, err)
+
+	ml := c.leader()
+	mjs, cc := ml.getJetStreamCluster()
+
+	// Build the assignment as a v2.15 meta leader would for a Limits->Interest
+	// retention change: the config holds the requested target, while the origin
+	// records what the stream must keep running at until the change is reached.
+	mjs.mu.RLock()
+	osa := mjs.streamAssignment(globalAccountName, "TEST")
+	require_NotNil(t, osa)
+	limits := LimitsPolicy
+	nsa := osa.copyGroup()
+	// Must not mutate the live assignment's config, it's shared by the clone.
+	nsa.Config = osa.Config.clone()
+	nsa.Config.Retention = InterestPolicy
+	nsa.Group.Desired = &desiredRaftGroup{
+		Created: time.Now().UTC(),
+		ID:      "DESIRED",
+		Peers:   copyStrings(osa.Group.Peers),
+		Cluster: osa.Group.Cluster,
+		Origin: &desiredRaftGroupOrigin{
+			Peers:     copyStrings(osa.Group.Peers),
+			Cluster:   osa.Group.Cluster,
+			Replicas:  osa.Config.Replicas,
+			Placement: osa.Config.Placement.clone(),
+			Retention: &limits,
+		},
+	}
+	mjs.mu.RUnlock()
+
+	require_NoError(t, cc.meta.Propose(cc.term, encodeUpdateStreamAssignment(nsa)))
+
+	// Every server must hold the requested retention on its assignment, while the
+	// stream itself keeps running at the origin retention until the change is reached.
+	checkFor(t, 5*time.Second, 100*time.Millisecond, func() error {
+		for _, s := range c.servers {
+			sjs := s.getJetStream()
+			sjs.mu.RLock()
+			sa := sjs.streamAssignment(globalAccountName, "TEST")
+			var cfg *StreamConfig
+			if sa != nil {
+				cfg = sa.Config
+			}
+			sjs.mu.RUnlock()
+
+			if sa == nil {
+				return fmt.Errorf("no stream assignment on %s", s)
+			}
+			if cfg.Retention != InterestPolicy {
+				return fmt.Errorf("assignment retention on %s, got %v, want %v", s, cfg.Retention, InterestPolicy)
+			}
+			mset, err := s.globalAccount().lookupStream("TEST")
+			if err != nil {
+				return err
+			}
+			if r := mset.config().Retention; r != LimitsPolicy {
+				return fmt.Errorf("running retention on %s, got %v, want %v", s, r, LimitsPolicy)
+			}
+		}
+		return nil
+	})
+
+	// Stream info must report the retention as requested, not the origin the
+	// stream is still running at.
+	var resp JSApiStreamInfoResponse
+	msg, err := nc.Request(fmt.Sprintf(JSApiStreamInfoT, "TEST"), nil, time.Second)
+	require_NoError(t, err)
+	require_NoError(t, json.Unmarshal(msg.Data, &resp))
+	require_True(t, resp.Error == nil)
+	require_NotNil(t, resp.StreamInfo)
+	require_Equal(t, resp.StreamInfo.Config.Retention, InterestPolicy)
+	require_NotNil(t, resp.StreamInfo.Cluster)
+	require_NotNil(t, resp.StreamInfo.Cluster.Desired)
+	require_NotNil(t, resp.StreamInfo.Cluster.Desired.Origin)
+	require_NotNil(t, resp.StreamInfo.Cluster.Desired.Origin.Retention)
+	require_Equal(t, *resp.StreamInfo.Cluster.Desired.Origin.Retention, LimitsPolicy)
+
+	// The same must hold for the monitoring endpoint, which reports the config
+	// alongside the cluster info that already exposes the desired state.
+	for _, s := range c.servers {
+		jsz, err := s.Jsz(&JSzOptions{Accounts: true, Streams: true, Config: true})
+		require_NoError(t, err)
+		for _, ad := range jsz.AccountDetails {
+			for _, sd := range ad.Streams {
+				if sd.Name != "TEST" {
+					continue
+				}
+				require_NotNil(t, sd.Config)
+				require_Equal(t, sd.Config.Retention, InterestPolicy)
+				require_NotNil(t, sd.Cluster)
+				require_NotNil(t, sd.Cluster.Desired)
+				require_NotNil(t, sd.Cluster.Desired.Origin)
+				require_NotNil(t, sd.Cluster.Desired.Origin.Retention)
+				require_Equal(t, *sd.Cluster.Desired.Origin.Retention, LimitsPolicy)
+			}
+		}
+	}
+}
+
+// A v2.15 meta leader records the desired state on the stream first, its consumers
+// are only mapped onto the new peer set later, as part of the migration. This server
+// does not act on desired state, so both the stream and its consumers keep running at
+// their origin, without a Raft node, until a v2.15 server drives the migration. They
+// must not be reported unhealthy for that.
+func TestJetStreamClusterConsumerHealthCheckUnmappedDuringMigration(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Replicas: 1,
+	})
+	require_NoError(t, err)
+	// No explicit replica count, so it inherits the stream's.
+	_, err = js.AddConsumer("TEST", &nats.ConsumerConfig{
+		Durable:   "CONSUMER",
+		AckPolicy: nats.AckExplicitPolicy,
+	})
+	require_NoError(t, err)
+
+	// The single server hosting the R1 stream.
+	var s *Server
+	for _, cs := range c.servers {
+		if _, err := cs.globalAccount().lookupStream("TEST"); err == nil {
+			s = cs
+			break
+		}
+	}
+	require_NotNil(t, s)
+	acc := s.globalAccount()
+	mset, err := acc.lookupStream("TEST")
+	require_NoError(t, err)
+
+	sjs := s.getJetStream()
+	sjs.mu.RLock()
+	sa := sjs.streamAssignment(globalAccountName, "TEST")
+	ca := sjs.consumerAssignment(globalAccountName, "TEST", "CONSUMER")
+	sjs.mu.RUnlock()
+	require_NotNil(t, sa)
+	require_NotNil(t, ca)
+
+	// Healthy to start with.
+	require_NoError(t, sjs.isStreamHealthy(acc, sa))
+	require_NoError(t, sjs.isConsumerHealthy(mset, sa, "CONSUMER", ca))
+
+	// Record desired state to scale up to R3, as a v2.15 meta leader would: the config
+	// holds the target while the group stays at its origin. The consumer is left
+	// untouched, it is only mapped onto the new peers later in the migration.
+	peers := []string{sa.Group.Peers[0]}
+	for _, cs := range c.servers {
+		if id := cs.Node(); id != sa.Group.Peers[0] {
+			peers = append(peers, id)
+		}
+	}
+	sjs.mu.Lock()
+	sa.Config.Replicas = 3
+	sa.Group.Desired = &desiredRaftGroup{
+		Created: time.Now().UTC(),
+		ID:      "DESIRED",
+		Peers:   peers,
+		Cluster: sa.Group.Cluster,
+		Origin: &desiredRaftGroupOrigin{
+			Peers:    copyStrings(sa.Group.Peers),
+			Cluster:  sa.Group.Cluster,
+			Replicas: 1,
+		},
+	}
+	sjs.mu.Unlock()
+	// The stream runs at its origin, but its replica count is the target already.
+	mset.cfgMu.Lock()
+	mset.cfg.Replicas = 3
+	mset.cfgMu.Unlock()
+
+	// Neither the stream nor the consumer moved: still on the origin peer, with no
+	// Raft node, while the replica count they are judged by is the target.
+	sjs.mu.RLock()
+	require_Len(t, len(sa.Group.Peers), 1)
+	require_True(t, sa.Group.node == nil)
+	require_Len(t, len(ca.Group.Peers), 1)
+	require_True(t, ca.Group.Desired == nil)
+	require_True(t, ca.Group.node == nil)
+	sjs.mu.RUnlock()
+	rc, err := mset.lookupConsumer("CONSUMER").replica()
+	require_NoError(t, err)
+	require_Equal(t, rc, 3)
+
+	// They must not be reported unhealthy for that.
+	require_NoError(t, sjs.isStreamHealthy(acc, sa))
+	require_NoError(t, sjs.isConsumerHealthy(mset, sa, "CONSUMER", ca))
+
+	// The stream can scale up while the consumer remap stalls, which is the normal
+	// case here: we don't drive the migration, so the consumer stays behind until a
+	// v2.15 server maps it. The group is no longer R1, but the consumer still is.
+	sjs.mu.Lock()
+	sa.Group.Peers = copyStrings(peers)
+	sjs.mu.Unlock()
+	sjs.mu.RLock()
+	require_Len(t, len(ca.Group.Peers), 1)
+	require_True(t, ca.Group.node == nil)
+	sjs.mu.RUnlock()
+	require_NoError(t, sjs.isConsumerHealthy(mset, sa, "CONSUMER", ca))
+	sjs.mu.Lock()
+	sa.Group.Peers = copyStrings(sa.Group.Desired.Origin.Peers)
+	sjs.mu.Unlock()
+
+	// Without the desired state there is nothing explaining the missing node, and both
+	// are reported. Confirms the checks above are not passing for some other reason.
+	sjs.mu.Lock()
+	desired := sa.Group.Desired
+	sa.Group.Desired = nil
+	sjs.mu.Unlock()
+	require_Error(t, sjs.isStreamHealthy(acc, sa), errors.New("group node missing"))
+	require_Error(t, sjs.isConsumerHealthy(mset, sa, "CONSUMER", ca), errors.New("group node missing"))
+	sjs.mu.Lock()
+	sa.Group.Desired = desired
+	sjs.mu.Unlock()
+	require_NoError(t, sjs.isStreamHealthy(acc, sa))
+	require_NoError(t, sjs.isConsumerHealthy(mset, sa, "CONSUMER", ca))
+}
+
+// A stream left with desired state by a newer server must not stay frozen in between its
+// origin and target. The user asks for the config they were already reported to have,
+// which must not be a no-op: the scale up happens and the retention is released.
+func TestJetStreamClusterDesiredStateResolvedOnStreamUpdate(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:      "TEST",
+		Subjects:  []string{"foo"},
+		Replicas:  1,
+		Retention: nats.LimitsPolicy,
+	})
+	require_NoError(t, err)
+	// No explicit replica count, so it follows the stream.
+	_, err = js.AddConsumer("TEST", &nats.ConsumerConfig{
+		Durable:   "CONSUMER",
+		AckPolicy: nats.AckExplicitPolicy,
+	})
+	require_NoError(t, err)
+
+	for range 10 {
+		_, err = js.Publish("foo", []byte("OK"))
+		require_NoError(t, err)
+	}
+
+	ml := c.leader()
+	mjs, cc := ml.getJetStreamCluster()
+
+	// Record desired state as a newer meta leader would: the config holds the target
+	// while the group and the stream stay at their origin.
+	mjs.mu.RLock()
+	osa := mjs.streamAssignment(globalAccountName, "TEST")
+	require_NotNil(t, osa)
+	require_Len(t, len(osa.Group.Peers), 1)
+	origin, limits := osa.Group.Peers[0], LimitsPolicy
+	peers := []string{origin}
+	for _, s := range c.servers {
+		if id := s.Node(); id != origin {
+			peers = append(peers, id)
+		}
+	}
+	nsa := osa.copyGroup()
+	// Must not mutate the live assignment's config, it's shared by the clone.
+	nsa.Config = osa.Config.clone()
+	nsa.Config.Replicas, nsa.Config.Retention = 3, InterestPolicy
+	nsa.Group.Name = groupNameForStream(peers, nsa.Group.Storage)
+	nsa.Group.Desired = &desiredRaftGroup{
+		Created: time.Now().UTC(),
+		ID:      "DESIRED",
+		Peers:   peers,
+		Cluster: osa.Group.Cluster,
+		Origin: &desiredRaftGroupOrigin{
+			Peers:     copyStrings(osa.Group.Peers),
+			Cluster:   osa.Group.Cluster,
+			Replicas:  osa.Config.Replicas,
+			Retention: &limits,
+		},
+	}
+	mjs.mu.RUnlock()
+
+	require_NoError(t, cc.meta.Propose(cc.term, encodeUpdateStreamAssignment(nsa)))
+
+	// Confirm we did not act on it.
+	checkFor(t, 5*time.Second, 100*time.Millisecond, func() error {
+		for _, s := range c.servers {
+			sjs := s.getJetStream()
+			sjs.mu.RLock()
+			sa := sjs.streamAssignment(globalAccountName, "TEST")
+			var frozen bool
+			if sa != nil && sa.Group != nil {
+				frozen = sa.Group.Desired != nil && len(sa.Group.Peers) == 1
+			}
+			sjs.mu.RUnlock()
+			if !frozen {
+				return fmt.Errorf("desired state not pending on %s", s)
+			}
+			if mset, err := s.globalAccount().lookupStream("TEST"); err == nil {
+				if r := mset.config().Retention; r != LimitsPolicy {
+					return fmt.Errorf("running retention on %s, got %v", s, r)
+				}
+			}
+		}
+		return nil
+	})
+
+	// Ask for the config we're reported to have.
+	si, err := js.UpdateStream(&nats.StreamConfig{
+		Name:      "TEST",
+		Subjects:  []string{"foo"},
+		Replicas:  3,
+		Retention: nats.InterestPolicy,
+	})
+	require_NoError(t, err)
+	require_Equal(t, si.Config.Replicas, 3)
+
+	checkFor(t, 10*time.Second, 200*time.Millisecond, func() error {
+		for _, s := range c.servers {
+			sjs := s.getJetStream()
+			sjs.mu.RLock()
+			sa := sjs.streamAssignment(globalAccountName, "TEST")
+			ca := sjs.consumerAssignment(globalAccountName, "TEST", "CONSUMER")
+			var nPeers, nConsumerPeers int
+			var desired *desiredRaftGroup
+			if sa != nil {
+				nPeers, desired = len(sa.Group.Peers), sa.Group.Desired
+			}
+			if ca != nil {
+				nConsumerPeers = len(ca.Group.Peers)
+			}
+			sjs.mu.RUnlock()
+
+			if sa == nil {
+				return fmt.Errorf("no stream assignment on %s", s)
+			}
+			if desired != nil {
+				return fmt.Errorf("desired state not cleared on %s", s)
+			}
+			if nPeers != 3 {
+				return fmt.Errorf("group peers on %s, got %d, want 3", s, nPeers)
+			}
+			// The consumers must have followed onto the new peer set.
+			if nConsumerPeers != 3 {
+				return fmt.Errorf("consumer peers on %s, got %d, want 3", s, nConsumerPeers)
+			}
+			// And the stream must be running there, at the released retention.
+			acc := s.globalAccount()
+			mset, err := acc.lookupStream("TEST")
+			if err != nil {
+				return fmt.Errorf("stream not on %s: %s", s, err)
+			}
+			if r := mset.config().Retention; r != InterestPolicy {
+				return fmt.Errorf("running retention on %s, got %v", s, r)
+			}
+			if mset.raftNode() == nil {
+				return fmt.Errorf("no raft node on %s", s)
+			}
+			if err = sjs.isStreamHealthy(acc, sa); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+
+	// Nothing is pending, so stream info must not report a desired state.
+	c.waitOnStreamLeader(globalAccountName, "TEST")
+	var resp JSApiStreamInfoResponse
+	msg, err := nc.Request(fmt.Sprintf(JSApiStreamInfoT, "TEST"), nil, 2*time.Second)
+	require_NoError(t, err)
+	require_NoError(t, json.Unmarshal(msg.Data, &resp))
+	require_NotNil(t, resp.StreamInfo)
+	require_True(t, resp.StreamInfo.Cluster.Desired == nil)
+	require_Equal(t, resp.StreamInfo.State.Msgs, 10)
+}
+
+// Same, for a move. The requested placement equals the config's, so it's only recognized
+// as a move when compared against the placement the stream is still running at.
+func TestJetStreamClusterDesiredStateMoveResolvedOnStreamUpdate(t *testing.T) {
+	sc := createJetStreamSuperCluster(t, 3, 2)
+	defer sc.shutdown()
+	sc.waitOnPeerCount(6)
+
+	nc, js := jsClientConnect(t, sc.randomServer())
+	defer nc.Close()
+
+	var servers []*Server
+	for _, cl := range sc.clusters {
+		servers = append(servers, cl.servers...)
+	}
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:      "TEST",
+		Subjects:  []string{"foo"},
+		Replicas:  3,
+		Placement: &nats.Placement{Cluster: "C1"},
+	})
+	require_NoError(t, err)
+
+	for range 10 {
+		_, err = js.Publish("foo", []byte("OK"))
+		require_NoError(t, err)
+	}
+
+	ml := sc.leader()
+	mjs, cc := ml.getJetStreamCluster()
+
+	// Record desired state for a move to C2: the config holds the target placement while
+	// the group stays on the peers in C1.
+	mjs.mu.RLock()
+	osa := mjs.streamAssignment(globalAccountName, "TEST")
+	require_NotNil(t, osa)
+	require_Len(t, len(osa.Group.Peers), 3)
+	var desiredPeers []string
+	for _, s := range sc.clusterForName("C2").servers {
+		desiredPeers = append(desiredPeers, s.Node())
+	}
+	originPeers := copyStrings(osa.Group.Peers)
+	nsa := osa.copyGroup()
+	// Must not mutate the live assignment's config, it's shared by the clone.
+	nsa.Config = osa.Config.clone()
+	nsa.Config.Placement = &Placement{Cluster: "C2"}
+	nsa.Group.Desired = &desiredRaftGroup{
+		Created: time.Now().UTC(),
+		ID:      "DESIRED",
+		Peers:   desiredPeers,
+		Cluster: "C2",
+		Move:    true,
+		Origin: &desiredRaftGroupOrigin{
+			Peers:     originPeers,
+			Cluster:   osa.Group.Cluster,
+			Replicas:  osa.Config.Replicas,
+			Placement: osa.Config.Placement.clone(),
+		},
+	}
+	mjs.mu.RUnlock()
+
+	require_NoError(t, cc.meta.Propose(cc.term, encodeUpdateStreamAssignment(nsa)))
+
+	// Confirm the stream did not move.
+	checkFor(t, 5*time.Second, 100*time.Millisecond, func() error {
+		for _, s := range servers {
+			sjs := s.getJetStream()
+			sjs.mu.RLock()
+			sa := sjs.streamAssignment(globalAccountName, "TEST")
+			var frozen bool
+			if sa != nil && sa.Group != nil {
+				frozen = sa.Group.Desired != nil && slices.Equal(sa.Group.Peers, originPeers)
+			}
+			sjs.mu.RUnlock()
+			if !frozen {
+				return fmt.Errorf("desired move not pending on %s", s)
+			}
+		}
+		return nil
+	})
+
+	// Ask for the placement we're reported to have.
+	_, err = js.UpdateStream(&nats.StreamConfig{
+		Name:      "TEST",
+		Subjects:  []string{"foo"},
+		Replicas:  3,
+		Placement: &nats.Placement{Cluster: "C2"},
+	})
+	require_NoError(t, err)
+
+	// The move must now be driven to completion.
+	checkFor(t, 10*time.Second, 200*time.Millisecond, func() error {
+		for _, s := range servers {
+			sjs := s.getJetStream()
+			sjs.mu.RLock()
+			sa := sjs.streamAssignment(globalAccountName, "TEST")
+			var peers []string
+			var desired *desiredRaftGroup
+			if sa != nil {
+				peers, desired = sa.Group.Peers, sa.Group.Desired
+			}
+			sjs.mu.RUnlock()
+			if sa == nil {
+				return fmt.Errorf("no stream assignment on %s", s)
+			}
+			if desired != nil {
+				return fmt.Errorf("desired state not cleared on %s", s)
+			}
+			if len(peers) != 3 {
+				return fmt.Errorf("group peers on %s, got %d, want 3", s, len(peers))
+			}
+			for _, p := range peers {
+				if !slices.Contains(desiredPeers, p) {
+					return fmt.Errorf("peer %q on %s is not in C2", p, s)
+				}
+			}
+		}
+		return nil
+	})
+
+	// The data moved with it.
+	sc.waitOnStreamLeader(globalAccountName, "TEST")
+	si, err := js.StreamInfo("TEST")
+	require_NoError(t, err)
+	require_Equal(t, si.State.Msgs, 10)
+	require_Equal(t, si.Cluster.Name, "C2")
+}

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -3160,7 +3160,9 @@ func (s *Server) accountDetail(jsa *jsAccount, optStreams, optConsumers, optDire
 			ci := js.clusterInfo(rgroup)
 			var cfg *StreamConfig
 			if optCfg {
-				c := stream.config()
+				// Report the config as requested, the stream can still be running at its origin.
+				// Must be consistent with the desired state reported as part of the cluster info.
+				c := js.targetStreamConfig(stream, stream.config())
 				cfg = &c
 			}
 			// Skip if we are only looking for stream leaders.
@@ -4099,7 +4101,7 @@ func (s *Server) healthz(opts *HealthzOptions) *HealthStatus {
 			mset, _ := acc.lookupStream(stream)
 			// Now check consumers.
 			for consumer, ca := range sa.consumers {
-				if err := js.isConsumerHealthy(mset, consumer, ca); err != nil {
+				if err := js.isConsumerHealthy(mset, sa, consumer, ca); err != nil {
 					if !details {
 						health.Status = na
 						health.Error = fmt.Sprintf("JetStream consumer '%s > %s > %s' is not current: %s", acc, stream, consumer, err)

--- a/server/raft.go
+++ b/server/raft.go
@@ -1302,6 +1302,13 @@ func (n *raft) Processed(index uint64, applied uint64) (entries uint64, bytes ui
 		}
 	}
 
+	// If we're a R1 node, and we've processed all that we needed to commit, make sure we can become
+	// leader as quickly as possible, so we don't wait out the election timeout.
+	if n.processed == n.commit && n.leader == _EMPTY_ && len(n.peers) == 1 && !n.pleader.Load() {
+		// Need to lower the election timeout, since only the run loop can transition.
+		n.resetElect(0)
+	}
+
 	// Calculate the number of entries and estimate the byte size that
 	// we can now remove with a compaction/snapshot.
 	if n.applied > n.papplied {

--- a/server/stream.go
+++ b/server/stream.go
@@ -369,13 +369,66 @@ type StreamAlternate struct {
 // ClusterInfo shows information about the underlying set of servers
 // that make up the stream or consumer.
 type ClusterInfo struct {
-	Name        string      `json:"name,omitempty"`
-	RaftGroup   string      `json:"raft_group,omitempty"`
-	Leader      string      `json:"leader,omitempty"`
-	LeaderSince *time.Time  `json:"leader_since,omitempty"`
-	SystemAcc   bool        `json:"system_account,omitempty"`
-	TrafficAcc  string      `json:"traffic_account,omitempty"`
-	Replicas    []*PeerInfo `json:"replicas,omitempty"`
+	Name        string              `json:"name,omitempty"`
+	RaftGroup   string              `json:"raft_group,omitempty"`
+	Leader      string              `json:"leader,omitempty"`
+	LeaderSince *time.Time          `json:"leader_since,omitempty"`
+	SystemAcc   bool                `json:"system_account,omitempty"`
+	TrafficAcc  string              `json:"traffic_account,omitempty"`
+	Replicas    []*PeerInfo         `json:"replicas,omitempty"`
+	Desired     *DesiredClusterInfo `json:"desired,omitempty"`
+}
+
+// DesiredClusterInfo shows information of the desired set of servers
+// that should make up the stream or consumer.
+type DesiredClusterInfo struct {
+	Created  time.Time                 `json:"created"`
+	Name     string                    `json:"name,omitempty"`
+	Replicas []*DesiredPeerInfo        `json:"replicas,omitempty"`
+	Origin   *DesiredClusterInfoOrigin `json:"origin,omitempty"`
+	Status   *DesiredClusterInfoStatus `json:"status,omitempty"`
+}
+
+type DesiredClusterInfoOrigin struct {
+	// Original replicas before it was updated.
+	Replicas int `json:"replicas"`
+	// Original placement before it was updated.
+	Placement *Placement `json:"placement,omitempty"`
+	// When changing between retention policies, this retention remains active until unset.
+	Retention *RetentionPolicy `json:"retention,omitempty"`
+}
+
+// DesiredPeerInfo is a minimal version of PeerInfo that shows information about the desired peer set.
+type DesiredPeerInfo struct {
+	Name    string `json:"name"`              // Name is the unique name for the peer
+	Offline bool   `json:"offline,omitempty"` // Offline indicates if it has not been seen recently
+	Peer    string `json:"peer"`              // Peer is the unique ID for the peer
+}
+
+// MigrationStatusType classifies a migration status by what has to change for the
+// migration to advance, so it can be matched on without parsing the status line.
+type MigrationStatusType string
+
+const (
+	MigrationStatusMeta        MigrationStatusType = "meta"        // The meta leader must record or advance desired state.
+	MigrationStatusMembership  MigrationStatusType = "membership"  // A proposed membership change must commit.
+	MigrationStatusSnapshot    MigrationStatusType = "snapshot"    // A snapshot must be installed.
+	MigrationStatusCatchup     MigrationStatusType = "catchup"     // Peers must become store-current.
+	MigrationStatusQuorum      MigrationStatusType = "quorum"      // More peers must come online before we can act without losing quorum.
+	MigrationStatusBlocked     MigrationStatusType = "blocked"     // Another asset must move first, i.e. the stream/consumer ordering constraint.
+	MigrationStatusUnavailable MigrationStatusType = "unavailable" // Nothing to do here, we're shutting down, or the assignment is gone.
+)
+
+type DesiredClusterInfoStatus struct {
+	// Description is a short status line describing what the group leader is currently
+	// doing to move this group toward its desired state, or what it's waiting on.
+	Description string `json:"description"`
+	// Type classifies Description by what has to change for the migration to
+	// advance, so it can be matched on without parsing the status line.
+	Type MigrationStatusType `json:"type"`
+	// Err is the underlying failure behind this status, if it had one. Only set
+	// for faults that persist across cycles, never for races that resolve themselves.
+	Err string `json:"err,omitempty"`
 }
 
 // PeerInfo shows information about all the peers in the cluster that
@@ -387,6 +440,7 @@ type PeerInfo struct {
 	Active  time.Duration `json:"active"`            // Active is the timestamp it was last active
 	Lag     uint64        `json:"lag,omitempty"`     // Lag is how many operations behind it is
 	Peer    string        `json:"peer"`              // Peer is the unique ID for the peer
+	Pending bool          `json:"pending,omitempty"` // Pending indicates the peer is part of the assignment, but is not a peer of the Raft group (yet)
 	// For migrations.
 	cluster string
 }


### PR DESCRIPTION
This PR adds a compatibility commit for the 2.14 release line, to be aware of 2.15's desired state. This is very useful and necessary to facilitate safe upgrades and downgrades, where the worst case becomes that a stream/consumer scale or move stalls until the upgrade to 2.15 is completed. The alternative would be to upgrade directly from a version that does not understand desired state in a mixed version cluster with 2.15, which could end up not just stalling a scale/move but leaving it in a stuck state that doesn't converge.

Before upgrading to 2.15.0+ we should recommend people upgrade first to the 2.14 patch version (or higher) that contains this compatibility, to ensure the smoothest upgrade experience.

Summary:
- Add desired state models and stream/consumer info reporting if desired state is set for a given assignment.
- A (noop) stream/consumer update can be sent if desired state is set to "unlock" any assignments left with desired state that would otherwise not converge since 2.14 does not drive desired state reconciliation.
- Tests are also added ensuring the desired state is persisted and reported, but does not result in weird healthz errors since under desired state a stream/consumer can be configured to have 3 replicas, but its assignment only contains 1 peer due to requiring desired state to scale up the peer set.