### PR TITLE
[FIXED] Last msg ID is restored only if it is in duplicate window

### DIFF
--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -2945,6 +2945,58 @@ func TestJetStreamPublishExpect(t *testing.T) {
 	}
 }
 
+func TestJetStreamRestoreLastMsgIDPastDedupeWindow(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	const (
+		streamName = "TEST"
+		subject    = "foo"
+		lastMsgID  = "A"
+	)
+	duplicateWindow := 100 * time.Millisecond
+
+	nc, js := jsClientConnect(t, s)
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:       streamName,
+		Subjects:   []string{subject},
+		Storage:    nats.FileStorage,
+		Duplicates: duplicateWindow,
+	})
+	require_NoError(t, err)
+
+	pa, err := js.Publish(subject, nil, nats.MsgId(lastMsgID))
+	require_NoError(t, err)
+	require_Equal(t, pa.Sequence, 1)
+
+	mset, err := s.GlobalAccount().lookupStream(streamName)
+	require_NoError(t, err)
+	checkFor(t, time.Second, 10*time.Millisecond, func() error {
+		if seq := mset.store.GetSeqFromTime(time.Now().Add(-duplicateWindow)); seq <= pa.Sequence {
+			return fmt.Errorf("last message still inside duplicate window at sequence %d", seq)
+		}
+		return nil
+	})
+
+	sd := s.JetStreamConfig().StoreDir
+	nc.Close()
+	s.Shutdown()
+	s.WaitForShutdown()
+
+	s = RunJetStreamServerOnPort(-1, sd)
+	defer s.Shutdown()
+	nc, js = jsClientConnect(t, s)
+	defer nc.Close()
+
+	msg := nats.NewMsg(subject)
+	msg.Header.Set(JSExpectedLastMsgId, lastMsgID)
+	pa, err = js.PublishMsg(msg)
+	require_NoError(t, err)
+	require_Equal(t, pa.Sequence, 2)
+}
+
 func TestJetStreamRedeliveryAfterServerRestart(t *testing.T) {
 	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()

--- a/server/stream.go
+++ b/server/stream.go
@@ -1601,6 +1601,16 @@ func (mset *stream) autoTuneFileStorageBlockSize(fsCfg *FileStoreConfig) {
 // headers and msgId in them. Would need signaling from the storage layer.
 // mset.mu and mset.ddMu locks should be held.
 func (mset *stream) rebuildDedupe() {
+	var smv StoreMsg
+	var state StreamState
+	mset.store.FastState(&state)
+
+	if state.LastSeq > 0 {
+		if sm, err := mset.store.LoadMsg(state.LastSeq, &smv); err == nil {
+			mset.lmsgId = getMsgId(sm.hdr)
+		}
+	}
+
 	duplicates := mset.cfg.Duplicates
 	if duplicates <= 0 {
 		return
@@ -1612,10 +1622,6 @@ func (mset *stream) rebuildDedupe() {
 		return
 	}
 
-	var smv StoreMsg
-	var state StreamState
-	mset.store.FastState(&state)
-
 	for seq := sseq; seq <= state.LastSeq; seq++ {
 		sm, err := mset.store.LoadMsg(seq, &smv)
 		if err != nil {
@@ -1626,9 +1632,6 @@ func (mset *stream) rebuildDedupe() {
 			if msgId = getMsgId(sm.hdr); msgId != _EMPTY_ {
 				mset.storeMsgIdLocked(&ddentry{msgId, sm.seq, sm.ts})
 			}
-		}
-		if seq == state.LastSeq {
-			mset.lmsgId = msgId
 		}
 	}
 }


### PR DESCRIPTION
On restart, the last message id was restored only if the last message was still within the duplicate window, and would otherwise be forgotten. A valid message using `Nats-Expected-Last-Msg-Id` could later be rejected.