### PR TITLE
Fix inverted --no_advertise flag help text

### DIFF
--- a/server/opts.go
+++ b/server/opts.go
@@ -6284,7 +6284,7 @@ func ConfigureOptions(fs *flag.FlagSet, args []string, printVersion, printHelp, 
 	fs.StringVar(&opts.Cluster.ListenStr, "cluster", _EMPTY_, "Cluster url from which members can solicit routes.")
 	fs.StringVar(&opts.Cluster.ListenStr, "cluster_listen", _EMPTY_, "Cluster url from which members can solicit routes.")
 	fs.StringVar(&opts.Cluster.Advertise, "cluster_advertise", _EMPTY_, "Cluster URL to advertise to other servers.")
-	fs.BoolVar(&opts.Cluster.NoAdvertise, "no_advertise", false, "Advertise known cluster IPs to clients.")
+	fs.BoolVar(&opts.Cluster.NoAdvertise, "no_advertise", false, "Do not advertise known cluster IPs to clients.")
 	fs.IntVar(&opts.Cluster.ConnectRetries, "connect_retries", 0, "For implicit routes, number of connect retries.")
 	fs.StringVar(&opts.Cluster.Name, "cluster_name", _EMPTY_, "Cluster Name, if not set one will be dynamically generated.")
 	fs.BoolVar(&showTLSHelp, "help_tls", false, "TLS help.")


### PR DESCRIPTION
The command-line help registered for `--no_advertise` currently reads:

```
Advertise known cluster IPs to clients.
```

That's the opposite of what the flag does. It binds `opts.Cluster.NoAdvertise`, and the server advertises cluster URLs to clients only when that value is false:

- `server/route.go:726`, `server/route.go:2388`, `server/route.go:2759` — all gated on `!opts.Cluster.NoAdvertise`
- `server/server.go:4603` — same

So passing `--no_advertise` (or `no_advertise: true`) *suppresses* advertising. The hand-maintained usage text in `main.go` already words it correctly ("Do not advertise known cluster information to clients"); this just brings the flag registration in `server/opts.go` into line with it.

`main.go` installs a custom `flag.Usage`, so this particular string isn't printed by `nats-server -h`, but `ConfigureOptions` is exported and writes it onto the `FlagSet`, so embedders and anything using the flag set's own help still see the inverted text.

`go build ./...` passes.
