### PR TITLE
Migrate math/rand to math/rand/v2

### DIFF
--- a/server/avl/norace_test.go
+++ b/server/avl/norace_test.go
@@ -19,7 +19,7 @@ import (
 	"flag"
 	"fmt"
 	"math"
-	"math/rand"
+	"math/rand/v2"
 	"runtime"
 	"runtime/debug"
 	"testing"
@@ -37,7 +37,7 @@ func TestNoRaceSeqSetSizeComparison(t *testing.T) {
 
 	seqs := make([]uint64, 0, num)
 	for i := 0; i < num; i++ {
-		n := uint64(rand.Int63n(int64(max + 1)))
+		n := uint64(rand.Int64N(int64(max + 1)))
 		seqs = append(seqs, n)
 	}
 
@@ -85,7 +85,7 @@ func TestNoRaceSeqSetEncodeLarge(t *testing.T) {
 	dmap := make(map[uint64]struct{}, num)
 	var ss SequenceSet
 	for i := 0; i < num; i++ {
-		n := uint64(rand.Int63n(int64(max + 1)))
+		n := uint64(rand.Int64N(int64(max + 1)))
 		ss.Insert(n)
 		dmap[n] = struct{}{}
 	}
@@ -126,7 +126,7 @@ func TestNoRaceSeqSetRelativeSpeed(t *testing.T) {
 
 	seqs := make([]uint64, 0, num)
 	for i := 0; i < num; i++ {
-		n := uint64(rand.Int63n(int64(max + 1)))
+		n := uint64(rand.Int64N(int64(max + 1)))
 		seqs = append(seqs, n)
 	}
 

--- a/server/avl/seqset_test.go
+++ b/server/avl/seqset_test.go
@@ -16,7 +16,7 @@ package avl
 import (
 	"encoding/base64"
 	"encoding/binary"
-	"math/rand"
+	"math/rand/v2"
 	"testing"
 )
 
@@ -72,7 +72,7 @@ func TestSeqSetCorrectness(t *testing.T) {
 	set := make(map[uint64]struct{}, num)
 	var ss SequenceSet
 	for i := 0; i < num; i++ {
-		n := uint64(rand.Int63n(int64(max + 1)))
+		n := uint64(rand.Int64N(int64(max + 1)))
 		ss.Insert(n)
 		set[n] = struct{}{}
 	}
@@ -215,7 +215,7 @@ func TestSeqSetClone(t *testing.T) {
 
 	var ss SequenceSet
 	for i := 0; i < num; i++ {
-		ss.Insert(uint64(rand.Int63n(int64(max + 1))))
+		ss.Insert(uint64(rand.Int64N(int64(max + 1))))
 	}
 
 	ssc := ss.Clone()

--- a/server/benchmark_publish_test.go
+++ b/server/benchmark_publish_test.go
@@ -15,7 +15,7 @@ package server
 
 import (
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"sync/atomic"
 	"testing"
 
@@ -26,7 +26,6 @@ func BenchmarkPublish(b *testing.B) {
 
 	const (
 		verbose     = false
-		seed        = 12345
 		minMessages = 10_000
 		subject     = "S"
 		queue       = "Q"
@@ -149,7 +148,7 @@ func BenchmarkPublish(b *testing.B) {
 							}
 							defer nc.Close()
 
-							rng := rand.New(rand.NewSource(int64(seed)))
+							rng := rand.NewChaCha8([32]byte{42})
 							message := make([]byte, bc.messageSize)
 							var published, errors int
 

--- a/server/consumer.go
+++ b/server/consumer.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"maps"
 	"math"
-	"math/rand"
+	"math/rand/v2"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -1513,13 +1513,13 @@ func (o *consumer) updateInactiveThreshold(cfg *ConsumerConfig) {
 	// Ephemerals will always have inactive thresholds.
 	if !o.isDurable() && cfg.InactiveThreshold <= 0 {
 		// Add in 1 sec of jitter above and beyond the default of 5s.
-		o.dthresh = JsDeleteWaitTimeDefault + 100*time.Millisecond + time.Duration(rand.Int63n(900))*time.Millisecond
+		o.dthresh = JsDeleteWaitTimeDefault + 100*time.Millisecond + time.Duration(rand.Int64N(900))*time.Millisecond
 		// Only stamp config with default sans jitter.
 		cfg.InactiveThreshold = JsDeleteWaitTimeDefault
 	} else if cfg.InactiveThreshold > 0 {
 		// Add in up to 1 sec of jitter if pull mode.
 		if o.isPullMode() {
-			o.dthresh = cfg.InactiveThreshold + 100*time.Millisecond + time.Duration(rand.Int63n(900))*time.Millisecond
+			o.dthresh = cfg.InactiveThreshold + 100*time.Millisecond + time.Duration(rand.Int64N(900))*time.Millisecond
 		} else {
 			o.dthresh = cfg.InactiveThreshold
 		}
@@ -2345,7 +2345,7 @@ func (o *consumer) deleteNotActive() {
 
 			// Check to make sure we went away.
 			// Don't think this needs to be a monitored go routine.
-			jitter := time.Duration(rand.Int63n(int64(cnaStart)))
+			jitter := time.Duration(rand.Int64N(int64(cnaStart)))
 			interval := cnaStart + jitter
 			ticker := time.NewTicker(interval)
 			defer ticker.Stop()
@@ -3449,7 +3449,7 @@ func (o *consumer) applyState(state *ConsumerState) {
 	if o.isLeader() && len(o.pending) > 0 {
 		// This is on startup or leader change. We want to check pending
 		// sooner in case there are inconsistencies etc. Pick between 500ms - 1.5s
-		delay := 500*time.Millisecond + time.Duration(rand.Int63n(1000))*time.Millisecond
+		delay := 500*time.Millisecond + time.Duration(rand.Int64N(1000))*time.Millisecond
 
 		// If normal is lower than this just use that.
 		if o.cfg.AckWait < delay {
@@ -3688,7 +3688,7 @@ func (o *consumer) shouldSample() bool {
 
 	// TODO(ripienaar) this is a tad slow so we need to rethink here, however this will only
 	// hit for those with sampling enabled and its not the default
-	return rand.Int31n(100) <= o.sfreq
+	return rand.Int32N(100) <= o.sfreq
 }
 
 func (o *consumer) sampleAck(sseq, dseq, dc uint64) {
@@ -5275,7 +5275,7 @@ func (o *consumer) processInboundAcks(qch chan struct{}) {
 
 	// How often we will check for ack floor drift.
 	// Spread these out for large numbers on a server restart.
-	delta := time.Duration(rand.Int63n(int64(time.Minute)))
+	delta := time.Duration(rand.Int64N(int64(time.Minute)))
 	ticker := time.NewTicker(time.Minute + delta)
 	defer ticker.Stop()
 
@@ -5912,7 +5912,7 @@ func (o *consumer) fcReply() string {
 	sb.WriteString(o.name)
 	sb.WriteByte(btsep)
 	var b [4]byte
-	rn := rand.Int63()
+	rn := rand.Int64()
 	for i, l := 0, rn; i < len(b); i++ {
 		b[i] = digits[l%base]
 		l /= base

--- a/server/dirstore_test.go
+++ b/server/dirstore_test.go
@@ -18,7 +18,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"math"
-	"math/rand"
+	"math/rand/v2"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -634,7 +634,7 @@ func TestLruVolume(t *testing.T) {
 		keys[i], err = k.PublicKey()
 		require_NoError(t, err)
 
-		createTestAccount(t, dirStore, 10000+rand.Intn(10000), k) // not intended to expire
+		createTestAccount(t, dirStore, 10000+rand.IntN(10000), k) // not intended to expire
 		assertStoreSize(t, dirStore, 2)
 		_, err = os.Stat(fmt.Sprintf("%s/%s.jwt", dir, keys[i-2]))
 		require_Error(t, err)

--- a/server/events.go
+++ b/server/events.go
@@ -22,7 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"math/rand"
+	"math/rand/v2"
 	"net/http"
 	"runtime"
 	"runtime/debug"
@@ -3005,7 +3005,7 @@ func (s *Server) newRespInbox() string {
 	var b [respInboxPrefixLen + replySuffixLen]byte
 	pres := b[:respInboxPrefixLen]
 	copy(pres, s.sys.inboxPre)
-	rn := rand.Int63()
+	rn := rand.Int64()
 	for i, l := respInboxPrefixLen, rn; i < len(b); i++ {
 		b[i] = digits[l%base]
 		l /= base

--- a/server/events_test.go
+++ b/server/events_test.go
@@ -19,7 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -3740,7 +3740,7 @@ func Benchmark_GetHash(b *testing.B) {
 		go func() {
 			defer wg.Done()
 			for i := 0; i < b.N; i++ {
-				idx := rand.Intn(100)
+				idx := rand.IntN(100)
 				if h := getHash(names[idx]); h != hashes[idx] {
 					errCh <- fmt.Errorf("Hash for name %q was %q, but should be %q", names[idx], h, hashes[idx])
 					return

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -30,7 +30,7 @@ import (
 	"io/fs"
 	"iter"
 	"math"
-	mrand "math/rand"
+	mrand "math/rand/v2"
 	"net"
 	"os"
 	"path/filepath"
@@ -12093,7 +12093,7 @@ func (fs *fileStore) setSyncTimer() {
 		// First time this fires will be between SyncInterval/2 and SyncInterval,
 		// so that different stores are spread out, rather than having many of
 		// them trying to all sync at once, causing blips and contending dios.
-		start := (fs.fcfg.SyncInterval / 2) + (time.Duration(mrand.Int63n(int64(fs.fcfg.SyncInterval / 2))))
+		start := (fs.fcfg.SyncInterval / 2) + (time.Duration(mrand.Int64N(int64(fs.fcfg.SyncInterval / 2))))
 		fs.syncTmr = time.AfterFunc(start, fs.syncBlocks)
 	}
 }
@@ -12123,7 +12123,7 @@ func (fs *fileStore) flushStreamStateLoop(qch, done chan struct{}) {
 	// Make sure we do not try to write these out too fast.
 	// Spread these out for large numbers on a server restart.
 	const writeThreshold = 2 * time.Minute
-	writeJitter := time.Duration(mrand.Int63n(int64(30 * time.Second)))
+	writeJitter := time.Duration(mrand.Int64N(int64(30 * time.Second)))
 	t := time.NewTicker(writeThreshold + writeJitter)
 	defer t.Stop()
 

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -30,7 +30,7 @@ import (
 	"io/fs"
 	"math"
 	"math/bits"
-	"math/rand"
+	"math/rand/v2"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -1438,7 +1438,7 @@ func TestFileStoreBitRot(t *testing.T) {
 
 			var index int
 			for {
-				index = rand.Intn(len(contents))
+				index = rand.IntN(len(contents))
 				// Reverse one byte anywhere.
 				b := contents[index]
 				contents[index] = bits.Reverse8(b)
@@ -2245,7 +2245,7 @@ func TestFileStoreSnapshot(t *testing.T) {
 		total := int64(toSend - 100)
 		// Delete 50 random messages.
 		for i := 0; i < 50; i++ {
-			seq := uint64(rand.Int63n(total) + 101)
+			seq := uint64(rand.Int64N(total) + 101)
 			fs.RemoveMsg(seq)
 		}
 
@@ -2431,7 +2431,7 @@ func TestFileStoreConsumer(t *testing.T) {
 		// Generate 8k pending.
 		state.Pending = make(map[uint64]*Pending)
 		for len(state.Pending) < 8192 {
-			seq := uint64(rand.Intn(9890) + 101)
+			seq := uint64(rand.IntN(9890) + 101)
 			if _, ok := state.Pending[seq]; !ok {
 				state.Pending[seq] = nt()
 			}
@@ -5362,12 +5362,12 @@ func TestFileStoreSubjectsTotals(t *testing.T) {
 
 	for i := 0; i < 10_000; i++ {
 		// Flip coin for prefix
-		if rand.Intn(2) == 0 {
+		if rand.IntN(2) == 0 {
 			ft, m = "foo", fmap
 		} else {
 			ft, m = "bar", bmap
 		}
-		dt := rand.Intn(100)
+		dt := rand.IntN(100)
 		subj := fmt.Sprintf("%s.%d", ft, dt)
 		m[dt]++
 
@@ -5724,7 +5724,7 @@ func TestFileStoreErrPartialLoad(t *testing.T) {
 		lmb.mu.Unlock()
 
 		if spread := int(last - first); spread > 0 {
-			seq := first + uint64(rand.Intn(spread))
+			seq := first + uint64(rand.IntN(spread))
 			_, err = fs.LoadMsg(seq, &smv)
 			require_NoError(t, err)
 		}
@@ -6706,9 +6706,9 @@ func TestFileStoreTrackSubjLenForPSIM(t *testing.T) {
 	for i := 0; i < 1000; i++ {
 		var b strings.Builder
 		// 1-6 tokens.
-		numTokens := rand.Intn(6) + 1
+		numTokens := rand.IntN(6) + 1
 		for i := 0; i < numTokens; i++ {
-			tlen := rand.Intn(4) + 2
+			tlen := rand.IntN(4) + 2
 			tok := buf[:tlen]
 			crand.Read(tok)
 			b.WriteString(hex.EncodeToString(tok))
@@ -6742,7 +6742,7 @@ func TestFileStoreTrackSubjLenForPSIM(t *testing.T) {
 	// Delete ~half
 	var smv StoreMsg
 	for i := 0; i < 500; i++ {
-		seq := uint64(rand.Intn(1000) + 1)
+		seq := uint64(rand.IntN(1000) + 1)
 		sm, err := fs.LoadMsg(seq, &smv)
 		if err != nil {
 			continue
@@ -6782,9 +6782,9 @@ func TestFileStoreLargeFullStatePSIM(t *testing.T) {
 	for i := 0; i < 100_000; i++ {
 		var b strings.Builder
 		// 1-6 tokens.
-		numTokens := rand.Intn(6) + 1
+		numTokens := rand.IntN(6) + 1
 		for i := 0; i < numTokens; i++ {
-			tlen := rand.Intn(8) + 2
+			tlen := rand.IntN(8) + 2
 			tok := buf[:tlen]
 			crand.Read(tok)
 			b.WriteString(hex.EncodeToString(tok))
@@ -6879,8 +6879,8 @@ func TestFileStoreSubjectCorruption(t *testing.T) {
 	numSubjects := 100
 	msgs := [][]byte{bytes.Repeat([]byte("ABC"), 333), bytes.Repeat([]byte("ABC"), 888), bytes.Repeat([]byte("ABC"), 555)}
 	for i := 0; i < 10_000; i++ {
-		subj := fmt.Sprintf("foo.%d", rand.Intn(numSubjects)+1)
-		msg := msgs[rand.Intn(len(msgs))]
+		subj := fmt.Sprintf("foo.%d", rand.IntN(numSubjects)+1)
+		msg := msgs[rand.IntN(len(msgs))]
 		fs.StoreMsg(subj, nil, msg, 0)
 	}
 	fs.Stop()
@@ -6914,7 +6914,7 @@ func TestFileStoreNumPendingLastBySubject(t *testing.T) {
 	numSubjects := 20
 	msg := bytes.Repeat([]byte("ABC"), 25)
 	for i := 1; i <= 1000; i++ {
-		subj := fmt.Sprintf("foo.%d.%d", rand.Intn(numSubjects)+1, i)
+		subj := fmt.Sprintf("foo.%d.%d", rand.IntN(numSubjects)+1, i)
 		fs.StoreMsg(subj, nil, msg, 0)
 	}
 	// Each block has ~8 msgs.
@@ -6953,7 +6953,7 @@ func TestFileStoreNumPendingLastBySubject(t *testing.T) {
 
 	// Make sure partials work properly.
 	for _, filter := range []string{"foo.10.*", "*.22.*", "*.*.222", "foo.5.999", "*.2.*"} {
-		sseq := uint64(rand.Intn(250) + 200) // Between 200-450
+		sseq := uint64(rand.IntN(250) + 200) // Between 200-450
 		total, _, err = fs.NumPending(sseq, filter, true)
 		require_NoError(t, err)
 		checkResult(sseq, total, filter)
@@ -8663,7 +8663,7 @@ func Benchmark_FileStoreLoadNextMsgSameFilterAsStream(b *testing.B) {
 
 	// Add in a bunch of msgs
 	for i := 0; i < 100_000; i++ {
-		subj := fmt.Sprintf("foo.%d", rand.Intn(1024))
+		subj := fmt.Sprintf("foo.%d", rand.IntN(1024))
 		fs.StoreMsg(subj, nil, msg, 0)
 	}
 
@@ -8689,7 +8689,7 @@ func Benchmark_FileStoreLoadNextMsgLiteralSubject(b *testing.B) {
 
 	// Add in a bunch of msgs
 	for i := 0; i < 100_000; i++ {
-		subj := fmt.Sprintf("foo.%d", rand.Intn(1024))
+		subj := fmt.Sprintf("foo.%d", rand.IntN(1024))
 		fs.StoreMsg(subj, nil, msg, 0)
 	}
 	// This is the one we will try to match.
@@ -8858,7 +8858,7 @@ func Benchmark_FileStoreLoadNextMsgVerySparseMsgsInBetweenWithWildcard(b *testin
 	// Add in a bunch of msgs.
 	// We need to make sure we have a range of subjects that could kick in a linear scan.
 	for i := 0; i < 1_000_000; i++ {
-		subj := fmt.Sprintf("foo.%d.bar", rand.Intn(100_000)+2)
+		subj := fmt.Sprintf("foo.%d.bar", rand.IntN(100_000)+2)
 		fs.StoreMsg(subj, nil, msg, 0)
 	}
 	// Make last msg one that would match as well.
@@ -8889,7 +8889,7 @@ func Benchmark_FileStoreLoadNextManySubjectsWithWildcardNearLastBlock(b *testing
 	// Add in a bunch of msgs.
 	// We need to make sure we have a range of subjects that could kick in a linear scan.
 	for i := 0; i < 1_000_000; i++ {
-		subj := fmt.Sprintf("foo.%d.bar", rand.Intn(100_000)+2)
+		subj := fmt.Sprintf("foo.%d.bar", rand.IntN(100_000)+2)
 		fs.StoreMsg(subj, nil, msg, 0)
 	}
 	// Make last msg one that would match as well.
@@ -8920,7 +8920,7 @@ func Benchmark_FileStoreLoadNextMsgVerySparseMsgsLargeTail(b *testing.B) {
 	// Add in a bunch of msgs.
 	// We need to make sure we have a range of subjects that could kick in a linear scan.
 	for i := 0; i < 1_000_000; i++ {
-		subj := fmt.Sprintf("foo.%d.bar", rand.Intn(64_000)+2)
+		subj := fmt.Sprintf("foo.%d.bar", rand.IntN(64_000)+2)
 		fs.StoreMsg(subj, nil, msg, 0)
 	}
 
@@ -9356,7 +9356,7 @@ func TestFileStoreNumPendingMulti(t *testing.T) {
 	totalMsgs := 100_000
 	totalSubjects := 10_000
 	numFiltered := 5000
-	startSeq := uint64(5_000 + rand.Intn(90_000))
+	startSeq := uint64(5_000 + rand.IntN(90_000))
 
 	subjects := make([]string, 0, totalSubjects)
 	for i := 0; i < totalSubjects; i++ {
@@ -9366,14 +9366,14 @@ func TestFileStoreNumPendingMulti(t *testing.T) {
 	// Put in 100k msgs with random subjects.
 	msg := bytes.Repeat([]byte("ZZZ"), 333)
 	for i := 0; i < totalMsgs; i++ {
-		_, _, err = fs.StoreMsg(subjects[rand.Intn(totalSubjects)], nil, msg, 0)
+		_, _, err = fs.StoreMsg(subjects[rand.IntN(totalSubjects)], nil, msg, 0)
 		require_NoError(t, err)
 	}
 
 	// Now we want to do a calculate NumPendingMulti.
 	filters := gsl.NewSublist[struct{}]()
 	for filters.Count() < uint32(numFiltered) {
-		filter := subjects[rand.Intn(totalSubjects)]
+		filter := subjects[rand.IntN(totalSubjects)]
 		if !filters.HasInterest(filter) {
 			filters.Insert(filter, struct{}{})
 		}
@@ -10479,7 +10479,7 @@ func TestFileStoreAllLastSeqs(t *testing.T) {
 	msg := []byte("abc")
 
 	for i := 0; i < 100_000; i++ {
-		subj := subjs[rand.Intn(len(subjs))]
+		subj := subjs[rand.IntN(len(subjs))]
 		fs.StoreMsg(subj, nil, msg, 0)
 	}
 
@@ -14883,7 +14883,7 @@ func TestFileStoreNoDirectoryNotEmptyError(t *testing.T) {
 			}
 		}()
 
-		time.Sleep(time.Duration(rand.Intn(10)) * time.Millisecond)
+		time.Sleep(time.Duration(rand.IntN(10)) * time.Millisecond)
 
 		err = obs.Delete()
 		require_NoError(t, err)
@@ -15332,7 +15332,7 @@ func TestFileStoreSubjectForSeqAliasRace(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for !stop.Load() {
-				seq := uint64(rand.Intn(N) + 1)
+				seq := uint64(rand.IntN(N) + 1)
 				got, err := fs.SubjectForSeq(seq)
 				if err != nil {
 					continue
@@ -16144,9 +16144,9 @@ func TestFileStoreDeleteMapView(t *testing.T) {
 			}
 		}
 		// Random probes mix both paths.
-		rng := rand.New(rand.NewSource(0))
+		rng := rand.New(rand.NewPCG(0, 0))
 		for i := 0; i < numMsgs*4; i++ {
-			seq := uint64(rng.Intn(numMsgs + 2))
+			seq := uint64(rng.IntN(numMsgs + 2))
 			require_Equal(t, v.Exists(seq), expected[seq])
 		}
 	}

--- a/server/gateway.go
+++ b/server/gateway.go
@@ -21,7 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"net/url"
 	"slices"
@@ -689,7 +689,7 @@ func (s *Server) solicitGateways() {
 func (s *Server) reconnectGateway(cfg *gatewayCfg) {
 	defer s.grWG.Done()
 
-	delay := time.Duration(rand.Intn(100)) * time.Millisecond
+	delay := time.Duration(rand.IntN(100)) * time.Millisecond
 	if !cfg.isImplicit() {
 		delay += gatewayReconnectDelay
 	}

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -24,7 +24,7 @@ import (
 	"iter"
 	"maps"
 	"math"
-	"math/rand"
+	"math/rand/v2"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -3566,14 +3566,14 @@ func (rg *raftGroup) setPreferred(s *Server) {
 
 		if len(online) == 0 {
 			// No online servers, just randomly select a peer for the preferred.
-			pi := rand.Int31n(int32(len(rg.Peers)))
+			pi := rand.Int32N(int32(len(rg.Peers)))
 			rg.Preferred = rg.Peers[pi]
 		} else if len(online) == 1 {
 			// Only one online server.
 			rg.Preferred = online[0]
 		} else {
 			// Randomly select an online peer.
-			pi := rand.Int31n(int32(len(online)))
+			pi := rand.Int32N(int32(len(online)))
 			rg.Preferred = online[pi]
 		}
 	}
@@ -3912,7 +3912,7 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 	)
 
 	// Spread these out for large numbers on server restart.
-	rci := time.Duration(rand.Int63n(int64(time.Minute)))
+	rci := time.Duration(rand.Int64N(int64(time.Minute)))
 	t := time.NewTicker(compactInterval + rci)
 	defer t.Stop()
 
@@ -4142,7 +4142,7 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 	var cist *time.Ticker
 	var cistc <-chan time.Time
 
-	checkInterestInterval := checkInterestStateT + time.Duration(rand.Intn(checkInterestStateJ))*time.Second
+	checkInterestInterval := checkInterestStateT + time.Duration(rand.IntN(checkInterestStateJ))*time.Second
 
 	if mset != nil && mset.isInterestRetention() {
 		// Wait on our consumers to be assigned and running before proceeding.
@@ -4206,7 +4206,7 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 					// If we are interest based make sure to check consumers if interest retention policy.
 					// This is to make sure we process any outstanding acks from all consumers.
 					if mset != nil && mset.isInterestRetention() {
-						fire := time.Duration(rand.Intn(5)+5) * time.Second
+						fire := time.Duration(rand.IntN(5)+5) * time.Second
 						time.AfterFunc(fire, mset.checkInterestState)
 					}
 					// If we became leader during this time and we need to send a snapshot to our
@@ -7604,7 +7604,7 @@ func (js *jetStream) monitorConsumer(o *consumer, ca *consumerAssignment) {
 	)
 
 	// Spread these out for large numbers on server restart.
-	rci := time.Duration(rand.Int63n(int64(time.Minute)))
+	rci := time.Duration(rand.Int64N(int64(time.Minute)))
 	t := time.NewTicker(compactInterval + rci)
 	defer t.Stop()
 
@@ -12670,7 +12670,7 @@ func (mset *stream) processSnapshot(snap *StreamReplicatedState, index uint64) (
 		// If we are interest based make sure to check our ack floor state.
 		// We will delay a bit to allow consumer states to also catchup.
 		if mset.isInterestRetention() {
-			fire := time.Duration(rand.Intn(10)+5) * time.Second
+			fire := time.Duration(rand.IntN(10)+5) * time.Second
 			time.AfterFunc(fire, mset.checkInterestState)
 		}
 	}()
@@ -13711,7 +13711,7 @@ func syncSubject(pre string) string {
 	sb.WriteByte(btsep)
 
 	var b [replySuffixLen]byte
-	rn := rand.Int63()
+	rn := rand.Int64()
 	for i, l := 0, rn; i < len(b); i++ {
 		b[i] = digits[l%base]
 		l /= base

--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -24,7 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"math/rand"
+	"math/rand/v2"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -7462,7 +7462,7 @@ func TestJetStreamClusterStreamPerf(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			js := conns[rand.Intn(numConnections)]
+			js := conns[rand.IntN(numConnections)]
 			<-startCh
 			for i := 0; i < int(toSend)/numProducers; i++ {
 				if _, err = js.Publish("foo", payload); err != nil {

--- a/server/jetstream_cluster_2_test.go
+++ b/server/jetstream_cluster_2_test.go
@@ -25,7 +25,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"math/rand"
+	"math/rand/v2"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -3390,7 +3390,7 @@ func TestJetStreamClusterRollups(t *testing.T) {
 
 	// Generate 1000 random measurements for 10 sensors
 	for i := 0; i < 1000; i++ {
-		id, temp := strconv.Itoa(rand.Intn(9)+1), rand.Int31n(42)+60 // 60-102 degrees.
+		id, temp := strconv.Itoa(rand.IntN(9)+1), rand.Int32N(42)+60 // 60-102 degrees.
 		le.PutUint16(bt[0:], uint16(temp))
 		js.PublishAsync(fmt.Sprintf("sensor.%v.temp", id), bt[:])
 	}
@@ -3401,7 +3401,7 @@ func TestJetStreamClusterRollups(t *testing.T) {
 	}
 
 	// Grab random sensor and do a rollup by averaging etc.
-	sensor := fmt.Sprintf("sensor.%v.temp", strconv.Itoa(rand.Intn(9)+1))
+	sensor := fmt.Sprintf("sensor.%v.temp", strconv.Itoa(rand.IntN(9)+1))
 	sub, err := js.SubscribeSync(sensor)
 	require_NoError(t, err)
 
@@ -5495,7 +5495,7 @@ func TestJetStreamClusterConsumerLeaderChangeDeadlock(t *testing.T) {
 			mset.mu.Lock()
 			for _, o := range mset.consumers {
 				o.mu.Lock()
-				time.Sleep(time.Duration(rand.Intn(10)) * time.Millisecond)
+				time.Sleep(time.Duration(rand.IntN(10)) * time.Millisecond)
 				o.mu.Unlock()
 			}
 			mset.mu.Unlock()

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -21,7 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"os"
 	"path/filepath"
@@ -4020,7 +4020,7 @@ func TestJetStreamClusterInterestStreamFilteredConsumersWithNoInterest(t *testin
 
 	// Now send 100 messages, randomly picking foo or bar, but never baz.
 	for i := 0; i < 100; i++ {
-		if rand.Intn(2) > 0 {
+		if rand.IntN(2) > 0 {
 			sendStreamMsg(t, nc, "foo", "HELLO")
 		} else {
 			sendStreamMsg(t, nc, "bar", "WORLD")

--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"math"
 	"math/big"
-	"math/rand"
+	"math/rand/v2"
 	"os"
 	"path"
 	"path/filepath"
@@ -1356,7 +1356,7 @@ func TestJetStreamClusterBusyStreams(t *testing.T) {
 				for i := 0; i < test.restarts; i++ {
 					switch {
 					case test.restartAny:
-						s := c.servers[rand.Intn(len(c.servers))]
+						s := c.servers[rand.IntN(len(c.servers))]
 						if test.ldmRestart {
 							s.lameDuckMode()
 						} else {
@@ -2415,8 +2415,8 @@ func TestJetStreamClusterPubAckSequenceDupe(t *testing.T) {
 		msgSubject := "TEST_SUBJECT." + strconv.FormatUint(seq, 10)
 		msgIdOpt := nats.MsgId(nuid.Next())
 
-		firstPublisherClient := &clients[rand.Intn(len(clients))]
-		secondPublisherClient := &clients[rand.Intn(len(clients))]
+		firstPublisherClient := &clients[rand.IntN(len(clients))]
+		secondPublisherClient := &clients[rand.IntN(len(clients))]
 
 		pubAck1, err := firstPublisherClient.js.Publish(msgSubject, msgData, msgIdOpt)
 		require_NoError(t, err)
@@ -3290,11 +3290,11 @@ func TestJetStreamClusterConsumerReplicasAfterScale(t *testing.T) {
 	sub, err := js.PullSubscribe("foo", "r1")
 	require_NoError(t, err)
 
-	fetch := rand.Intn(99) + 1 // Needs to be at least 1.
+	fetch := rand.IntN(99) + 1 // Needs to be at least 1.
 	msgs, err := sub.Fetch(fetch, nats.MaxWait(10*time.Second))
 	require_NoError(t, err)
 	require_Equal(t, len(msgs), fetch)
-	ack := rand.Intn(fetch)
+	ack := rand.IntN(fetch)
 	for i := 0; i <= ack; i++ {
 		msgs[i].AckSync()
 	}
@@ -6111,7 +6111,7 @@ func TestJetStreamClusterObserverNotElectedMetaLeader(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			// Add some random delay before changing state and stepping down.
-			time.Sleep(time.Duration(rand.Intn(25)) * time.Millisecond)
+			time.Sleep(time.Duration(rand.IntN(25)) * time.Millisecond)
 			setToObserverAndStepDown(other)
 		}()
 		setToObserverAndStepDown(leader)

--- a/server/jetstream_cluster_long_test.go
+++ b/server/jetstream_cluster_long_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"slices"
 	"strings"
 	"sync"
@@ -59,7 +59,7 @@ func TestLongKVPutWithServerRestarts(t *testing.T) {
 	}
 
 	test := func(t *testing.T, p Parameters) {
-		rng := rand.New(rand.NewSource(Seed))
+		rng := rand.New(rand.NewPCG(uint64(Seed), 0))
 
 		// Create cluster
 		clusterName := fmt.Sprintf("C_%d-%s", p.numServers, p.storage)
@@ -126,7 +126,7 @@ func TestLongKVPutWithServerRestarts(t *testing.T) {
 		// Pick a random key and update it with a random value
 		valueBuffer := make([]byte, ValueSize)
 		updateRandomKey := func() error {
-			key := keys[rand.Intn(NumKeys)]
+			key := keys[rand.IntN(NumKeys)]
 			_, err := rng.Read(valueBuffer)
 			require_NoError(t, err)
 			_, err = kv.Put(key, valueBuffer)
@@ -159,7 +159,7 @@ func TestLongKVPutWithServerRestarts(t *testing.T) {
 				}
 
 			case <-restartServerTicker.C:
-				randomServer := cluster.servers[rng.Intn(len(cluster.servers))]
+				randomServer := cluster.servers[rng.IntN(len(cluster.servers))]
 				randomServer.Shutdown()
 				randomServer.WaitForShutdown()
 				restartedServer := cluster.restartServer(randomServer)
@@ -254,7 +254,7 @@ func TestLongNRGChainOfBlocks(t *testing.T) {
 	}
 
 	rngSeed := time.Now().UnixNano()
-	rng := rand.New(rand.NewSource(rngSeed))
+	rng := rand.New(rand.NewPCG(uint64(rngSeed), 0))
 	t.Logf("Seed: %d", rngSeed)
 
 	// Chose a node from the list (and remove it)
@@ -264,7 +264,7 @@ func TestLongNRGChainOfBlocks(t *testing.T) {
 			return nodes, nil
 		}
 		// Pick random node
-		i := rng.Intn(len(nodes))
+		i := rng.IntN(len(nodes))
 		node := nodes[i]
 		// Move last element in its place
 		nodes[i] = nodes[len(nodes)-1]
@@ -340,7 +340,7 @@ func TestLongNRGChainOfBlocks(t *testing.T) {
 		}
 
 		// Choose a random operation to perform in this iteration
-		nextOperation := opsWeighted[rng.Intn(len(opsWeighted))]
+		nextOperation := opsWeighted[rng.IntN(len(opsWeighted))]
 
 		// If we're about to stop one or all nodes, do some sanity checks to ensure we don't
 		// spam stops which would constantly interrupt the chance of making progress.
@@ -398,14 +398,14 @@ func TestLongNRGChainOfBlocks(t *testing.T) {
 		case Snapshot:
 			// Choose a random active node and tell it to create a snapshot
 			if len(activeNodes) > 0 {
-				n := activeNodes[rng.Intn(len(activeNodes))]
+				n := activeNodes[rng.IntN(len(activeNodes))]
 				n.(*RCOBStateMachine).createSnapshot()
 			}
 
 		case Propose:
 			// Make an active node propose the next block (if any nodes are active)
 			if len(activeNodes) > 0 {
-				n := activeNodes[rng.Intn(len(activeNodes))]
+				n := activeNodes[rng.IntN(len(activeNodes))]
 				n.(*RCOBStateMachine).proposeBlock()
 			}
 
@@ -418,7 +418,7 @@ func TestLongNRGChainOfBlocks(t *testing.T) {
 
 		case Pause:
 			// Noop, let things run undisturbed for a little bit
-			time.Sleep(time.Duration(rng.Intn(250)) * time.Millisecond)
+			time.Sleep(time.Duration(rng.IntN(250)) * time.Millisecond)
 
 		case Check:
 			// Restart any stopped node
@@ -560,7 +560,7 @@ func TestLongClusterWorkQueueMessagesNotSkipped(t *testing.T) {
 				require_NoError(t, err)
 				for msg := range msgs.Messages() {
 					go func() {
-						time.Sleep(time.Millisecond * time.Duration(rand.Int31n(100)))
+						time.Sleep(time.Millisecond * time.Duration(rand.Int32N(100)))
 						require_NoError(t, msg.Ack())
 						sig <- msg
 					}()
@@ -632,7 +632,7 @@ func TestLongClusterJetStreamKeyValueSync(t *testing.T) {
 	createData := func(n int) []byte {
 		b := make([]byte, n)
 		for i := range b {
-			b[i] = letterBytes[rand.Intn(len(letterBytes))]
+			b[i] = letterBytes[rand.IntN(len(letterBytes))]
 		}
 		return b
 	}
@@ -727,7 +727,7 @@ func TestLongClusterJetStreamKeyValueSync(t *testing.T) {
 				return
 			default:
 			}
-			r := rand.Intn(numKeys)
+			r := rand.IntN(numKeys)
 			key := fmt.Sprintf("key-%d", r)
 
 			for i := 0; i < 5; i++ {
@@ -1162,7 +1162,7 @@ func TestLongFileStoreEnforceMsgPerSubjectLimit(t *testing.T) {
 	}
 	// Now update some of them. Leave a bit of a mess with some big gaps.
 	for i := 0; i < 5_000_000; i++ {
-		n := rand.Int31n(100_000)
+		n := rand.Int32N(100_000)
 		if n < 5000 {
 			continue
 		}

--- a/server/jetstream_consumer_test.go
+++ b/server/jetstream_consumer_test.go
@@ -23,7 +23,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"net/url"
 	os "os"
 	"path/filepath"
@@ -261,13 +261,13 @@ func TestJetStreamConsumerMultipleConsumersSingleFilter(t *testing.T) {
 		go func(subject string, messages int, wc bool) {
 			nc, js := jsClientConnect(t, s)
 			defer nc.Close()
-			time.Sleep(time.Duration(rand.Int63n(1000)+1) * time.Millisecond)
+			time.Sleep(time.Duration(rand.Int64N(1000)+1) * time.Millisecond)
 			for i := 0; i < messages; i++ {
-				time.Sleep(time.Duration(rand.Int63n(1000)+1) * time.Microsecond)
+				time.Sleep(time.Duration(rand.Int64N(1000)+1) * time.Microsecond)
 				// If subject has wildcard, add random last subject token.
 				pubSubject := subject
 				if wc {
-					pubSubject = fmt.Sprintf("%v.%v", subject, rand.Int63n(10))
+					pubSubject = fmt.Sprintf("%v.%v", subject, rand.Int64N(10))
 				}
 				_, err := js.PublishAsync(pubSubject, []byte("data"))
 				require_NoError(t, err)
@@ -373,13 +373,13 @@ func TestJetStreamConsumerMultipleConsumersMultipleFilters(t *testing.T) {
 		go func(subject string, messages int, wc bool) {
 			nc, js := jsClientConnect(t, s)
 			defer nc.Close()
-			time.Sleep(time.Duration(rand.Int63n(1000)+1) * time.Millisecond)
+			time.Sleep(time.Duration(rand.Int64N(1000)+1) * time.Millisecond)
 			for i := 0; i < messages; i++ {
-				time.Sleep(time.Duration(rand.Int63n(1000)+1) * time.Microsecond)
+				time.Sleep(time.Duration(rand.Int64N(1000)+1) * time.Microsecond)
 				// If subject has wildcard, add random last subject token.
 				pubSubject := subject
 				if wc {
-					pubSubject = fmt.Sprintf("%v.%v", subject, rand.Int63n(10))
+					pubSubject = fmt.Sprintf("%v.%v", subject, rand.Int64N(10))
 				}
 				ack, err := js.PublishAsync(pubSubject, []byte("data"))
 				require_NoError(t, err)
@@ -4781,7 +4781,7 @@ func TestJetStreamConsumerReplayRate(t *testing.T) {
 				lst = time.Now()
 				nc.Publish("DC", []byte("OK!"))
 				// Calculate a gap between messages.
-				gap := 10*time.Millisecond + time.Duration(rand.Intn(20))*time.Millisecond
+				gap := 10*time.Millisecond + time.Duration(rand.IntN(20))*time.Millisecond
 				time.Sleep(gap)
 			}
 
@@ -4891,7 +4891,7 @@ func TestJetStreamConsumerReplayRateNoAck(t *testing.T) {
 			totalMsgs := 10
 			for i := 0; i < totalMsgs; i++ {
 				nc.Request("DC", []byte("Hello World"), time.Second)
-				time.Sleep(time.Duration(rand.Intn(5)) * time.Millisecond)
+				time.Sleep(time.Duration(rand.IntN(5)) * time.Millisecond)
 			}
 			if state := mset.state(); state.Msgs != uint64(totalMsgs) {
 				t.Fatalf("Expected %d messages, got %d", totalMsgs, state.Msgs)
@@ -4908,7 +4908,7 @@ func TestJetStreamConsumerReplayRateNoAck(t *testing.T) {
 			}
 			defer o.delete()
 			// Sleep a random amount of time.
-			time.Sleep(time.Duration(rand.Intn(20)) * time.Millisecond)
+			time.Sleep(time.Duration(rand.IntN(20)) * time.Millisecond)
 
 			sub, _ := nc.SubscribeSync(subj)
 			nc.Flush()

--- a/server/jetstream_helpers_test.go
+++ b/server/jetstream_helpers_test.go
@@ -26,7 +26,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"net/url"
 	"os"
@@ -459,8 +459,8 @@ func createJetStreamSuperClusterWithTemplateAndModHook(t *testing.T, tmpl string
 
 	startClusterPorts := []int{20_022, 22_022, 24_022}
 	startGatewayPorts := []int{20_122, 22_122, 24_122}
-	startClusterPort := startClusterPorts[rand.Intn(len(startClusterPorts))]
-	startGWPort := startGatewayPorts[rand.Intn(len(startGatewayPorts))]
+	startClusterPort := startClusterPorts[rand.IntN(len(startClusterPorts))]
+	startGWPort := startGatewayPorts[rand.IntN(len(startGatewayPorts))]
 
 	// Make the GWs form faster for the tests.
 	SetGatewaysSolicitDelay(10 * time.Millisecond)
@@ -805,7 +805,7 @@ func createJetStreamClusterWithTemplate(t testing.TB, tmpl string, clusterName s
 
 func createJetStreamClusterWithTemplateAndModHook(t testing.TB, tmpl string, clusterName string, numServers int, modify modifyCb) *cluster {
 	startPorts := []int{7_022, 9_022, 11_022, 15_022}
-	port := startPorts[rand.Intn(len(startPorts))]
+	port := startPorts[rand.IntN(len(startPorts))]
 	return createJetStreamClusterAndModHook(t, tmpl, clusterName, _EMPTY_, numServers, port, true, modify)
 }
 
@@ -821,7 +821,7 @@ func createJetStreamClusterAndModHook(t testing.TB, tmpl, cName, snPre string, n
 
 func createJetStreamClusterWithNetProxy(t testing.TB, cName string, numServers int, cnp *clusterProxy) *cluster {
 	startPorts := []int{7_122, 9_122, 11_122, 15_122}
-	port := startPorts[rand.Intn(len(startPorts))]
+	port := startPorts[rand.IntN(len(startPorts))]
 	return createJetStreamClusterEx(t, jsClusterTempl, cName, _EMPTY_, numServers, port, true, nil, cnp)
 }
 

--- a/server/jetstream_super_cluster_test.go
+++ b/server/jetstream_super_cluster_test.go
@@ -20,7 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"math/rand"
+	"math/rand/v2"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -1914,7 +1914,7 @@ func TestJetStreamSuperClusterSourceAndMirrorConsumersLeaderChange(t *testing.T)
 
 	// Now make sure we only have a single direct consumer on our origin streams.
 	// Pick one at random.
-	name := fmt.Sprintf("O%d", rand.Intn(numStreams-1)+1)
+	name := fmt.Sprintf("O%d", rand.IntN(numStreams-1)+1)
 	c1.waitOnStreamLeader("$G", name)
 	s := c1.streamLeader("$G", name)
 	a, err := s.lookupAccount("$G")

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -25,7 +25,7 @@ import (
 	"io"
 	"math"
 	"math/big"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"net/http"
 	"net/url"
@@ -1591,7 +1591,7 @@ func TestJetStreamWildcardSubjectFiltering(t *testing.T) {
 			toShip := 25
 			shipped := make(map[int]bool)
 			for i := 0; i < toShip; {
-				orderId := rand.Intn(toSend-1) + 1
+				orderId := rand.IntN(toSend-1) + 1
 				if shipped[orderId] {
 					continue
 				}
@@ -3249,15 +3249,15 @@ func TestJetStreamSnapshots(t *testing.T) {
 	defer nc.Close()
 
 	// Make sure we send some as floor.
-	toSend := rand.Intn(200) + 22
+	toSend := rand.IntN(200) + 22
 	for i := 1; i <= toSend; i++ {
 		msg := fmt.Sprintf("Hello World %d", i)
-		subj := subjects[rand.Intn(len(subjects))]
+		subj := subjects[rand.IntN(len(subjects))]
 		sendStreamMsg(t, nc, subj, msg)
 	}
 
 	// Create up to 10 consumers.
-	numConsumers := rand.Intn(10) + 1
+	numConsumers := rand.IntN(10) + 1
 	var obs []obsi
 	for i := 1; i <= numConsumers; i++ {
 		cname := fmt.Sprintf("WQ-%d", i)
@@ -3268,7 +3268,7 @@ func TestJetStreamSnapshots(t *testing.T) {
 			t.Fatalf("Unexpected error: %v", err)
 		}
 		// Now grab some messages.
-		toReceive := rand.Intn(toSend/2) + 1
+		toReceive := rand.IntN(toSend/2) + 1
 		for r := 0; r < toReceive; r++ {
 			resp, err := nc.Request(o.requestNextMsgSubject(), nil, time.Second)
 			if err != nil {
@@ -3932,10 +3932,10 @@ func TestJetStreamSnapshotsAPI(t *testing.T) {
 	nc := clientConnectToServer(t, s)
 	defer nc.Close()
 
-	toSend := max(30, rand.Intn(100)+1)
+	toSend := max(30, rand.IntN(100)+1)
 	for i := 1; i <= toSend; i++ {
 		msg := fmt.Sprintf("Hello World %d", i)
-		subj := subjects[rand.Intn(len(subjects))]
+		subj := subjects[rand.IntN(len(subjects))]
 		sendStreamMsg(t, nc, subj, msg)
 	}
 
@@ -3949,7 +3949,7 @@ func TestJetStreamSnapshotsAPI(t *testing.T) {
 	o, err := mset.addConsumer(workerModeConfig("WQ"))
 	require_NoError(t, err)
 	// Now grab some messages.
-	toReceive := rand.Intn(int(mset.state().Msgs)) + 1
+	toReceive := rand.IntN(int(mset.state().Msgs)) + 1
 	for r := 0; r < toReceive; r++ {
 		resp, err := nc.Request(o.requestNextMsgSubject(), nil, time.Second)
 		if err != nil {
@@ -6669,14 +6669,14 @@ func TestJetStreamSimpleFileRecovery(t *testing.T) {
 			t.Fatalf("Unexpected error adding stream %q: %v", msetName, err)
 		}
 
-		toSend := rand.Intn(100) + 1
+		toSend := rand.IntN(100) + 1
 		for n := 1; n <= toSend; n++ {
 			msg := fmt.Sprintf("Hello %d", n*i)
-			subj := subjects[rand.Intn(len(subjects))]
+			subj := subjects[rand.IntN(len(subjects))]
 			sendStreamMsg(t, nc, subj, msg)
 		}
 		// Create up to 5 consumers.
-		numObs := rand.Intn(5) + 1
+		numObs := rand.IntN(5) + 1
 		var obs []obsi
 		for n := 1; n <= numObs; n++ {
 			oname := fmt.Sprintf("WQ-%d-%d", i, n)
@@ -6685,7 +6685,7 @@ func TestJetStreamSimpleFileRecovery(t *testing.T) {
 				t.Fatalf("Unexpected error: %v", err)
 			}
 			// Now grab some messages.
-			toReceive := rand.Intn(toSend) + 1
+			toReceive := rand.IntN(toSend) + 1
 			rsubj := o.requestNextMsgSubject()
 			for r := 0; r < toReceive; r++ {
 				resp, err := nc.Request(rsubj, nil, time.Second)
@@ -8127,7 +8127,7 @@ func TestJetStreamSingleInstanceRemoteAccess(t *testing.T) {
 	defer shutdownCluster(cb)
 
 	// Connect our leafnode server to cluster B.
-	opts := cb.opts[rand.Intn(len(cb.opts))]
+	opts := cb.opts[rand.IntN(len(cb.opts))]
 	s, _ := runSolicitLeafServer(opts)
 	defer s.Shutdown()
 
@@ -8152,7 +8152,7 @@ func TestJetStreamSingleInstanceRemoteAccess(t *testing.T) {
 	}
 
 	// Now create a push based consumer. Connected to the non-jetstream server via a random server on cluster A.
-	sl := ca.servers[rand.Intn(len(ca.servers))]
+	sl := ca.servers[rand.IntN(len(ca.servers))]
 	nc2 := clientConnectToServer(t, sl)
 	defer nc2.Close()
 
@@ -17876,7 +17876,7 @@ func TestJetStreamKVReductionInHistory(t *testing.T) {
 
 	numKeys, msg := 1000, bytes.Repeat([]byte("ABC"), 330) // ~1000bytes
 	for {
-		key := fmt.Sprintf("%X", rand.Intn(numKeys)+1)
+		key := fmt.Sprintf("%X", rand.IntN(numKeys)+1)
 		_, err = kv.Put(key, msg)
 		require_NoError(t, err)
 		status, err := kv.Status()
@@ -21859,7 +21859,7 @@ func TestJetStreamMaxMsgsPerSubjectAndDeliverLastPerSubject(t *testing.T) {
 	// sequences give us interior gaps after MaxMsgsPerSubject has been
 	// enforced which is needed for this test to work.
 	for range msgs {
-		subj := fmt.Sprintf("foo.%d", rand.Intn(subjects))
+		subj := fmt.Sprintf("foo.%d", rand.IntN(subjects))
 		_, err = js.Publish(subj, nil)
 		require_NoError(t, err)
 	}
@@ -21867,7 +21867,7 @@ func TestJetStreamMaxMsgsPerSubjectAndDeliverLastPerSubject(t *testing.T) {
 	// Then publish some messages on a different subject. These won't be
 	// matched by the consumer filter.
 	for range msgs / 10 {
-		subj := fmt.Sprintf("bar.%d", rand.Intn(subjects/10))
+		subj := fmt.Sprintf("bar.%d", rand.IntN(subjects/10))
 		_, err = js.Publish(subj, nil)
 		require_NoError(t, err)
 	}

--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -21,7 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"net/http"
 	"net/url"
@@ -818,7 +818,7 @@ func connectToRemoteLeafNode(s *Server, remote *leafNodeCfg, firstConnect bool) 
 			}
 		}
 		if err != nil {
-			jitter := time.Duration(rand.Int63n(int64(reconnectDelay)))
+			jitter := time.Duration(rand.Int64N(int64(reconnectDelay)))
 			delay := reconnectDelay + jitter
 			attempts++
 			if s.shouldReportConnectErr(firstConnect, attempts) {
@@ -2673,7 +2673,7 @@ func (acc *Account) updateLeafNodesEx(sub *subscription, delta int32, hubOnly bo
 	nleafs := len(acc.lleafs)
 	start := 0
 	if nleafs > 1 {
-		start = rand.Intn(nleafs)
+		start = rand.IntN(nleafs)
 	}
 	for i := 0; i < nleafs; i++ {
 		ln := acc.lleafs[(start+i)%nleafs]

--- a/server/memstore_test.go
+++ b/server/memstore_test.go
@@ -19,7 +19,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"reflect"
 	"slices"
 	"testing"
@@ -572,12 +572,12 @@ func TestMemStoreSubjectsTotals(t *testing.T) {
 
 	for i := 0; i < 10_000; i++ {
 		// Flip coin for prefix
-		if rand.Intn(2) == 0 {
+		if rand.IntN(2) == 0 {
 			ft, m = "foo", fmap
 		} else {
 			ft, m = "bar", bmap
 		}
-		dt := rand.Intn(100)
+		dt := rand.IntN(100)
 		subj := fmt.Sprintf("%s.%d", ft, dt)
 		m[dt]++
 
@@ -647,10 +647,10 @@ func TestMemStoreNumPending(t *testing.T) {
 	tokens := []string{"foo", "bar", "baz"}
 	genSubj := func() string {
 		return fmt.Sprintf("%s.%s.%s.%s",
-			tokens[rand.Intn(len(tokens))],
-			tokens[rand.Intn(len(tokens))],
-			tokens[rand.Intn(len(tokens))],
-			tokens[rand.Intn(len(tokens))],
+			tokens[rand.IntN(len(tokens))],
+			tokens[rand.IntN(len(tokens))],
+			tokens[rand.IntN(len(tokens))],
+			tokens[rand.IntN(len(tokens))],
 		)
 	}
 
@@ -818,7 +818,7 @@ func TestMemStoreDeleteBlocks(t *testing.T) {
 	delete := 5000
 	deleteMap := make(map[int]struct{}, delete)
 	for len(deleteMap) < delete {
-		deleteMap[rand.Intn(total)+1] = struct{}{}
+		deleteMap[rand.IntN(total)+1] = struct{}{}
 	}
 	// Now remove?
 	for seq := range deleteMap {
@@ -1095,7 +1095,7 @@ func TestMemStoreNumPendingMulti(t *testing.T) {
 	totalMsgs := 100_000
 	totalSubjects := 10_000
 	numFiltered := 5000
-	startSeq := uint64(5_000 + rand.Intn(90_000))
+	startSeq := uint64(5_000 + rand.IntN(90_000))
 
 	subjects := make([]string, 0, totalSubjects)
 	for i := 0; i < totalSubjects; i++ {
@@ -1105,14 +1105,14 @@ func TestMemStoreNumPendingMulti(t *testing.T) {
 	// Put in 100k msgs with random subjects.
 	msg := bytes.Repeat([]byte("ZZZ"), 333)
 	for i := 0; i < totalMsgs; i++ {
-		_, _, err = ms.StoreMsg(subjects[rand.Intn(totalSubjects)], nil, msg, 0)
+		_, _, err = ms.StoreMsg(subjects[rand.IntN(totalSubjects)], nil, msg, 0)
 		require_NoError(t, err)
 	}
 
 	// Now we want to do a calculate NumPendingMulti.
 	filters := gsl.NewSublist[struct{}]()
 	for filters.Count() < uint32(numFiltered) {
-		filter := subjects[rand.Intn(totalSubjects)]
+		filter := subjects[rand.IntN(totalSubjects)]
 		if !filters.HasInterest(filter) {
 			filters.Insert(filter, struct{}{})
 		}
@@ -1279,7 +1279,7 @@ func TestMemStoreAllLastSeqs(t *testing.T) {
 	msg := []byte("abc")
 
 	for i := 0; i < 100_000; i++ {
-		subj := subjs[rand.Intn(len(subjs))]
+		subj := subjs[rand.IntN(len(subjs))]
 		ms.StoreMsg(subj, nil, msg, 0)
 	}
 

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"io"
 	"math"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"net/http"
 	"net/url"

--- a/server/mqtt_test.go
+++ b/server/mqtt_test.go
@@ -23,7 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"os"
 	"path/filepath"
@@ -3514,7 +3514,7 @@ func TestMQTTClusterConnectDisconnectClean(t *testing.T) {
 	// specified.
 	N := 100
 	for n := 0; n < N; n++ {
-		testMQTTConnectDisconnect(t, cl.opts[rand.Intn(nServers)], clientID, true, false)
+		testMQTTConnectDisconnect(t, cl.opts[rand.IntN(nServers)], clientID, true, false)
 	}
 }
 
@@ -7014,7 +7014,7 @@ type chunkWriteConn struct {
 
 func (cwc *chunkWriteConn) Write(p []byte) (int, error) {
 	max := len(p)
-	cs := rand.Intn(max) + 1
+	cs := rand.IntN(max) + 1
 	if cs < max {
 		if pn, perr := cwc.Conn.Write(p[:cs]); perr != nil {
 			return pn, perr

--- a/server/msgtrace.go
+++ b/server/msgtrace.go
@@ -17,7 +17,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"strconv"
 	"strings"
 	"sync"
@@ -548,7 +548,7 @@ func sample(sampling int) bool {
 	if sampling <= 0 || sampling >= 100 {
 		return true
 	}
-	return rand.Int31n(100) <= int32(sampling)
+	return rand.Int32N(100) <= int32(sampling)
 }
 
 // This function will return the header as a map (instead of http.Header because

--- a/server/nkey_test.go
+++ b/server/nkey_test.go
@@ -20,10 +20,9 @@ import (
 	"fmt"
 	"strings"
 	"testing"
-	"time"
 
 	crand "crypto/rand"
-	mrand "math/rand"
+	mrand "math/rand/v2"
 
 	"github.com/nats-io/nkeys"
 )
@@ -256,7 +255,7 @@ func BenchmarkCryptoRandGeneration(b *testing.B) {
 
 func BenchmarkMathRandGeneration(b *testing.B) {
 	data := make([]byte, 16)
-	prng := mrand.New(mrand.NewSource(time.Now().UnixNano()))
+	prng := mrand.NewChaCha8([32]byte{42})
 	for i := 0; i < b.N; i++ {
 		prng.Read(data)
 	}
@@ -265,7 +264,7 @@ func BenchmarkMathRandGeneration(b *testing.B) {
 func BenchmarkNonceGeneration(b *testing.B) {
 	data := make([]byte, nonceRawLen)
 	b64 := make([]byte, nonceLen)
-	prand := mrand.New(mrand.NewSource(time.Now().UnixNano()))
+	prand := mrand.NewChaCha8([32]byte{42})
 	for i := 0; i < b.N; i++ {
 		prand.Read(data)
 		base64.RawURLEncoding.Encode(b64, data)

--- a/server/norace_1_test.go
+++ b/server/norace_1_test.go
@@ -26,7 +26,7 @@ import (
 	"fmt"
 	"io"
 	"math"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"net/http"
 	"net/url"
@@ -1726,7 +1726,7 @@ func TestNoRaceJetStreamSuperClusterMixedModeMirrors(t *testing.T) {
 		wg.Add(mirrorsCount)
 		errCh := make(chan error, 1)
 		for m := 0; m < mirrorsCount; m++ {
-			sname := fmt.Sprintf("S%d", rand.Intn(10)+1)
+			sname := fmt.Sprintf("S%d", rand.IntN(10)+1)
 			go func(sname string, mirrorIdx int) {
 				defer wg.Done()
 				if _, err := js.AddStream(&nats.StreamConfig{
@@ -2403,7 +2403,7 @@ func TestNoRaceJetStreamSuperClusterRIPStress(t *testing.T) {
 		for _, sns := range scm {
 			rand.Shuffle(len(sns), func(i, j int) { sns[i], sns[j] = sns[j], sns[i] })
 			for _, sn := range sns {
-				js := jsc[rand.Intn(len(jsc))]
+				js := jsc[rand.IntN(len(jsc))]
 				if _, err = js.PublishAsync(sn, msg); err != nil {
 					t.Fatalf("Unexpected publish error: %v", err)
 				}
@@ -3906,7 +3906,7 @@ func TestNoRaceJetStreamKeyValueCompaction(t *testing.T) {
 
 	value := strings.Repeat("A", 128*1024)
 	for i := 0; i < 5_000; i++ {
-		key := fmt.Sprintf("K-%d", rand.Intn(256)+1)
+		key := fmt.Sprintf("K-%d", rand.IntN(256)+1)
 		if _, err := kv.PutString(key, value); err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
@@ -5221,7 +5221,7 @@ func TestNoRaceJetStreamClusterInterestPullConsumerStreamLimitBug(t *testing.T) 
 			require_NoError(t, err)
 
 			for {
-				pt := time.NewTimer(time.Duration(rand.Intn(300)) * time.Millisecond)
+				pt := time.NewTimer(time.Duration(rand.IntN(300)) * time.Millisecond)
 				select {
 				case <-pt.C:
 					msgs, err := sub.Fetch(1)
@@ -5231,7 +5231,7 @@ func TestNoRaceJetStreamClusterInterestPullConsumerStreamLimitBug(t *testing.T) 
 					}
 					if len(msgs) > 0 {
 						go func() {
-							ackDelay := time.Duration(rand.Intn(375)+15) * time.Millisecond
+							ackDelay := time.Duration(rand.IntN(375)+15) * time.Millisecond
 							m := msgs[0]
 							time.AfterFunc(ackDelay, func() { m.AckSync() })
 						}()
@@ -5335,7 +5335,7 @@ func TestNoRaceJetStreamClusterDirectAccessAllPeersSubs(t *testing.T) {
 					return
 				default:
 					// Send as fast as we can.
-					js.Publish(fmt.Sprintf("kv.%d", rand.Intn(1000)), msg)
+					js.Publish(fmt.Sprintf("kv.%d", rand.IntN(1000)), msg)
 				}
 			}
 		}()
@@ -6520,7 +6520,7 @@ func TestNoRaceJetStreamKVAccountWithServerRestarts(t *testing.T) {
 			require_NoError(t, err)
 
 			for i := 0; i < npubs; i++ {
-				subj := fmt.Sprintf("KEY-%d", rand.Intn(nsubjs))
+				subj := fmt.Sprintf("KEY-%d", rand.IntN(nsubjs))
 				if _, err := kv.PutString(subj, "hello"); err != nil {
 					nc, js := jsClientConnect(t, c.randomServer())
 					defer nc.Close()
@@ -6588,7 +6588,7 @@ func TestNoRaceJetStreamConsumerCreateTimeNumPending(t *testing.T) {
 	msg := bytes.Repeat([]byte("X"), 8*1024)
 
 	for i := 0; i < n; i++ {
-		subj := fmt.Sprintf("events.%d", rand.Intn(100_000))
+		subj := fmt.Sprintf("events.%d", rand.IntN(100_000))
 		js.PublishAsync(subj, msg)
 	}
 	select {
@@ -6933,13 +6933,13 @@ func TestNoRaceJetStreamClusterF3Setup(t *testing.T) {
 					rand.Shuffle(len(msgs), func(i, j int) { msgs[i], msgs[j] = msgs[j], msgs[i] })
 
 					// Wait for a random interval up to 100ms.
-					time.Sleep(time.Duration(rand.Intn(100)) * time.Millisecond)
+					time.Sleep(time.Duration(rand.IntN(100)) * time.Millisecond)
 
 					for _, m := range msgs {
 						// If we want to simulate max redeliveries being hit, since not acking
 						// once will cause it due to subscriber setup.
 						// 100_000 == 0.01%
-						if simulateMaxRedeliveries && rand.Intn(100_000) == 0 {
+						if simulateMaxRedeliveries && rand.IntN(100_000) == 0 {
 							md, err := m.Metadata()
 							require_NoError(t, err)
 							t.Logf("** Skipping Ack: %d **", md.Sequence.Stream)
@@ -6996,9 +6996,9 @@ func TestNoRaceJetStreamClusterF3Setup(t *testing.T) {
 
 			for {
 				// Grab a random source stream
-				stream := sources[rand.Intn(len(sources))]
+				stream := sources[rand.IntN(len(sources))]
 				// Grab random event type.
-				evt := eventTypes[rand.Intn(len(eventTypes))]
+				evt := eventTypes[rand.IntN(len(eventTypes))]
 				subj := fmt.Sprintf("%s.%s", stream, evt)
 				start := time.Now()
 				_, err := js.Publish(subj, msg)
@@ -7579,10 +7579,10 @@ func TestNoRaceFileStoreNumPending(t *testing.T) {
 	tokens := []string{"foo", "bar", "baz"}
 	genSubj := func() string {
 		return fmt.Sprintf("%s.%s.%s.%s",
-			tokens[rand.Intn(len(tokens))],
-			tokens[rand.Intn(len(tokens))],
-			tokens[rand.Intn(len(tokens))],
-			tokens[rand.Intn(len(tokens))],
+			tokens[rand.IntN(len(tokens))],
+			tokens[rand.IntN(len(tokens))],
+			tokens[rand.IntN(len(tokens))],
+			tokens[rand.IntN(len(tokens))],
 		)
 	}
 
@@ -8390,7 +8390,7 @@ func TestNoRaceRoutePoolAndPerAccountConfigReload(t *testing.T) {
 					default:
 					}
 					if i%300 == 0 {
-						time.Sleep(time.Duration(rand.Intn(5)) * time.Millisecond)
+						time.Sleep(time.Duration(rand.IntN(5)) * time.Millisecond)
 					}
 				}
 			}()

--- a/server/norace_2_test.go
+++ b/server/norace_2_test.go
@@ -22,7 +22,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"os"
 	"path/filepath"
@@ -607,7 +607,7 @@ func TestNoRaceStoreStreamEncoderDecoder(t *testing.T) {
 
 	test := func(t *testing.T, gs StreamStore) {
 		t.Parallel()
-		prand := rand.New(rand.NewSource(seed))
+		prand := rand.New(rand.NewPCG(uint64(seed), 0))
 		tick := time.NewTicker(time.Second)
 		defer tick.Stop()
 		done := time.NewTimer(10 * time.Second)
@@ -637,7 +637,7 @@ func TestNoRaceStoreStreamEncoderDecoder(t *testing.T) {
 			case <-done.C:
 				running = false
 			default:
-				key := strconv.Itoa(prand.Intn(256_000))
+				key := strconv.Itoa(prand.IntN(256_000))
 				gs.StoreMsg(key, nil, msg, 0)
 			}
 		}
@@ -695,12 +695,12 @@ func TestNoRaceJetStreamClusterKVWithServerKill(t *testing.T) {
 
 			case <-tk.C:
 				// Pick a random key within the range.
-				k := fmt.Sprintf("key.%d", rand.Intn(numKeys))
+				k := fmt.Sprintf("key.%d", rand.IntN(numKeys))
 				// Attempt to get a key.
 				e, err := kv.Get(k)
 				// If found, attempt to update or delete.
 				if err == nil {
-					if rand.Intn(10) < 3 {
+					if rand.IntN(10) < 3 {
 						kv.Delete(k, nats.LastRevision(e.Revision()))
 					} else {
 						kv.Update(k, nil, e.Revision())
@@ -732,7 +732,7 @@ func TestNoRaceJetStreamClusterKVWithServerKill(t *testing.T) {
 		c.waitOnStreamLeader(globalAccountName, "KV_TEST")
 
 		// Wait for a bit and then start the server again.
-		time.Sleep(time.Duration(rand.Intn(1250)) * time.Millisecond)
+		time.Sleep(time.Duration(rand.IntN(1250)) * time.Millisecond)
 		s = c.restartServer(s)
 		c.waitOnServerCurrent(s)
 		c.waitOnLeader()
@@ -916,7 +916,7 @@ func TestNoRaceJetStreamAPIDispatchQueuePending(t *testing.T) {
 	// space and wildcards for now does the trick.
 	toks := []string{"foo", "bar", "baz"} // for second token.
 	for i := 1; i <= 500_000; i++ {
-		subj := fmt.Sprintf("foo.%s.%d", toks[rand.Intn(len(toks))], i)
+		subj := fmt.Sprintf("foo.%s.%d", toks[rand.IntN(len(toks))], i)
 		_, err := js.PublishAsync(subj, nil, nats.StallWait(time.Second))
 		require_NoError(t, err)
 	}
@@ -1101,7 +1101,7 @@ func TestNoRaceJetStreamClusterStreamCatchupLargeInteriorDeletes(t *testing.T) {
 
 	// Create 50k messages randomly from 1-100
 	for i := 0; i < 50_000; i++ {
-		subj := fmt.Sprintf("foo.%d", rand.Intn(100)+1)
+		subj := fmt.Sprintf("foo.%d", rand.IntN(100)+1)
 		publishAsync(t, js, subj, msg)
 	}
 	select {
@@ -1120,7 +1120,7 @@ func TestNoRaceJetStreamClusterStreamCatchupLargeInteriorDeletes(t *testing.T) {
 	}
 	// Do 50k random again at end.
 	for i := 0; i < 50_000; i++ {
-		subj := fmt.Sprintf("foo.%d", rand.Intn(100)+1)
+		subj := fmt.Sprintf("foo.%d", rand.IntN(100)+1)
 		publishAsync(t, js, subj, msg)
 	}
 	select {
@@ -1320,7 +1320,7 @@ func TestNoRaceJetStreamKVReplaceWithServerRestart(t *testing.T) {
 		const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 		b := make([]byte, n)
 		for i := range b {
-			b[i] = letterBytes[rand.Intn(len(letterBytes))]
+			b[i] = letterBytes[rand.IntN(len(letterBytes))]
 		}
 		return b
 	}
@@ -1583,7 +1583,7 @@ func TestNoRaceJetStreamWQSkippedMsgsOnScaleUp(t *testing.T) {
 		for {
 			select {
 			case <-st.C:
-				subj := publishSubjects[rand.Intn(len(publishSubjects))]
+				subj := publishSubjects[rand.IntN(len(publishSubjects))]
 				_, err = js.Publish(subj, msg)
 				require_NoError(t, err)
 			case <-pdone:
@@ -1618,11 +1618,11 @@ func TestNoRaceJetStreamWQSkippedMsgsOnScaleUp(t *testing.T) {
 				}
 				require_Equal(t, len(msgs), 1)
 				m := msgs[0]
-				if rand.Intn(10) == 1 {
+				if rand.IntN(10) == 1 {
 					m.Nak()
 				} else {
 					// Wait up to 20ms to ack.
-					time.Sleep(time.Duration(rand.Intn(20)) * time.Millisecond)
+					time.Sleep(time.Duration(rand.IntN(20)) * time.Millisecond)
 					// This could fail and that is ok, system should recover due to low ack wait.
 					m.Ack()
 				}
@@ -2160,7 +2160,7 @@ func TestNoRaceFileStoreWriteFullStateUniqueSubjects(t *testing.T) {
 			partB := nuid.Next()
 			for k := 0; k < 500; k++ {
 				partC := nuid.Next()
-				partD := labels[rand.Intn(len(labels)-1)]
+				partD := labels[rand.IntN(len(labels)-1)]
 				subject := fmt.Sprintf("records.%s.%s.%s.%s.%s", partA, partB, partC, partD, nuid.Next())
 				start := time.Now()
 				fs.StoreMsg(subject, nil, msg, 0)

--- a/server/raft_chain_of_blocks_helpers_test.go
+++ b/server/raft_chain_of_blocks_helpers_test.go
@@ -23,11 +23,12 @@ package server
 
 import (
 	"encoding"
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"hash"
 	"hash/crc32"
-	"math/rand"
+	"math/rand/v2"
 	"sync"
 )
 
@@ -56,7 +57,7 @@ type RCOBStateMachine struct {
 	wg                         sync.WaitGroup
 	leader                     bool
 	proposalSequence           uint64
-	rng                        *rand.Rand
+	rng                        *rand.ChaCha8
 	hash                       hash.Hash
 	blocksApplied              uint64
 	blocksAppliedSinceSnapshot uint64
@@ -205,7 +206,7 @@ func (sm *RCOBStateMachine) proposeBlock() {
 	sm.proposalSequence += 1
 
 	// Create a block
-	blockSize := 1 + sm.rng.Intn(RCOBOptions.maxBlockSize)
+	blockSize := 1 + rand.New(sm.rng).IntN(RCOBOptions.maxBlockSize)
 	block := RCOBBlock{
 		Proposer:         sm.s.Name(),
 		ProposerSequence: sm.proposalSequence,
@@ -366,7 +367,9 @@ func newRaftChainStateMachine(s *Server, cfg *RaftConfig, n RaftNode) stateMachi
 	for _, c := range []byte(n.ID()) {
 		seed += int64(c)
 	}
-	rng := rand.New(rand.NewSource(seed))
+	var seedBytes [32]byte
+	binary.LittleEndian.PutUint64(seedBytes[:8], uint64(seed))
+	rng := rand.NewChaCha8(seedBytes)
 
 	// Initialize empty hash block
 	hashBlock := crc32.NewIEEE()

--- a/server/raft_helpers_test.go
+++ b/server/raft_helpers_test.go
@@ -20,7 +20,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"sync"
 	"testing"
 	"time"
@@ -84,7 +84,7 @@ func (sg smGroup) waitOnLeader() stateMachine {
 
 // Pick a random member.
 func (sg smGroup) randomMember() stateMachine {
-	return sg[rand.Intn(len(sg))]
+	return sg[rand.IntN(len(sg))]
 }
 
 // Return a non-leader

--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -19,7 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"math/rand"
+	"math/rand/v2"
 	"net/url"
 	"os"
 	"path"
@@ -63,7 +63,7 @@ func TestNRGSnapshotAndRestart(t *testing.T) {
 	sm := rg.nonLeader().(*stateAdder)
 
 	for i := 0; i < 1000; i++ {
-		delta := rand.Int63n(222)
+		delta := rand.Int64N(222)
 		expectedTotal += delta
 		leader.proposeDelta(delta)
 
@@ -145,7 +145,7 @@ func TestNRGAppendEntryDecode(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		b := copyBytes(buf)
 		// modifying the header (idx < 42) will not result in an error by decodeAppendEntry
-		bi := 42 + rand.Intn(len(b)-42)
+		bi := 42 + rand.IntN(len(b)-42)
 		if b[bi] != 0 && bi != 40 {
 			b[bi] = 0
 			_, err = decodeAppendEntry(b, nil, _EMPTY_)

--- a/server/route.go
+++ b/server/route.go
@@ -19,7 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"hash/fnv"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"net/url"
 	"reflect"
@@ -2896,7 +2896,7 @@ func (s *Server) reConnectToRoute(rURL *url.URL, rtype RouteType, accName string
 	// registers the route on the opposite TCP connection, the
 	// two connections will end-up being closed.
 	// Add some random delay to reduce risk of repeated failures.
-	delay := time.Duration(rand.Intn(100)) * time.Millisecond
+	delay := time.Duration(rand.IntN(100)) * time.Millisecond
 	if rtype == Explicit {
 		delay += DEFAULT_ROUTE_RECONNECT
 	}

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -20,7 +20,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -4021,7 +4021,7 @@ func TestRouteCompression(t *testing.T) {
 			var payloads [][]byte
 			count := 26
 			for i := 0; i < count; i++ {
-				n := rand.Intn(2048) + 1
+				n := rand.IntN(2048) + 1
 				p := make([]byte, n)
 				for j := 0; j < n; j++ {
 					p[j] = byte(i) + 'A'
@@ -5096,7 +5096,7 @@ func TestRouteMsgWithManyHeadersDoesNotCorruptJSON(t *testing.T) {
 	total := 3000
 	bodies := make([][]byte, total)
 	for i := 0; i < total; i++ {
-		filler := strings.Repeat("x", 32+rand.Intn(12*1024))
+		filler := strings.Repeat("x", 32+rand.IntN(12*1024))
 		body := fmt.Sprintf(
 			`{"branch":"main","idx":%d,`+
 				`"some_tag":"tag-aaaaaaaaaaaaaaaaaaaaaaaa",`+

--- a/server/server.go
+++ b/server/server.go
@@ -24,7 +24,7 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"net/http"
 	"net/url"
@@ -1465,7 +1465,7 @@ func (s *Server) configureAccounts(reloading bool) (map[string]struct{}, error) 
 			if uname == _EMPTY_ {
 				// Create a unique name so we do not collide.
 				var b [8]byte
-				rn := rand.Int63()
+				rn := rand.Int64()
 				for i, l := 0, rn; i < len(b); i++ {
 					b[i] = digits[l%base]
 					l /= base
@@ -4556,7 +4556,7 @@ func (s *Server) lameDuckMode() {
 		}
 		if batch == 1 || i%batch == 0 {
 			// We pick a random interval which will be at least si/2
-			v := rand.Int63n(si)
+			v := rand.Int64N(si)
 			if v < si/2 {
 				v = si / 2
 			}
@@ -4688,7 +4688,7 @@ func (s *Server) getRandomIP(resolver netResolver, url string, excludedAddresses
 		if len(ips) == 1 {
 			ip = ips[0]
 		} else {
-			ip = ips[rand.Int31n(int32(len(ips)))]
+			ip = ips[rand.Int32N(int32(len(ips)))]
 		}
 		// add the port
 		address = net.JoinHostPort(ip, port)

--- a/server/stream.go
+++ b/server/stream.go
@@ -22,7 +22,7 @@ import (
 	"io"
 	"math"
 	"math/big"
-	"math/rand"
+	"math/rand/v2"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -3707,7 +3707,7 @@ func (mset *stream) scheduleSetupMirrorConsumerRetry() {
 	next += calculateRetryBackoff(mset.mirror.fails)
 
 	// Add some jitter.
-	next += time.Duration(rand.Intn(int(100*time.Millisecond))) + 100*time.Millisecond
+	next += time.Duration(rand.IntN(int(100*time.Millisecond))) + 100*time.Millisecond
 
 	stopAndClearTimer(&mset.mirrorConsumerSetup)
 	mset.mirrorConsumerSetup = time.AfterFunc(next, func() {
@@ -4240,7 +4240,7 @@ func (mset *stream) setupSourceConsumer(iname string, seq uint64, startTime time
 	}
 
 	// Always add some jitter
-	scheduleDelay += time.Duration(rand.Intn(int(100*time.Millisecond))) + 100*time.Millisecond
+	scheduleDelay += time.Duration(rand.IntN(int(100*time.Millisecond))) + 100*time.Millisecond
 
 	// Schedule the call to trySetupSourceConsumer
 	mset.sourceSetupSchedules[iname] = time.AfterFunc(scheduleDelay, func() {
@@ -5166,7 +5166,7 @@ func (mset *stream) subscribeToStream() error {
 		if mset.cfg.Replicas == 1 {
 			mset.setupSourceConsumers()
 		} else {
-			mset.sourcesConsumerSetup = time.AfterFunc(time.Duration(rand.Intn(int(500*time.Millisecond)))+100*time.Millisecond, func() {
+			mset.sourcesConsumerSetup = time.AfterFunc(time.Duration(rand.IntN(int(500*time.Millisecond)))+100*time.Millisecond, func() {
 				mset.mu.Lock()
 				mset.setupSourceConsumers()
 				mset.mu.Unlock()

--- a/server/stree/stree_test.go
+++ b/server/stree/stree_test.go
@@ -18,7 +18,7 @@ import (
 	"encoding/hex"
 	"flag"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"runtime"
 	"strconv"
 	"strings"
@@ -492,7 +492,7 @@ func TestSubjectTreeMatchSubjectParam(t *testing.T) {
 func TestSubjectTreeMatchRandomDoublePWC(t *testing.T) {
 	st := NewSubjectTree[int]()
 	for i := 1; i <= 10_000; i++ {
-		subj := fmt.Sprintf("foo.%d.%d", rand.Intn(20)+1, i)
+		subj := fmt.Sprintf("foo.%d.%d", rand.IntN(20)+1, i)
 		st.Insert(b(subj), 42)
 	}
 	match(t, st, "foo.*.*", 10_000)
@@ -700,9 +700,9 @@ func TestSubjectTreeRandomTrackEntries(t *testing.T) {
 	for i := 0; i < 1000; i++ {
 		var sb strings.Builder
 		// 1-6 tokens.
-		numTokens := rand.Intn(6) + 1
+		numTokens := rand.IntN(6) + 1
 		for i := 0; i < numTokens; i++ {
-			tlen := rand.Intn(4) + 2
+			tlen := rand.IntN(4) + 2
 			tok := buf[:tlen]
 			crand.Read(tok)
 			sb.WriteString(hex.EncodeToString(tok))
@@ -755,7 +755,7 @@ func TestSubjectTreeMatchAllPerf(t *testing.T) {
 	st := NewSubjectTree[int]()
 
 	for i := 0; i < 1_000_000; i++ {
-		subj := fmt.Sprintf("subj.%d.%d", rand.Intn(100)+1, i)
+		subj := fmt.Sprintf("subj.%d.%d", rand.IntN(100)+1, i)
 		st.Insert(b(subj), 22)
 	}
 
@@ -785,7 +785,7 @@ func TestSubjectTreeIterPerf(t *testing.T) {
 	st := NewSubjectTree[int]()
 
 	for i := 0; i < 1_000_000; i++ {
-		subj := fmt.Sprintf("subj.%d.%d", rand.Intn(100)+1, i)
+		subj := fmt.Sprintf("subj.%d.%d", rand.IntN(100)+1, i)
 		st.Insert(b(subj), 22)
 	}
 

--- a/server/subject_transform.go
+++ b/server/subject_transform.go
@@ -17,7 +17,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"math"
-	"math/rand"
+	"math/rand/v2"
 	"regexp"
 	"slices"
 	"strconv"
@@ -463,7 +463,7 @@ func (tr *subjectTransform) getRandomPartition(ceiling int) string {
 		return "0"
 	}
 
-	return strconv.Itoa(int(rand.Int31()) % ceiling)
+	return strconv.Itoa(int(rand.Int32()) % ceiling)
 }
 
 func (tr *subjectTransform) getHashPartition(key []byte, numBuckets int) string {

--- a/server/sublist_test.go
+++ b/server/sublist_test.go
@@ -17,7 +17,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"os"
 	"runtime"
 	"strconv"
@@ -2346,7 +2346,7 @@ func cacheContentionTest(b *testing.B, numMatchers, numAdders, numRemovers int) 
 	// Removers
 	for i := 0; i < numRemovers; i++ {
 		go func() {
-			prand := rand.New(rand.NewSource(time.Now().UnixNano()))
+			prand := rand.New(rand.NewPCG(uint64(time.Now().UnixNano()), 0))
 			swg.Done()
 			swg.Wait()
 			for {
@@ -2357,7 +2357,7 @@ func cacheContentionTest(b *testing.B, numMatchers, numAdders, numRemovers int) 
 				default:
 					mu.RLock()
 					lh := len(subs) - 1
-					index := prand.Intn(lh)
+					index := prand.IntN(lh)
 					sub := subs[index]
 					mu.RUnlock()
 					s.Remove(sub)

--- a/server/test_test.go
+++ b/server/test_test.go
@@ -16,7 +16,7 @@ package server
 import (
 	"cmp"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"net/url"
 	"os"
 	"reflect"

--- a/server/util_test.go
+++ b/server/util_test.go
@@ -15,7 +15,7 @@ package server
 
 import (
 	"math"
-	"math/rand"
+	"math/rand/v2"
 	"net/url"
 	"reflect"
 	"strconv"
@@ -280,7 +280,7 @@ func createTestSub() *subscription {
 
 func BenchmarkArrayRand(b *testing.B) {
 	b.StopTimer()
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	r := rand.New(rand.NewPCG(uint64(time.Now().UnixNano()), 0))
 	// Create an array of 10 items
 	subs := []*subscription{}
 	for i := 0; i < 10; i++ {
@@ -289,7 +289,7 @@ func BenchmarkArrayRand(b *testing.B) {
 	b.StartTimer()
 
 	for i := 0; i < b.N; i++ {
-		index := r.Intn(len(subs))
+		index := r.IntN(len(subs))
 		_ = subs[index]
 	}
 }

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"io"
 	"log"
-	mrand "math/rand"
+	mrand "math/rand/v2"
 	"net"
 	"net/http"
 	"net/url"
@@ -656,7 +656,7 @@ func wsFillFrameHeader(fh []byte, useMasking, first, final, compressed bool, fra
 	if useMasking {
 		var keyBuf [4]byte
 		if _, err := io.ReadFull(crand.Reader, keyBuf[:4]); err != nil {
-			kv := mrand.Int31()
+			kv := mrand.Int32()
 			binary.LittleEndian.PutUint32(keyBuf[:4], uint32(kv))
 		}
 		copy(fh[n:], keyBuf[:4])

--- a/server/websocket_test.go
+++ b/server/websocket_test.go
@@ -23,7 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"net/http"
 	"net/url"
@@ -3480,7 +3480,7 @@ func TestWSCompressionFrameSizeLimit(t *testing.T) {
 
 			uncompressedPayload := make([]byte, 2*wsFrameSizeForBrowsers)
 			for i := 0; i < len(uncompressedPayload); i++ {
-				uncompressedPayload[i] = byte(rand.Intn(256))
+				uncompressedPayload[i] = byte(rand.IntN(256))
 			}
 
 			c.mu.Lock()
@@ -4632,7 +4632,7 @@ type partialWriteConn struct {
 func (c *partialWriteConn) Write(b []byte) (int, error) {
 	max := len(b)
 	if max > 0 {
-		max = rand.Intn(max)
+		max = rand.IntN(max)
 		if max == 0 {
 			max = 1
 		}
@@ -4676,7 +4676,7 @@ func TestWSWithPartialWrite(t *testing.T) {
 
 	var msgs [][]byte
 	for i := 0; i < 100; i++ {
-		msg := make([]byte, rand.Intn(10000)+10)
+		msg := make([]byte, rand.IntN(10000)+10)
 		for j := 0; j < len(msg); j++ {
 			msg[j] = byte('A' + j%26)
 		}
@@ -4979,7 +4979,7 @@ var ch = []byte("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!
 func sizedString(sz int) string {
 	b := make([]byte, sz)
 	for i := range b {
-		b[i] = ch[rand.Intn(len(ch))]
+		b[i] = ch[rand.IntN(len(ch))]
 	}
 	return string(b)
 }
@@ -4990,7 +4990,7 @@ func sizedStringForCompression(sz int) string {
 	s := 0
 	for i := range b {
 		if s%20 == 0 {
-			c = ch[rand.Intn(len(ch))]
+			c = ch[rand.IntN(len(ch))]
 		}
 		b[i] = c
 	}
@@ -5394,7 +5394,7 @@ func TestWSCompressedFragmentsDoNotShareNbPoolBuffer(t *testing.T) {
 	// Random data does not compress, so the compressed output stays larger than
 	// the browser frame-size limit and is split into multiple frames.
 	uncompressed := make([]byte, 4*wsFrameSizeForBrowsers)
-	n, err := io.ReadFull(rand.New(rand.NewSource(12345)), uncompressed)
+	n, err := io.ReadFull(rand.NewChaCha8([32]byte{42}), uncompressed)
 	require_NoError(t, err)
 	require_Equal(t, n, len(uncompressed))
 

--- a/test/bench_test.go
+++ b/test/bench_test.go
@@ -22,7 +22,7 @@ package test
 import (
 	"bufio"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"net/url"
 	"testing"
@@ -83,7 +83,7 @@ var ch = []byte("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!
 func sizedBytes(sz int) []byte {
 	b := make([]byte, sz)
 	for i := range b {
-		b[i] = ch[rand.Intn(len(ch))]
+		b[i] = ch[rand.IntN(len(ch))]
 	}
 	return b
 }
@@ -791,7 +791,7 @@ func doS2CompressBench(b *testing.B, compress string) {
 	// Make it random so that compression code has more to do.
 	payload2 := make([]byte, 256)
 	for i := 0; i < len(payload); i++ {
-		payload2[i] = byte(rand.Intn(26) + 'A')
+		payload2[i] = byte(rand.IntN(26) + 'A')
 	}
 	b.StartTimer()
 

--- a/test/client_cluster_test.go
+++ b/test/client_cluster_test.go
@@ -15,7 +15,7 @@ package test
 
 import (
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"strconv"
 	"sync"
 	"sync/atomic"

--- a/test/cluster_test.go
+++ b/test/cluster_test.go
@@ -16,7 +16,7 @@ package test
 import (
 	"errors"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"runtime"
 	"strings"
 	"testing"
@@ -662,7 +662,7 @@ func TestClusterNameDynamicNegotiation(t *testing.T) {
 	`))
 
 	// Create a random number of additional servers, up to 20.
-	numServers := rand.Intn(20) + 1
+	numServers := rand.IntN(20) + 1
 	servers := make([]*server.Server, 0, numServers+1)
 	servers = append(servers, seed)
 

--- a/test/leafnode_test.go
+++ b/test/leafnode_test.go
@@ -19,7 +19,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"net/url"
 	"os"
@@ -2898,7 +2898,7 @@ func TestLeafNodeDistributedQueueAcrossGWs(t *testing.T) {
 	// Create queue subscribers
 	createQS := func(c *cluster) *nats.Conn {
 		t.Helper()
-		opts := c.opts[rand.Intn(len(c.opts))]
+		opts := c.opts[rand.IntN(len(c.opts))]
 		url := fmt.Sprintf("nats://ngs:pass@%s:%d", opts.Host, opts.Port)
 		nc, err := nats.Connect(url)
 		if err != nil {
@@ -2939,7 +2939,7 @@ func TestLeafNodeDistributedQueueAcrossGWs(t *testing.T) {
 	checkClientDQ := func(c *cluster, nreqs int) {
 		t.Helper()
 		// Pick one at random.
-		opts := c.opts[rand.Intn(len(c.opts))]
+		opts := c.opts[rand.IntN(len(c.opts))]
 		url := fmt.Sprintf("nats://dlc:pass@%s:%d", opts.Host, opts.Port)
 		connectAndRequest(url, c.name, nreqs)
 	}
@@ -2952,7 +2952,7 @@ func TestLeafNodeDistributedQueueAcrossGWs(t *testing.T) {
 	createLNS := func(c *cluster) (*server.Server, *server.Options) {
 		t.Helper()
 		// Pick one at random.
-		copts := c.opts[rand.Intn(len(c.servers))]
+		copts := c.opts[rand.IntN(len(c.servers))]
 		s, opts := runSolicitLeafServerToURL(fmt.Sprintf("nats-leaf://dlc:pass@%s:%d", copts.LeafNode.Host, copts.LeafNode.Port))
 		checkLeafNodeConnected(t, s)
 		return s, opts
@@ -2984,7 +2984,7 @@ func TestLeafNodeDistributedQueueEvenly(t *testing.T) {
 	// Create queue subscribers
 	createQS := func(c *cluster) *nats.Conn {
 		t.Helper()
-		opts := c.opts[rand.Intn(len(c.opts))]
+		opts := c.opts[rand.IntN(len(c.opts))]
 		url := fmt.Sprintf("nats://ngs:pass@%s:%d", opts.Host, opts.Port)
 		nc, err := nats.Connect(url)
 		if err != nil {
@@ -3032,7 +3032,7 @@ func TestLeafNodeDistributedQueueEvenly(t *testing.T) {
 	createLNS := func(c *cluster) (*server.Server, *server.Options) {
 		t.Helper()
 		// Pick one at random.
-		copts := c.opts[rand.Intn(len(c.servers))]
+		copts := c.opts[rand.IntN(len(c.servers))]
 		s, opts := runSolicitLeafServerToURL(fmt.Sprintf("nats-leaf://dlc:pass@%s:%d", copts.LeafNode.Host, copts.LeafNode.Port))
 		checkLeafNodeConnected(t, s)
 		return s, opts
@@ -3231,7 +3231,7 @@ func runSolicitLeafCluster(t *testing.T, clusterName string, d1, d2 *cluster) *c
 	c := &cluster{servers: make([]*server.Server, 0, 2), opts: make([]*server.Options, 0, 2), name: clusterName}
 
 	// Who we will solicit for server 1
-	ci := rand.Intn(len(d1.opts))
+	ci := rand.IntN(len(d1.opts))
 	opts := d1.opts[ci]
 	surl := fmt.Sprintf("nats-leaf://%s:%d", opts.LeafNode.Host, opts.LeafNode.Port)
 
@@ -3254,7 +3254,7 @@ func runSolicitLeafCluster(t *testing.T, clusterName string, d1, d2 *cluster) *c
 	curl, _ := url.Parse(routeAddr)
 
 	// Who we will solicit for server 2
-	ci = rand.Intn(len(d2.opts))
+	ci = rand.IntN(len(d2.opts))
 	opts = d2.opts[ci]
 	surl = fmt.Sprintf("nats-leaf://%s:%d", opts.LeafNode.Host, opts.LeafNode.Port)
 
@@ -3288,7 +3288,7 @@ func runSolicitLeafCluster(t *testing.T, clusterName string, d1, d2 *cluster) *c
 
 func clientForCluster(t *testing.T, c *cluster) *nats.Conn {
 	t.Helper()
-	opts := c.opts[rand.Intn(len(c.opts))]
+	opts := c.opts[rand.IntN(len(c.opts))]
 	url := fmt.Sprintf("nats://%s:%d", opts.Host, opts.Port)
 	nc, err := nats.Connect(url)
 	if err != nil {

--- a/test/service_latency_test.go
+++ b/test/service_latency_test.go
@@ -16,7 +16,7 @@ package test
 import (
 	"encoding/json"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -53,7 +53,7 @@ const cnlen = 8
 
 func randClusterName() string {
 	var name []byte
-	rn := rand.Int63()
+	rn := rand.Int64()
 	for i := 0; i < cnlen; i++ {
 		name = append(name, digits[rn%base])
 		rn /= base

--- a/test/system_services_test.go
+++ b/test/system_services_test.go
@@ -15,7 +15,7 @@ package test
 
 import (
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"net/url"
 	"strconv"
 	"strings"
@@ -29,8 +29,8 @@ import (
 const dbgSubs = "$SYS.DEBUG.SUBSCRIBERS"
 
 func (sc *supercluster) selectRandomServer() *server.Options {
-	ci := rand.Int31n(int32(len(sc.clusters)))
-	si := rand.Int31n(int32(len(sc.clusters[ci].servers)))
+	ci := rand.Int32N(int32(len(sc.clusters)))
+	si := rand.Int32N(int32(len(sc.clusters[ci].servers)))
 	return sc.clusters[ci].opts[si]
 }
 
@@ -204,8 +204,8 @@ func TestSystemServiceSubscribersLeafNodesWithoutSystem(t *testing.T) {
 
 	sc.setupSystemServicesImports(t, "FOO")
 
-	ci := rand.Int31n(int32(len(sc.clusters)))
-	si := rand.Int31n(int32(len(sc.clusters[ci].servers)))
+	ci := rand.Int32N(int32(len(sc.clusters)))
+	si := rand.Int32N(int32(len(sc.clusters[ci].servers)))
 	s, opts := sc.clusters[ci].servers[si], sc.clusters[ci].opts[si]
 	url := fmt.Sprintf("nats://%s:pass@%s:%d", "foo", opts.Host, opts.LeafNode.Port)
 	ls, lopts := runSolicitLeafServerToURL(url)
@@ -297,8 +297,8 @@ func TestSystemServiceSubscribersLeafNodesWithSystem(t *testing.T) {
 
 	sc.setupSystemServicesImports(t, "FOO")
 
-	ci := rand.Int31n(int32(len(sc.clusters)))
-	si := rand.Int31n(int32(len(sc.clusters[ci].servers)))
+	ci := rand.Int32N(int32(len(sc.clusters)))
+	si := rand.Int32N(int32(len(sc.clusters[ci].servers)))
 	s, opts := sc.clusters[ci].servers[si], sc.clusters[ci].opts[si]
 	url := fmt.Sprintf("nats://%s:pass@%s:%d", "foo", opts.Host, opts.LeafNode.Port)
 	ls, lopts := runSolicitLeafServerWithSystemToURL(url)


### PR DESCRIPTION
This PR is a direct successor to #8538, ensuring uniform and consistent usage of `math/rand/v2` throughout the `nats-server` repository. 

All changes are mechanical and direct translations from the legacy `math/rand` package. No refactoring or logic changes were made.