### PR TITLE
[FIXED] Catchup signal lost when a stalled catchup is re-requested

### DIFF
--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -14767,62 +14767,85 @@ func TestJetStreamClusterNoInterestDesyncOnConsumerCreate(t *testing.T) {
 }
 
 func TestJetStreamClusterRaftCatchupSignalsMetaRecovery(t *testing.T) {
-	c := createJetStreamClusterExplicit(t, "R3S", 3)
-	defer c.shutdown()
+	test := func(t *testing.T, stall bool) {
+		c := createJetStreamClusterExplicit(t, "R3S", 3)
+		defer c.shutdown()
 
-	nc, js := jsClientConnect(t, c.randomServer())
-	defer nc.Close()
+		nc, js := jsClientConnect(t, c.randomServer())
+		defer nc.Close()
 
-	_, err := js.AddStream(&nats.StreamConfig{
-		Name:     "TEST",
-		Subjects: []string{"foo"},
-		Replicas: 3,
-	})
-	require_NoError(t, err)
+		_, err := js.AddStream(&nats.StreamConfig{
+			Name:     "TEST",
+			Subjects: []string{"foo"},
+			Replicas: 3,
+		})
+		require_NoError(t, err)
 
-	rs := c.randomNonLeader()
-	checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
-		if !rs.JetStreamIsStreamAssigned(globalAccountName, "TEST") {
-			return errors.New("not assigned")
+		rs := c.randomNonLeader()
+		checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+			if !rs.JetStreamIsStreamAssigned(globalAccountName, "TEST") {
+				return errors.New("not assigned")
+			}
+			return nil
+		})
+
+		sjs := rs.getJetStream()
+		sjs.mu.Lock()
+		sa := sjs.streamAssignment(globalAccountName, "TEST")
+		encodedDelete := encodeDeleteStreamAssignment(sa)
+		sjs.mu.Unlock()
+		meta := sjs.getMetaGroup().(*raft)
+		apply := meta.ApplyQ()
+
+		// Should not panic if we receive a nil entry "randomly".
+		_, err = apply.push(nil)
+		require_NoError(t, err)
+
+		// Should put us in upper-layer recovery mode.
+		// For this test using two large values so we remain in catchup.
+		meta.Lock()
+		meta.createCatchup(&appendEntry{pterm: 100, pindex: 100})
+		meta.sendCatchupSignal()
+		meta.Unlock()
+
+		// Deleting a stream should be staged, not immediately performed.
+		_, err = apply.push(newCommittedEntry(1, []*Entry{{EntryNormal, encodedDelete}}))
+		require_NoError(t, err)
+		time.Sleep(200 * time.Millisecond)
+		require_True(t, rs.JetStreamIsStreamAssigned(globalAccountName, "TEST"))
+
+		// Healthz reports the in-flight catchup.
+		hs := rs.healthz(nil)
+		require_Equal(t, hs.Error, "JetStream is not current with the meta leader")
+
+		if stall {
+			// A stalled catchup is re-requested through createCatchup, which
+			// replaces the catchup state. The upper layer was already signaled,
+			// so completing this catchup must still signal it back.
+			meta.Lock()
+			meta.createCatchup(&appendEntry{pterm: 100, pindex: 100})
+			meta.Unlock()
 		}
-		return nil
-	})
 
-	sjs := rs.getJetStream()
-	sjs.mu.Lock()
-	sa := sjs.streamAssignment(globalAccountName, "TEST")
-	encodedDelete := encodeDeleteStreamAssignment(sa)
-	sjs.mu.Unlock()
-	meta := sjs.getMetaGroup().(*raft)
-	apply := meta.ApplyQ()
+		// Canceling the catchup, because it's completed, should result in the staged changes to be applied.
+		meta.Lock()
+		meta.cancelCatchup()
+		meta.Unlock()
+		checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+			if rs.JetStreamIsStreamAssigned(globalAccountName, "TEST") {
+				return errors.New("still assigned")
+			}
+			return nil
+		})
 
-	// Should not panic if we receive a nil entry "randomly".
-	_, err = apply.push(nil)
-	require_NoError(t, err)
+		// And healthz is healthy again.
+		hs = rs.healthz(nil)
+		require_Equal(t, hs.StatusCode, 200)
+		require_Equal(t, hs.Error, _EMPTY_)
+	}
 
-	// Should put us in upper-layer recovery mode.
-	// For this test using two large values so we remain in catchup.
-	meta.Lock()
-	meta.createCatchup(&appendEntry{pterm: 100, pindex: 100})
-	meta.sendCatchupSignal()
-	meta.Unlock()
-
-	// Deleting a stream should be staged, not immediately performed.
-	_, err = apply.push(newCommittedEntry(1, []*Entry{{EntryNormal, encodedDelete}}))
-	require_NoError(t, err)
-	time.Sleep(200 * time.Millisecond)
-	require_True(t, rs.JetStreamIsStreamAssigned(globalAccountName, "TEST"))
-
-	// Canceling the catchup, because it's completed, should result in the staged changes to be applied.
-	meta.Lock()
-	meta.cancelCatchup()
-	meta.Unlock()
-	checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
-		if rs.JetStreamIsStreamAssigned(globalAccountName, "TEST") {
-			return errors.New("still assigned")
-		}
-		return nil
-	})
+	t.Run("NoStall", func(t *testing.T) { test(t, false) })
+	t.Run("Stall", func(t *testing.T) { test(t, true) })
 }
 
 func TestJetStreamClusterRaftCatchupSignalsMetaRecoveryRecreateStream(t *testing.T) {

--- a/server/raft.go
+++ b/server/raft.go
@@ -2528,9 +2528,6 @@ func (n *raft) Reset() {
 
 	n.stepdownLocked(_EMPTY_)
 
-	// Cancel any in-flight catchup so it does not race the reset.
-	n.cancelCatchup()
-
 	// Drop proposals and inbound entries; they are no longer meaningful
 	// against whatever log this node ends up following.
 	n.prop.drain()
@@ -2539,6 +2536,10 @@ func (n *raft) Reset() {
 	n.apply.drain()
 	n.reqs.drain()
 	n.votes.drain()
+
+	// Cancel any in-flight catchup so it does not race the reset.
+	// Cancel after draining, we might have sent EntryCatchup and need to get them the nil entry.
+	n.cancelCatchup()
 
 	// Remove every snapshot under our snapshots dir, not just the one referenced
 	// by n.snapfile. Orphans (e.g. from a crash between install and the previous
@@ -4274,9 +4275,13 @@ func (n *raft) catchupStalled() bool {
 // to it. The remote side will stream entries to that subject.
 // Lock should be held.
 func (n *raft) createCatchup(ae *appendEntry) string {
-	// Cleanup any old ones.
-	if n.catchup != nil && n.catchup.sub != nil {
-		n.unsubscribe(n.catchup.sub)
+	// Cleanup any old ones, but preserve whether we signaled the upper layer.
+	var signal bool
+	if n.catchup != nil {
+		if n.catchup.sub != nil {
+			n.unsubscribe(n.catchup.sub)
+		}
+		signal = n.catchup.signal
 	}
 	// Snapshot term and index.
 	n.catchup = &catchupState{
@@ -4285,6 +4290,7 @@ func (n *raft) createCatchup(ae *appendEntry) string {
 		pterm:  n.pterm,
 		pindex: n.pindex,
 		active: time.Now(),
+		signal: signal,
 	}
 	inbox := n.newCatchupInbox()
 	sub, _ := n.subscribe(inbox, n.handleAppendEntry)

--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -7964,6 +7964,85 @@ func TestNRGCatchupRerequestDoesNotOrphanProgressQueue(t *testing.T) {
 	require_True(t, q == q2)
 }
 
+func TestNRGCatchupRerequestLosesCatchupSignal(t *testing.T) {
+	test := func(t *testing.T, stall bool) {
+		n, cleanup := initSingleMemRaftNode(t)
+		defer cleanup()
+
+		esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true)
+		entries := []*Entry{newEntry(EntryNormal, esm)}
+
+		nats0 := "S1Nunr6R" // "nats-0"
+
+		// One committed entry, so we have some log.
+		n.processAppendEntry(encode(t, &appendEntry{leader: nats0, term: 1, commit: 0, pterm: 0, pindex: 0, entries: entries}), n.aesub)
+		n.processAppendEntry(encode(t, &appendEntry{leader: nats0, term: 1, commit: 1, pterm: 1, pindex: 1}), n.aesub)
+		require_Equal(t, n.commit, 1)
+
+		// Leader is at 5, we're at 1, so request a catchup.
+		n.processAppendEntry(encode(t, &appendEntry{leader: nats0, term: 1, commit: 5, pterm: 1, pindex: 5, entries: entries}), n.aesub)
+		require_True(t, n.catchup != nil)
+		require_False(t, n.catchup.signal)
+		require_Equal(t, n.catchup.cindex, 5)
+
+		// Snapshot at 3 installs and signals the upper layer.
+		n.RLock()
+		ps := encodePeerState(&peerState{n.peerNames(), n.csz, n.extSt})
+		n.RUnlock()
+		aeSnap := encode(t, &appendEntry{leader: nats0, term: 1, commit: 3, pterm: 1, pindex: 3,
+			entries: []*Entry{{EntrySnapshot, []byte("snapshot")}, {EntryPeerState, ps}}})
+		n.processAppendEntry(aeSnap, n.catchup.sub)
+		require_Equal(t, n.pindex, 3)
+		require_True(t, n.catchup != nil)
+		require_True(t, n.catchup.signal)
+
+		if stall {
+			// No progress for 2s, so the catchup is stalled and re-requested.
+			hb := encode(t, &appendEntry{leader: nats0, term: 1, commit: 5, pterm: 1, pindex: 5})
+			n.processAppendEntry(hb, n.aesub)
+			require_True(t, n.catchup != nil)
+			n.Lock()
+			n.catchup.active = time.Now().Add(-3 * time.Second)
+			n.Unlock()
+			n.processAppendEntry(hb, n.aesub)
+			require_True(t, n.catchup != nil)
+			require_True(t, n.catchup.signal)
+		}
+
+		// Catchup entries 4 and 5 carry the leader's old commit, so we don't re-signal.
+		n.processAppendEntry(encode(t, &appendEntry{leader: nats0, term: 1, commit: 3, pterm: 1, pindex: 3, entries: entries}), n.catchup.sub)
+		n.processAppendEntry(encode(t, &appendEntry{leader: nats0, term: 1, commit: 3, pterm: 1, pindex: 4, entries: entries}), n.catchup.sub)
+		require_Equal(t, n.pindex, 5)
+		require_Equal(t, n.commit, 3)
+
+		// We're current now, the catchup is canceled.
+		n.processAppendEntry(encode(t, &appendEntry{leader: nats0, term: 1, commit: 5, pterm: 1, pindex: 5}), n.aesub)
+		require_True(t, n.catchup == nil)
+		require_Equal(t, n.commit, 5)
+
+		// Must have seen EntryCatchup followed by nil.
+		var sawCatchup, sawDone bool
+		for _, ce := range n.apply.pop() {
+			if ce == nil {
+				if sawCatchup {
+					sawDone = true
+				}
+				continue
+			}
+			for _, e := range ce.Entries {
+				if e.Type == EntryCatchup {
+					sawCatchup = true
+				}
+			}
+		}
+		require_True(t, sawCatchup)
+		require_True(t, sawDone)
+	}
+
+	t.Run("NoStall", func(t *testing.T) { test(t, false) })
+	t.Run("Stall", func(t *testing.T) { test(t, true) })
+}
+
 func TestNRGCatchupDoesNotAddPeerOnCompletion(t *testing.T) {
 	nats0 := "S1Nunr6R" // "nats-0"
 	nats1 := "yrzKKRBu" // "nats-1"


### PR DESCRIPTION
The Raft logic signals catchup based on having received a snapshot or generally catching up, which the meta layer uses to stage changes instead of needing to apply every single one while still catching up. However, if the Raft layer re-created catchup, for example if it was stalled, it would lose the knowledge of needing to signal back when it was finished which would leave the meta layer in indefinite recovery mode where it would keep staging and never applying entries. Which means the meta layer on this server would not make progress until restarted, resulting in stream/consumer operations to effectively freeze on this server.