### PR TITLE
Perform message size checks before more expensive header checks

### DIFF
--- a/server/msgtrace_test.go
+++ b/server/msgtrace_test.go
@@ -5355,11 +5355,11 @@ func TestMsgTraceJetStreamWithSuperCluster(t *testing.T) {
 					case 1:
 						// Update stream to prevent rollups, and set a max size.
 						cfg.AllowRollup = false
-						cfg.MaxMsgSize = 100
+						cfg.MaxMsgSize = 256
 						_, err = js.UpdateStream(cfg)
 						require_NoError(t, err)
 					case 2:
-						msg.Data = make([]byte, 200)
+						msg.Data = make([]byte, 512)
 					case 3:
 						pa, err := jst.Publish(mainTest.stream, []byte("hello"))
 						require_NoError(t, err)

--- a/server/stream.go
+++ b/server/stream.go
@@ -6565,6 +6565,28 @@ func (mset *stream) processJetStreamMsgWithBatch(subject, reply string, hdr, msg
 	var incr *big.Int
 	var rollupSub, rollupAll bool
 
+	// Check to see if we are over the max msg size.
+	// Subtract to prevent against overflows.
+	if canConsistencyCheck && maxMsgSize >= 0 && (len(hdr) > maxMsgSize || len(msg) > maxMsgSize-len(hdr)) {
+		if canRespond {
+			resp.PubAck = &PubAck{Stream: name}
+			resp.Error = NewJSStreamMessageExceedsMaximumError()
+			b, _ := json.Marshal(resp)
+			outq.sendMsg(reply, b)
+		}
+		return ErrMaxPayload
+	}
+
+	if canConsistencyCheck && len(hdr) > math.MaxUint16 {
+		if canRespond {
+			resp.PubAck = &PubAck{Stream: name}
+			resp.Error = NewJSStreamHeaderExceedsMaximumError()
+			b, _ := json.Marshal(resp)
+			outq.sendMsg(reply, b)
+		}
+		return ErrMaxPayload
+	}
+
 	if len(hdr) > 0 {
 		// Certain checks have already been performed if in clustered mode, so only check if not.
 		// Note, for cluster mode but with message tracing (without message delivery), we need
@@ -7090,28 +7112,6 @@ func (mset *stream) processJetStreamMsgWithBatch(subject, reply string, hdr, msg
 			}
 			return ErrMaxPayload
 		}
-	}
-
-	// Check to see if we are over the max msg size.
-	// Subtract to prevent against overflows.
-	if canConsistencyCheck && maxMsgSize >= 0 && (len(hdr) > maxMsgSize || len(msg) > maxMsgSize-len(hdr)) {
-		if canRespond {
-			resp.PubAck = &PubAck{Stream: name}
-			resp.Error = NewJSStreamMessageExceedsMaximumError()
-			response, _ = json.Marshal(resp)
-			outq.sendMsg(reply, response)
-		}
-		return ErrMaxPayload
-	}
-
-	if canConsistencyCheck && len(hdr) > math.MaxUint16 {
-		if canRespond {
-			resp.PubAck = &PubAck{Stream: name}
-			resp.Error = NewJSStreamHeaderExceedsMaximumError()
-			response, _ = json.Marshal(resp)
-			outq.sendMsg(reply, response)
-		}
-		return ErrMaxPayload
 	}
 
 	// Check to see if we have exceeded our limits.

--- a/server/stream.go
+++ b/server/stream.go
@@ -7114,6 +7114,30 @@ func (mset *stream) processJetStreamMsgWithBatch(subject, reply string, hdr, msg
 		}
 	}
 
+	// Header processing above may have changed the message, such as when a
+	// counter increment generates its value payload. Check the resulting size
+	// against the stream limit as well as checking the inbound size early.
+	// Subtract to prevent against overflows.
+	if canConsistencyCheck && maxMsgSize >= 0 && (len(hdr) > maxMsgSize || len(msg) > maxMsgSize-len(hdr)) {
+		if canRespond {
+			resp.PubAck = &PubAck{Stream: name}
+			resp.Error = NewJSStreamMessageExceedsMaximumError()
+			response, _ = json.Marshal(resp)
+			outq.sendMsg(reply, response)
+		}
+		return ErrMaxPayload
+	}
+
+	if canConsistencyCheck && len(hdr) > math.MaxUint16 {
+		if canRespond {
+			resp.PubAck = &PubAck{Stream: name}
+			resp.Error = NewJSStreamHeaderExceedsMaximumError()
+			response, _ = json.Marshal(resp)
+			outq.sendMsg(reply, response)
+		}
+		return ErrMaxPayload
+	}
+
 	// Check to see if we have exceeded our limits.
 	// Don't error and log/stepdown if we're tracing when clustered.
 	if !isClustered && js.limitsExceeded(stype) {


### PR DESCRIPTION
This stops us from doing a bunch of work on headers if the limits were violated.