### PR TITLE
Optimise `NumPending` and `NumPendingMulti` when max messages per subject is 1

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -4325,12 +4325,13 @@ func (fs *fileStore) NumPending(sseq uint64, filter string, lastPerSubject bool)
 		return isSubsetMatchTokenized(tsa, fsa)
 	}
 
-	// Handle last by subject a bit differently.
+	// Use the per-subject index when at most one message per subject should be counted.
+	// This applies to last-per-subject consumers and streams limited to one message per subject.
 	// We will scan PSIM since we accurately track the last block we have seen the subject in. This
 	// allows us to only need to load at most one block now.
 	// For the last block, we need to track the subjects that we know are in that block, and track seen
 	// while in the block itself, but complexity there worth it.
-	if lastPerSubject {
+	if lastPerSubject || fs.cfg.MaxMsgsPer == 1 {
 		// If we want all and our start sequence is equal or less than first return number of subjects.
 		if isAll && sseq <= fs.state.FirstSeq {
 			return uint64(fs.psim.Size()), validThrough, nil
@@ -4665,12 +4666,13 @@ func (fs *fileStore) NumPendingMulti(sseq uint64, sl *gsl.SimpleSublist, lastPer
 		return sl.HasInterest(subj)
 	}
 
-	// Handle last by subject a bit differently.
+	// Use the per-subject index when at most one message per subject should be counted.
+	// This applies to last-per-subject consumers and streams limited to one message per subject.
 	// We will scan PSIM since we accurately track the last block we have seen the subject in. This
 	// allows us to only need to load at most one block now.
 	// For the last block, we need to track the subjects that we know are in that block, and track seen
 	// while in the block itself, but complexity there worth it.
-	if lastPerSubject {
+	if lastPerSubject || fs.cfg.MaxMsgsPer == 1 {
 		// If we want all and our start sequence is equal or less than first return number of subjects.
 		if isAll && sseq <= fs.state.FirstSeq {
 			return uint64(fs.psim.Size()), validThrough, nil

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -7529,7 +7529,7 @@ func TestFileStoreFSSExpire(t *testing.T) {
 func TestFileStoreFSSExpireNumPending(t *testing.T) {
 	fs, err := newFileStore(
 		FileStoreConfig{StoreDir: t.TempDir(), BlockSize: 8192, CacheExpire: 1 * time.Second, SubjectStateExpire: 2 * time.Second},
-		StreamConfig{Name: "zzz", Subjects: []string{"foo.*.*"}, MaxMsgsPer: 1, Storage: FileStorage})
+		StreamConfig{Name: "zzz", Subjects: []string{"foo.*.*"}, Storage: FileStorage})
 	require_NoError(t, err)
 	defer fs.Stop()
 

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -9049,6 +9049,30 @@ func Benchmark_FileStoreSubjectStateConsistencyOptimizationPerf(b *testing.B) {
 	}
 }
 
+func Benchmark_FileStoreNumPendingMaxMsgsPerSubjectOneByStartSequence(b *testing.B) {
+	fs, err := newFileStore(
+		FileStoreConfig{StoreDir: b.TempDir(), BlockSize: 1024},
+		StreamConfig{Name: "TEST", Subjects: []string{"foo.*"}, Storage: FileStorage, MaxMsgsPer: 1},
+	)
+	require_NoError(b, err)
+	defer fs.Stop()
+
+	const numSubjects = 10_000
+	for i := 0; i < numSubjects*2; i++ {
+		_, _, err = fs.StoreMsg(fmt.Sprintf("foo.%d", i%numSubjects), nil, nil, 0)
+		require_NoError(b, err)
+	}
+
+	const startSeq = numSubjects + numSubjects/2
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		total, _, err := fs.NumPending(startSeq, "foo.*", false)
+		require_NoError(b, err)
+		require_Equal(b, total, uint64(numSubjects/2+1))
+	}
+}
+
 func benchmarkFileStoreSyncDeletedFullBlocks(b *testing.B, msgSize int) {
 	fs, _ := newFileStore(
 		FileStoreConfig{


### PR DESCRIPTION
In this case, we can consult the PSIM and shortcut scanning.

The attached benchmark before:

- 217358 ns/op
- 102044 B/op
- 200 allocs/op

... and after:

- 150158 ns/op
- 56380 B/op
- 46 allocs/op