### PR TITLE
(2.15) [FIXED] DefaultMaxConsumers override consistency

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -1160,11 +1160,14 @@ func (mset *stream) addConsumerWithAssignmentAndMode(config *ConsumerConfig, ona
 		// than stream config we prefer the account limits to handle cases where account limits are
 		// updated during the lifecycle of the stream
 		maxc := cfg.MaxConsumers
-		if maxConsumers := srvLim.DefaultMaxConsumers; maxConsumers > 0 && maxc <= 0 {
-			maxc = maxConsumers
-		}
 		if maxc <= 0 || (selectedLimits.MaxConsumers > 0 && selectedLimits.MaxConsumers < maxc) {
 			maxc = selectedLimits.MaxConsumers
+		}
+		// Only apply default limits if the user specified neither stream nor account limit.
+		// An unlimited (-1) stream or account limit counts as not set, since that is also
+		// the default for accounts, so the default can't be opted out of per stream or account.
+		if maxConsumers := srvLim.DefaultMaxConsumers; maxConsumers > 0 && maxc <= 0 {
+			maxc = maxConsumers
 		}
 		if maxc > 0 && mset.numLimitableConsumers() >= maxc {
 			mset.mu.Unlock()

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -11611,7 +11611,10 @@ func (s *Server) jsClusteredConsumerRequest(ci *ClientInfo, acc *Account, subjec
 		// counts.
 		streamMaxc := sa.Config.MaxConsumers
 		tierMaxc := selectedLimits.MaxConsumers
-		if maxConsumers := s.getOpts().JetStreamLimits.DefaultMaxConsumers; maxConsumers > 0 && streamMaxc <= 0 {
+		// Only apply default limits if the user specified neither stream nor account limit.
+		// An unlimited (-1) stream or account limit counts as not set, since that is also
+		// the default for accounts, so the default can't be opted out of per stream or account.
+		if maxConsumers := s.getOpts().JetStreamLimits.DefaultMaxConsumers; maxConsumers > 0 && streamMaxc <= 0 && tierMaxc <= 0 {
 			streamMaxc = maxConsumers
 		}
 		if streamMaxc > 0 || tierMaxc > 0 {

--- a/server/jetstream_cluster_2_test.go
+++ b/server/jetstream_cluster_2_test.go
@@ -9504,8 +9504,7 @@ func TestJetStreamClusterDefaultMaxConsumers(t *testing.T) {
 
 	// The consumer limit is now reached, so creating more is rejected.
 	_, err = js.AddConsumer("S", &nats.ConsumerConfig{Durable: "C3", AckPolicy: nats.AckExplicitPolicy})
-	require_Error(t, err)
-	require_Contains(t, err.Error(), "maximum consumers limit reached")
+	require_Error(t, err, NewJSMaximumConsumersLimitError())
 	nc.Close()
 
 	// Restart the cluster with the limit lowered to 1.
@@ -9534,8 +9533,7 @@ func TestJetStreamClusterDefaultMaxConsumers(t *testing.T) {
 		require_NoError(t, err)
 	}
 	_, err = js.AddConsumer("S", &nats.ConsumerConfig{Durable: "C3", AckPolicy: nats.AckExplicitPolicy})
-	require_Error(t, err)
-	require_Contains(t, err.Error(), "maximum consumers limit reached")
+	require_Error(t, err, NewJSMaximumConsumersLimitError())
 
 	// Existing assets can still be idempotently recreated and updated, even while
 	// above the lowered limit, since that doesn't add new assets.
@@ -9569,8 +9567,7 @@ func TestJetStreamClusterDefaultMaxConsumersSourcingExempt(t *testing.T) {
 		require_NoError(t, err)
 	}
 	_, err = js.AddConsumer("S", &nats.ConsumerConfig{Durable: "C3", AckPolicy: nats.AckExplicitPolicy})
-	require_Error(t, err)
-	require_Contains(t, err.Error(), "maximum consumers limit reached")
+	require_Error(t, err, NewJSMaximumConsumersLimitError())
 
 	// Mirroring/sourcing "S" creates internal Direct/Sourcing consumers on it,
 	// those are not counted toward the limit and must not be rejected by it.
@@ -9601,8 +9598,54 @@ func TestJetStreamClusterDefaultMaxConsumersSourcingExempt(t *testing.T) {
 
 	// Regular consumers must still be rejected.
 	_, err = js.AddConsumer("S", &nats.ConsumerConfig{Durable: "C3", AckPolicy: nats.AckExplicitPolicy})
-	require_Error(t, err)
-	require_Contains(t, err.Error(), "maximum consumers limit reached")
+	require_Error(t, err, NewJSMaximumConsumersLimitError())
+}
+
+func TestJetStreamClusterDefaultMaxConsumersOnlyWithoutStreamOrAccountLimit(t *testing.T) {
+	// The default only applies when neither the stream nor the account sets
+	// a max consumers limit. If either is set, that takes precedence, even
+	// when it's higher than the default.
+	for _, test := range []struct {
+		name       string
+		accountMax int // 0 leaves the account limit unset, -1 is unlimited.
+		streamMax  int // 0 leaves the stream limit unset, -1 is unlimited.
+		expected   int
+	}{
+		{"neither set, default applies", 0, 0, 2},
+		{"stream above default", 0, 4, 4},
+		{"stream below default", 0, 1, 1},
+		{"account above default", 4, 0, 4},
+		{"account below default", 1, 0, 1},
+		{"both set, stream lowest", 4, 3, 3},
+		{"both set, equal", 3, 3, 3},
+		// Unlimited counts as not set, the default can't be opted out of.
+		{"stream unlimited, default applies", 0, -1, 2},
+		{"account unlimited, default applies", -1, 0, 2},
+		{"both unlimited, default applies", -1, -1, 2},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			accountLimit := "enabled"
+			if test.accountMax != 0 {
+				accountLimit = fmt.Sprintf("{ max_consumers: %d }", test.accountMax)
+			}
+			tmpl := strings.Replace(jsClusterAssetLimitsTempl, "accounts {",
+				"accounts {\n\tA { jetstream: "+accountLimit+", users = [ { user: \"a\", pass: \"pwd\" } ] }\n", 1)
+			c := createJetStreamClusterWithTemplate(t, tmpl, "ALT", 3)
+			defer c.shutdown()
+
+			nc, js := jsClientConnect(t, c.randomServer(), nats.UserInfo("a", "pwd"))
+			defer nc.Close()
+
+			_, err := js.AddStream(&nats.StreamConfig{Name: "S", Subjects: []string{"S.>"}, Replicas: 3, MaxConsumers: test.streamMax})
+			require_NoError(t, err)
+			for i := range test.expected {
+				_, err = js.AddConsumer("S", &nats.ConsumerConfig{Durable: fmt.Sprintf("C%d", i), AckPolicy: nats.AckExplicitPolicy})
+				require_NoError(t, err)
+			}
+			_, err = js.AddConsumer("S", &nats.ConsumerConfig{Durable: "OVER", AckPolicy: nats.AckExplicitPolicy})
+			require_Error(t, err, NewJSMaximumConsumersLimitError())
+		})
+	}
 }
 
 //

--- a/server/jetstream_helpers_test.go
+++ b/server/jetstream_helpers_test.go
@@ -538,6 +538,7 @@ func createJetStreamSuperClusterWithTemplateAndModHook(t *testing.T, tmpl string
 	}
 
 	sc := &supercluster{t, clusters, nproxies}
+	sc.campaignMetaImmediately()
 	sc.waitOnLeader()
 	sc.waitOnAllCurrent()
 
@@ -601,7 +602,7 @@ func (sc *supercluster) waitOnLeader() {
 		}
 		time.Sleep(25 * time.Millisecond)
 	}
-	antithesis.AssertUnreachable(sc.t, "Timeout in supercluster.waitOnStreamLeader", nil)
+	antithesis.AssertUnreachable(sc.t, "Timeout in supercluster.waitOnLeader", nil)
 	sc.t.Fatalf("Expected a cluster leader, got none")
 }
 
@@ -624,6 +625,14 @@ func (sc *supercluster) waitOnAccount(account string) {
 	}
 
 	sc.t.Fatalf("Expected account %q to exist but didn't", account)
+}
+
+func (sc *supercluster) campaignMetaImmediately() {
+	var servers []*Server
+	for _, c := range sc.clusters {
+		servers = append(servers, c.servers...)
+	}
+	campaignMetaImmediately(servers)
 }
 
 func (sc *supercluster) waitOnAllCurrent() {
@@ -787,6 +796,7 @@ func createMixedModeCluster(t testing.TB, tmpl string, clusterName, snPre string
 	// Wait til we are formed and have a leader.
 	c.checkClusterFormed()
 	if numJsServers > 0 {
+		c.campaignMetaImmediately()
 		c.waitOnPeerCount(numJsServers)
 	}
 
@@ -884,10 +894,39 @@ func createJetStreamClusterEx(t testing.TB, tmpl, cName, snPre string, numServer
 	// Wait til we are formed and have a leader.
 	c.checkClusterFormed()
 	if wait {
+		c.campaignMetaImmediately()
 		c.waitOnClusterReady()
 	}
 
 	return c
+}
+
+func (c *cluster) campaignMetaImmediately() {
+	campaignMetaImmediately(c.servers)
+}
+
+func campaignMetaImmediately(servers []*Server) {
+	// Only campaign on a single meta group, but check all servers first
+	// since one could already know of a leader. Pick the campaigning server
+	// at random so tests don't always end up with the same meta leader.
+	var nodes []RaftNode
+	for _, s := range servers {
+		js := s.getJetStream()
+		if js == nil {
+			continue
+		}
+		n := js.getMetaGroup()
+		if n == nil {
+			continue
+		}
+		if n.GroupLeader() != _EMPTY_ {
+			return
+		}
+		nodes = append(nodes, n)
+	}
+	if len(nodes) > 0 {
+		nodes[rand.IntN(len(nodes))].CampaignImmediately()
+	}
 }
 
 func (c *cluster) addInNewServer() *Server {
@@ -1623,9 +1662,27 @@ func (c *cluster) waitOnServerCurrent(s *Server) {
 
 func (c *cluster) waitOnAllCurrent() {
 	c.t.Helper()
-	for _, cs := range c.servers {
-		c.waitOnServerCurrent(cs)
+	// Callers use this to wait for a proposal they just made to be applied,
+	// so give it a chance to be committed before checking for currency.
+	time.Sleep(100 * time.Millisecond)
+	expires := time.Now().Add(30 * time.Second)
+	for time.Now().Before(expires) {
+		current := true
+		for _, s := range c.servers {
+			if s.JetStreamEnabled() && !s.JetStreamIsCurrent() {
+				current = false
+				break
+			}
+		}
+		if current {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
+	antithesis.AssertUnreachable(c.t, "Timeout in cluster.waitOnAllCurrent", map[string]any{
+		"cluster": c.name,
+	})
+	c.t.Fatalf("Expected all servers in cluster %q to eventually be current", c.name)
 }
 
 func (c *cluster) serverByName(sname string) *Server {
@@ -1719,7 +1776,6 @@ func (c *cluster) waitOnAccount(account string) {
 func (c *cluster) waitOnClusterReady() {
 	c.t.Helper()
 	c.waitOnClusterReadyWithNumPeers(len(c.servers))
-	c.waitOnLeader()
 }
 
 func (c *cluster) waitOnClusterReadyWithNumPeers(numPeersExpected int) {
@@ -1733,8 +1789,16 @@ func (c *cluster) waitOnClusterReadyWithNumPeers(numPeersExpected int) {
 			continue
 		}
 		if len(leader.JetStreamClusterPeers()) == numPeersExpected {
-			time.Sleep(100 * time.Millisecond)
-			return
+			current := true
+			for _, s := range c.servers {
+				if s.Running() && s.JetStreamEnabled() && !s.JetStreamIsCurrent() {
+					current = false
+					break
+				}
+			}
+			if current {
+				return
+			}
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
@@ -1812,6 +1876,8 @@ func (c *cluster) restartAll() {
 			c.opts[i] = o
 		}
 	}
+	c.checkClusterFormed()
+	c.campaignMetaImmediately()
 	c.waitOnClusterReady()
 }
 
@@ -1829,6 +1895,8 @@ func (c *cluster) lameDuckRestartAll() {
 			c.opts[i] = o
 		}
 	}
+	c.checkClusterFormed()
+	c.campaignMetaImmediately()
 	c.waitOnClusterReady()
 }
 
@@ -1841,6 +1909,8 @@ func (c *cluster) restartAllSamePorts() {
 			c.servers[i] = s
 		}
 	}
+	c.checkClusterFormed()
+	c.campaignMetaImmediately()
 	c.waitOnClusterReady()
 }
 

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -6571,8 +6571,7 @@ func TestJetStreamDefaultMaxConsumers(t *testing.T) {
 
 	// The limit is now reached, so creating more is rejected.
 	_, err = js.AddConsumer("S", &nats.ConsumerConfig{Durable: "C3", AckPolicy: nats.AckExplicitPolicy})
-	require_Error(t, err)
-	require_Contains(t, err.Error(), "maximum consumers limit reached")
+	require_Error(t, err, NewJSMaximumConsumersLimitError())
 
 	// Updating or idempotently recreating existing assets does not add new
 	// ones and must still be allowed while at the limit.
@@ -6603,12 +6602,10 @@ func TestJetStreamDefaultMaxConsumers(t *testing.T) {
 	})
 
 	_, err = js.AddConsumer("S", &nats.ConsumerConfig{Durable: "C3", AckPolicy: nats.AckExplicitPolicy})
-	require_Error(t, err)
-	require_Contains(t, err.Error(), "maximum consumers limit reached")
+	require_Error(t, err, NewJSMaximumConsumersLimitError())
 	// Ephemerals are new consumers as well.
 	_, err = js.AddConsumer("S", &nats.ConsumerConfig{AckPolicy: nats.AckExplicitPolicy})
-	require_Error(t, err)
-	require_Contains(t, err.Error(), "maximum consumers limit reached")
+	require_Error(t, err, NewJSMaximumConsumersLimitError())
 
 	// Existing assets can still be idempotently recreated and updated, even while
 	// above the lowered limit, since that doesn't add new assets.
@@ -6641,8 +6638,7 @@ func TestJetStreamDefaultMaxConsumersSourcingExempt(t *testing.T) {
 	_, err = js.AddConsumer("S", &nats.ConsumerConfig{Durable: "C1", AckPolicy: nats.AckExplicitPolicy})
 	require_NoError(t, err)
 	_, err = js.AddConsumer("S", &nats.ConsumerConfig{Durable: "C2", AckPolicy: nats.AckExplicitPolicy})
-	require_Error(t, err)
-	require_Contains(t, err.Error(), "maximum consumers limit reached")
+	require_Error(t, err, NewJSMaximumConsumersLimitError())
 
 	// Mirroring/sourcing "S" creates internal Direct/Sourcing consumers on it,
 	// those are not counted toward the limit and must not be rejected by it.
@@ -6672,8 +6668,67 @@ func TestJetStreamDefaultMaxConsumersSourcingExempt(t *testing.T) {
 
 	// Regular consumers must still be rejected.
 	_, err = js.AddConsumer("S", &nats.ConsumerConfig{Durable: "C2", AckPolicy: nats.AckExplicitPolicy})
-	require_Error(t, err)
-	require_Contains(t, err.Error(), "maximum consumers limit reached")
+	require_Error(t, err, NewJSMaximumConsumersLimitError())
+}
+
+func TestJetStreamDefaultMaxConsumersOnlyWithoutStreamOrAccountLimit(t *testing.T) {
+	// The default only applies when neither the stream nor the account sets
+	// a max consumers limit. If either is set, that takes precedence, even
+	// when it's higher than the default.
+	for _, test := range []struct {
+		name       string
+		accountMax int // 0 leaves the account limit unset, -1 is unlimited.
+		streamMax  int // 0 leaves the stream limit unset, -1 is unlimited.
+		expected   int
+	}{
+		{"neither set, default applies", 0, 0, 2},
+		{"stream above default", 0, 4, 4},
+		{"stream below default", 0, 1, 1},
+		{"account above default", 4, 0, 4},
+		{"account below default", 1, 0, 1},
+		{"both set, stream lowest", 4, 3, 3},
+		{"both set, equal", 3, 3, 3},
+		// Unlimited counts as not set, the default can't be opted out of.
+		{"stream unlimited, default applies", 0, -1, 2},
+		{"account unlimited, default applies", -1, 0, 2},
+		{"both unlimited, default applies", -1, -1, 2},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			accountLimit := "enabled"
+			if test.accountMax != 0 {
+				accountLimit = fmt.Sprintf("{ max_consumers: %d }", test.accountMax)
+			}
+			conf := createConfFile(t, []byte(fmt.Sprintf(`
+				listen: 127.0.0.1:-1
+				jetstream: {
+					store_dir: %q
+					limits: {
+						default_max_consumers: 2
+					}
+				}
+				accounts {
+					A {
+						jetstream: %s
+						users = [ { user: "a", pass: "pwd" } ]
+					}
+				}
+			`, t.TempDir(), accountLimit)))
+			s, _ := RunServerWithConfig(conf)
+			defer s.Shutdown()
+
+			nc, js := jsClientConnect(t, s, nats.UserInfo("a", "pwd"))
+			defer nc.Close()
+
+			_, err := js.AddStream(&nats.StreamConfig{Name: "S", Subjects: []string{"S.>"}, MaxConsumers: test.streamMax})
+			require_NoError(t, err)
+			for i := range test.expected {
+				_, err = js.AddConsumer("S", &nats.ConsumerConfig{Durable: fmt.Sprintf("C%d", i), AckPolicy: nats.AckExplicitPolicy})
+				require_NoError(t, err)
+			}
+			_, err = js.AddConsumer("S", &nats.ConsumerConfig{Durable: "OVER", AckPolicy: nats.AckExplicitPolicy})
+			require_Error(t, err, NewJSMaximumConsumersLimitError())
+		})
+	}
 }
 
 type obsi struct {

--- a/server/norace_1_test.go
+++ b/server/norace_1_test.go
@@ -8418,7 +8418,7 @@ func TestNoRaceRoutePoolAndPerAccountConfigReload(t *testing.T) {
 						if strings.Contains(e, "No route for account") {
 							numErrs++
 						}
-					case <-time.After(DEFAULT_ROUTE_RECONNECT + 250*time.Millisecond):
+					case <-time.After(routeReconnectDelay + 500*time.Millisecond):
 						ok = true
 					}
 				}

--- a/server/opts.go
+++ b/server/opts.go
@@ -383,7 +383,7 @@ type JSLimitOpts struct {
 	MaxBatchTimeout           time.Duration `json:"max_batch_timeout,omitempty"`             // MaxBatchTimeout is the maximum time to receive the commit message after receiving the first message of a batch
 
 	// Max asset limits
-	DefaultMaxConsumers int `json:"default_max_consumers,omitempty"` // DefaultMaxConsumers is the maximum number of consumers per stream (unless overwritten on the stream) (-1=unlimited)
+	DefaultMaxConsumers int `json:"default_max_consumers,omitempty"` // DefaultMaxConsumers is the maximum number of consumers per stream (unless overwritten on the stream or the account) (-1=unlimited)
 }
 
 type JSTpmOpts struct {

--- a/server/reload_test.go
+++ b/server/reload_test.go
@@ -1858,7 +1858,7 @@ func TestConfigReloadClusterRemoveSolicitedRoutes(t *testing.T) {
 
 	// We should not have a cluster formed here.
 	numRoutes := 0
-	deadline := time.Now().Add(2 * DEFAULT_ROUTE_RECONNECT)
+	deadline := time.Now().Add(routeReconnectDelay + 500*time.Millisecond)
 	for time.Now().Before(deadline) {
 		if numRoutes = srva.NumRoutes(); numRoutes != 0 {
 			break

--- a/server/route.go
+++ b/server/route.go
@@ -148,6 +148,7 @@ const (
 var (
 	routeConnectDelay    = DEFAULT_ROUTE_CONNECT
 	routeConnectMaxDelay = DEFAULT_ROUTE_CONNECT_MAX
+	routeReconnectDelay  = DEFAULT_ROUTE_RECONNECT
 	routeMaxPingInterval = defaultRouteMaxPingInterval
 )
 
@@ -2898,7 +2899,7 @@ func (s *Server) reConnectToRoute(rURL *url.URL, rtype RouteType, accName string
 	// Add some random delay to reduce risk of repeated failures.
 	delay := time.Duration(rand.IntN(100)) * time.Millisecond
 	if rtype == Explicit {
-		delay += DEFAULT_ROUTE_RECONNECT
+		delay += routeReconnectDelay
 	}
 	select {
 	case <-time.After(delay):

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -43,6 +43,7 @@ import (
 func init() {
 	routeConnectDelay = 15 * time.Millisecond
 	routeConnectMaxDelay = 15 * time.Millisecond
+	routeReconnectDelay = 15 * time.Millisecond
 }
 
 func checkNumRoutes(t *testing.T, s *Server, expected int) {
@@ -339,7 +340,7 @@ func checkClusterFormed(t testing.TB, servers ...*Server) {
 			enr = append(enr, total)
 		}
 	}
-	checkFor(t, 10*time.Second, 100*time.Millisecond, func() error {
+	checkFor(t, 10*time.Second, 15*time.Millisecond, func() error {
 		for i, s := range servers {
 			if numRoutes := s.NumRoutes(); numRoutes != enr[i] {
 				return fmt.Errorf("Expected %d routes for server %q, got %d", enr[i], s, numRoutes)
@@ -1785,7 +1786,7 @@ func TestRouteReconnectExponentialBackoff(t *testing.T) {
 	s2.SetLogger(l, true, false)
 
 	// Remove initial delay before reconnect, and allow for some skew.
-	now := time.Now().Add(DEFAULT_ROUTE_RECONNECT).Add(-100 * time.Millisecond)
+	now := time.Now().Add(routeReconnectDelay).Add(-100 * time.Millisecond)
 	var delay time.Duration
 
 	// S2 should retry ConnectRetries+1 times and then stop
@@ -1959,7 +1960,7 @@ func TestRoutePoolAndPerAccountErrors(t *testing.T) {
 		case <-time.After(2 * time.Second):
 			t.Fatalf("Did not get expected error regarding no route for account")
 		}
-		time.Sleep(DEFAULT_ROUTE_RECONNECT + 100*time.Millisecond)
+		time.Sleep(routeReconnectDelay + 100*time.Millisecond)
 	}
 }
 
@@ -2149,7 +2150,7 @@ func TestRoutePoolConnectRace(t *testing.T) {
 							t.Fatalf("Routes are constantly reconnecting: %v", e)
 						}
 					}
-				case <-time.After(DEFAULT_ROUTE_RECONNECT + 250*time.Millisecond):
+				case <-time.After(routeReconnectDelay + 500*time.Millisecond):
 					// More than reconnect and some, and no reconnect, so we are good.
 					done = true
 				}
@@ -2838,7 +2839,7 @@ func TestRoutePerAccountConnectRace(t *testing.T) {
 					t.Fatalf("Routes are constantly reconnecting: %v", e)
 				}
 			}
-		case <-time.After(DEFAULT_ROUTE_RECONNECT + 250*time.Millisecond):
+		case <-time.After(routeReconnectDelay + 500*time.Millisecond):
 			// More than reconnect and some, and no reconnect, so we are good.
 			done = true
 		}
@@ -3743,6 +3744,11 @@ func TestRoutePoolWithOlderServerConnectAndReconnect(t *testing.T) {
 }
 
 func TestRoutePoolBadAuthNoRunawayCreateRoute(t *testing.T) {
+	// This test checks the reconnect rate, so use the default reconnect delay.
+	oRouteReconnectDelay := routeReconnectDelay
+	routeReconnectDelay = DEFAULT_ROUTE_RECONNECT
+	defer func() { routeReconnectDelay = oRouteReconnectDelay }()
+
 	conf1 := createConfFile(t, []byte(`
 		server_name: "S1"
 		listen: "127.0.0.1:-1"

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -2039,7 +2039,7 @@ func TestReconnectErrorReports(t *testing.T) {
 	cs.Shutdown()
 
 	// Specifically for route test, wait at least reconnect interval before checking logs
-	time.Sleep(DEFAULT_ROUTE_RECONNECT)
+	time.Sleep(routeReconnectDelay)
 
 	checkContent := func(t *testing.T, txt string, attempt int, shouldBeThere bool) {
 		t.Helper()


### PR DESCRIPTION
The `default_max_consumers` setting now properly only overrides if neither an explicit stream nor account limit exist.

Also sped up (super) cluster tests by campaigning the meta leader early, less redundant sleeps, and shorter route reconnect delays under tests.