### PR TITLE
Hold route interest for accounts that are not configured yet

### DIFF
--- a/server/reload.go
+++ b/server/reload.go
@@ -2352,9 +2352,9 @@ func (s *Server) reloadAuthorization() {
 		c.processSubsOnConfigReload(awcsti)
 	}
 
-	// Routes may have sent us interest for accounts that were not configured
-	// at the time. Apply the ones whose account this reload has introduced.
-	s.applyPendingRouteSubs()
+	// Routes may have advertised interest for accounts that were not configured
+	// at the time. Have them resend it if this reload introduced the account.
+	s.resyncRoutesForNewAccounts()
 
 	for _, route := range routes {
 		// Disconnect any unauthorized routes.

--- a/server/reload.go
+++ b/server/reload.go
@@ -2352,6 +2352,10 @@ func (s *Server) reloadAuthorization() {
 		c.processSubsOnConfigReload(awcsti)
 	}
 
+	// Routes may have sent us interest for accounts that were not configured
+	// at the time. Apply the ones whose account this reload has introduced.
+	s.applyPendingRouteSubs()
+
 	for _, route := range routes {
 		// Disconnect any unauthorized routes.
 		// Do this only for routes that were accepted, not initiated

--- a/server/route.go
+++ b/server/route.go
@@ -99,6 +99,9 @@ type route struct {
 	// the servers of a cluster one at a time, so this records that the route
 	// has to resend its subscriptions once the account arrives.
 	unknownAccounts map[string]struct{}
+	// Set when names had to be discarded because the map was full, so that a
+	// reload reconnects the route rather than deciding from an incomplete set.
+	unknownAccountsOverflow bool
 }
 
 // Maximum number of unknown account names recorded per route, so that a remote
@@ -109,27 +112,43 @@ const maxUnknownRouteAccounts = 256
 // account is not configured here. Lock should not be held.
 func (c *client) noteUnknownAccount(accName string) {
 	c.mu.Lock()
-	defer c.mu.Unlock()
 	if c.route == nil {
+		c.mu.Unlock()
 		return
 	}
 	if c.route.unknownAccounts == nil {
 		c.route.unknownAccounts = make(map[string]struct{})
 	}
-	if _, ok := c.route.unknownAccounts[accName]; ok {
-		return
+	if _, ok := c.route.unknownAccounts[accName]; !ok {
+		if len(c.route.unknownAccounts) < maxUnknownRouteAccounts {
+			c.route.unknownAccounts[accName] = struct{}{}
+		} else {
+			// Decide from a reconnect rather than from an incomplete set.
+			c.route.unknownAccountsOverflow = true
+		}
 	}
-	if len(c.route.unknownAccounts) >= maxUnknownRouteAccounts {
-		return
+	c.mu.Unlock()
+
+	// The account can be configured between the lookup that failed above and
+	// this being recorded, in which case a reload running concurrently has
+	// already looked at this route and will not look again. Check once more so
+	// the subscription is not left dropped until some later reload.
+	if _, err := c.srv.LookupAccount(accName); err == nil {
+		c.srv.resyncRoutesForNewAccounts()
 	}
-	c.route.unknownAccounts[accName] = struct{}{}
 }
 
 // Closes the routes that dropped interest for an account that has since been
 // configured, so that they resend their subscriptions when they reconnect.
-// Called after a configuration reload.
+// Called after a configuration reload, and when a route records an account
+// that turns out to be configured after all.
 func (s *Server) resyncRoutesForNewAccounts() {
-	var resync []*client
+	type candidate struct {
+		route    *client
+		names    []string
+		overflow bool
+	}
+	var candidates []candidate
 
 	s.mu.Lock()
 	s.forEachRoute(func(r *client) {
@@ -138,22 +157,41 @@ func (s *Server) resyncRoutesForNewAccounts() {
 		if r.route == nil {
 			return
 		}
-		for accName := range r.route.unknownAccounts {
-			// Not LookupAccount, which would take the server lock held here.
-			if _, ok := s.accounts.Load(accName); !ok {
-				continue
-			}
-			r.route.unknownAccounts = nil
-			resync = append(resync, r)
+		if len(r.route.unknownAccounts) == 0 && !r.route.unknownAccountsOverflow {
 			return
 		}
+		names := make([]string, 0, len(r.route.unknownAccounts))
+		for accName := range r.route.unknownAccounts {
+			names = append(names, accName)
+		}
+		candidates = append(candidates, candidate{r, names, r.route.unknownAccountsOverflow})
 	})
 	s.mu.Unlock()
 
-	// Outside of the lock above, closing takes it.
-	for _, r := range resync {
-		r.Debugf("Closing route to resend subscriptions for a newly configured account")
-		r.closeConnection(RouteRemoved)
+	// Resolved outside of the lock above, since a lookup can take it and can
+	// also materialize an account that a reloaded resolver has made available
+	// but that is not in the account map yet.
+	for _, c := range candidates {
+		resync := c.overflow
+		for _, accName := range c.names {
+			if resync {
+				break
+			}
+			if _, err := s.LookupAccount(accName); err == nil {
+				resync = true
+			}
+		}
+		if !resync {
+			continue
+		}
+		c.route.mu.Lock()
+		if c.route.route != nil {
+			c.route.route.unknownAccounts = nil
+			c.route.route.unknownAccountsOverflow = false
+		}
+		c.route.mu.Unlock()
+		c.route.Debugf("Closing route to resend subscriptions for a newly configured account")
+		c.route.closeConnection(RouteRemoved)
 	}
 }
 

--- a/server/route.go
+++ b/server/route.go
@@ -1656,17 +1656,26 @@ func (c *client) processRemoteSub(argo []byte, leafSub, hasOrigin bool) (err err
 		// When a client comes along, expiration will prevent it from being used,
 		// cause a fetch and update the account to what is should be.
 		if staticResolver {
-			c.Errorf("Unknown account %q for remote subject %q", accountName, sub.subject)
-			return
-		}
-		c.Debugf("Unknown account %q for remote subject %q", accountName, sub.subject)
+			// The account may simply not be configured here yet: a configuration
+			// reload that introduces an account reaches the servers of a cluster
+			// one at a time. Dropping the subscription would lose that interest
+			// for good, since nothing sends it again once the account appears,
+			// so hold it in a placeholder account instead. A reload updates
+			// accounts in place, so the interest survives into the real one, and
+			// an account that never appears in the configuration is removed by
+			// the next reload.
+			c.Debugf("Unknown account %q for remote subject %q, holding interest", accountName, sub.subject)
+			acc, _ = srv.LookupOrRegisterAccount(accountName)
+		} else {
+			c.Debugf("Unknown account %q for remote subject %q", accountName, sub.subject)
 
-		var isNew bool
-		if acc, isNew = srv.LookupOrRegisterAccount(accountName); isNew {
-			acc.mu.Lock()
-			acc.expired.Store(true)
-			acc.incomplete = true
-			acc.mu.Unlock()
+			var isNew bool
+			if acc, isNew = srv.LookupOrRegisterAccount(accountName); isNew {
+				acc.mu.Lock()
+				acc.expired.Store(true)
+				acc.incomplete = true
+				acc.mu.Unlock()
+			}
 		}
 	}
 

--- a/server/route.go
+++ b/server/route.go
@@ -94,6 +94,117 @@ type route struct {
 	// the creation of the next after receiving a PONG, ensuring
 	// that authentication did not fail.
 	startNewRoute *routeInfo
+	// Subscriptions received for accounts that are not configured here yet,
+	// keyed by account name and then by subject and queue name. A reload that
+	// introduces an account reaches the servers of a cluster one at a time, so
+	// these are held until it appears rather than dropped, which would lose
+	// the interest for good.
+	pendingSubs map[string]map[string]*pendingRouteSub
+}
+
+// A subscription received for an account this server does not know about yet.
+type pendingRouteSub struct {
+	arg       []byte
+	leafSub   bool
+	hasOrigin bool
+}
+
+// Maximum number of subscriptions held per route for accounts that are not
+// configured, so that a remote naming accounts that never appear cannot grow
+// this without bound.
+const maxPendingRouteSubs = 1024
+
+func pendingRouteSubKey(subject, queue []byte) string {
+	return bytesToString(subject) + "\x00" + bytesToString(queue)
+}
+
+// Records a subscription for an account that is not configured here yet so it
+// can be applied once the account appears. Lock should not be held.
+func (c *client) holdSubForUnknownAccount(accName string, sub *subscription, arg []byte, leafSub, hasOrigin bool) {
+	key := pendingRouteSubKey(sub.subject, sub.queue)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.route == nil {
+		return
+	}
+	if c.route.pendingSubs == nil {
+		c.route.pendingSubs = make(map[string]map[string]*pendingRouteSub)
+	}
+	subs, ok := c.route.pendingSubs[accName]
+	if _, held := subs[key]; !held {
+		var total int
+		for _, subs := range c.route.pendingSubs {
+			total += len(subs)
+		}
+		if total >= maxPendingRouteSubs {
+			c.Warnf("Dropping subscription on %q for unknown account %q, %d subscriptions already held",
+				sub.subject, accName, total)
+			return
+		}
+	}
+	if !ok {
+		subs = make(map[string]*pendingRouteSub)
+		c.route.pendingSubs[accName] = subs
+	}
+	// Copy, the argument references the read buffer.
+	subs[key] = &pendingRouteSub{arg: append([]byte(nil), arg...), leafSub: leafSub, hasOrigin: hasOrigin}
+}
+
+// Drops a held subscription when the remote unsubscribes before the account
+// has appeared. Lock should not be held.
+func (c *client) removePendingSubForUnknownAccount(accName string, subject, queue []byte) {
+	key := pendingRouteSubKey(subject, queue)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.route == nil {
+		return
+	}
+	if subs, ok := c.route.pendingSubs[accName]; ok {
+		delete(subs, key)
+		if len(subs) == 0 {
+			delete(c.route.pendingSubs, accName)
+		}
+	}
+}
+
+// Applies the subscriptions held for accounts that have since been configured.
+// Called after a configuration reload.
+func (s *Server) applyPendingRouteSubs() {
+	type heldSubs struct {
+		route *client
+		subs  []*pendingRouteSub
+	}
+	var held []heldSubs
+
+	s.forEachRoute(func(r *client) {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		if r.route == nil || len(r.route.pendingSubs) == 0 {
+			return
+		}
+		var subs []*pendingRouteSub
+		for accName, accSubs := range r.route.pendingSubs {
+			if _, err := s.LookupAccount(accName); err != nil {
+				continue
+			}
+			for _, sub := range accSubs {
+				subs = append(subs, sub)
+			}
+			delete(r.route.pendingSubs, accName)
+		}
+		if len(subs) > 0 {
+			held = append(held, heldSubs{r, subs})
+		}
+	})
+
+	// Applied outside of the lock above, since this takes it again.
+	for _, h := range held {
+		for _, sub := range h.subs {
+			h.route.processRemoteSub(sub.arg, sub.leafSub, sub.hasOrigin)
+		}
+	}
 }
 
 // This contains the information required to create a new route.
@@ -1430,7 +1541,7 @@ func (c *client) processRemoteUnsub(arg []byte, leafUnsub bool) (err error) {
 	c.mu.Unlock()
 
 	hasOrigin := leafUnsub && originSupport
-	origin, accNameFromProto, subject, _, err := c.parseUnsubProto(arg, accInProto, hasOrigin)
+	origin, accNameFromProto, subject, queue, err := c.parseUnsubProto(arg, accInProto, hasOrigin)
 	if err != nil {
 		return fmt.Errorf("processRemoteUnsub %s", err.Error())
 	}
@@ -1444,6 +1555,7 @@ func (c *client) processRemoteUnsub(arg []byte, leafUnsub bool) (err error) {
 		acc = v.(*Account)
 	} else {
 		c.Debugf("Unknown account %q for subject %q", accountName, subject)
+		c.removePendingSubForUnknownAccount(accountName, subject, queue)
 		return nil
 	}
 
@@ -1656,26 +1768,23 @@ func (c *client) processRemoteSub(argo []byte, leafSub, hasOrigin bool) (err err
 		// When a client comes along, expiration will prevent it from being used,
 		// cause a fetch and update the account to what is should be.
 		if staticResolver {
-			// The account may simply not be configured here yet: a configuration
-			// reload that introduces an account reaches the servers of a cluster
-			// one at a time. Dropping the subscription would lose that interest
-			// for good, since nothing sends it again once the account appears,
-			// so hold it in a placeholder account instead. A reload updates
-			// accounts in place, so the interest survives into the real one, and
-			// an account that never appears in the configuration is removed by
-			// the next reload.
-			c.Debugf("Unknown account %q for remote subject %q, holding interest", accountName, sub.subject)
-			acc, _ = srv.LookupOrRegisterAccount(accountName)
-		} else {
-			c.Debugf("Unknown account %q for remote subject %q", accountName, sub.subject)
+			// The account may simply not be configured here yet: a reload that
+			// introduces one reaches the servers of a cluster one at a time.
+			// Nothing sends this subscription again once the account appears,
+			// so hold it rather than drop it, otherwise the interest is lost
+			// for good and messages are discarded at the account boundary.
+			c.Debugf("Holding subscription on %q for unknown account %q", sub.subject, accountName)
+			c.holdSubForUnknownAccount(accountName, sub, argo, leafSub, hasOrigin)
+			return
+		}
+		c.Debugf("Unknown account %q for remote subject %q", accountName, sub.subject)
 
-			var isNew bool
-			if acc, isNew = srv.LookupOrRegisterAccount(accountName); isNew {
-				acc.mu.Lock()
-				acc.expired.Store(true)
-				acc.incomplete = true
-				acc.mu.Unlock()
-			}
+		var isNew bool
+		if acc, isNew = srv.LookupOrRegisterAccount(accountName); isNew {
+			acc.mu.Lock()
+			acc.expired.Store(true)
+			acc.incomplete = true
+			acc.mu.Unlock()
 		}
 	}
 

--- a/server/route.go
+++ b/server/route.go
@@ -94,116 +94,66 @@ type route struct {
 	// the creation of the next after receiving a PONG, ensuring
 	// that authentication did not fail.
 	startNewRoute *routeInfo
-	// Subscriptions received for accounts that are not configured here yet,
-	// keyed by account name and then by subject and queue name. A reload that
-	// introduces an account reaches the servers of a cluster one at a time, so
-	// these are held until it appears rather than dropped, which would lose
-	// the interest for good.
-	pendingSubs map[string]map[string]*pendingRouteSub
+	// Names of accounts this route advertised interest for that were not
+	// configured here at the time. A reload that introduces an account reaches
+	// the servers of a cluster one at a time, so this records that the route
+	// has to resend its subscriptions once the account arrives.
+	unknownAccounts map[string]struct{}
 }
 
-// A subscription received for an account this server does not know about yet.
-type pendingRouteSub struct {
-	arg       []byte
-	leafSub   bool
-	hasOrigin bool
-}
+// Maximum number of unknown account names recorded per route, so that a remote
+// naming accounts that never appear cannot grow this without bound.
+const maxUnknownRouteAccounts = 256
 
-// Maximum number of subscriptions held per route for accounts that are not
-// configured, so that a remote naming accounts that never appear cannot grow
-// this without bound.
-const maxPendingRouteSubs = 1024
-
-func pendingRouteSubKey(subject, queue []byte) string {
-	return bytesToString(subject) + "\x00" + bytesToString(queue)
-}
-
-// Records a subscription for an account that is not configured here yet so it
-// can be applied once the account appears. Lock should not be held.
-func (c *client) holdSubForUnknownAccount(accName string, sub *subscription, arg []byte, leafSub, hasOrigin bool) {
-	key := pendingRouteSubKey(sub.subject, sub.queue)
-
+// Records that interest from this route could not be applied because the
+// account is not configured here. Lock should not be held.
+func (c *client) noteUnknownAccount(accName string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.route == nil {
 		return
 	}
-	if c.route.pendingSubs == nil {
-		c.route.pendingSubs = make(map[string]map[string]*pendingRouteSub)
+	if c.route.unknownAccounts == nil {
+		c.route.unknownAccounts = make(map[string]struct{})
 	}
-	subs, ok := c.route.pendingSubs[accName]
-	if _, held := subs[key]; !held {
-		var total int
-		for _, subs := range c.route.pendingSubs {
-			total += len(subs)
-		}
-		if total >= maxPendingRouteSubs {
-			c.Warnf("Dropping subscription on %q for unknown account %q, %d subscriptions already held",
-				sub.subject, accName, total)
-			return
-		}
-	}
-	if !ok {
-		subs = make(map[string]*pendingRouteSub)
-		c.route.pendingSubs[accName] = subs
-	}
-	// Copy, the argument references the read buffer.
-	subs[key] = &pendingRouteSub{arg: append([]byte(nil), arg...), leafSub: leafSub, hasOrigin: hasOrigin}
-}
-
-// Drops a held subscription when the remote unsubscribes before the account
-// has appeared. Lock should not be held.
-func (c *client) removePendingSubForUnknownAccount(accName string, subject, queue []byte) {
-	key := pendingRouteSubKey(subject, queue)
-
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if c.route == nil {
+	if _, ok := c.route.unknownAccounts[accName]; ok {
 		return
 	}
-	if subs, ok := c.route.pendingSubs[accName]; ok {
-		delete(subs, key)
-		if len(subs) == 0 {
-			delete(c.route.pendingSubs, accName)
-		}
+	if len(c.route.unknownAccounts) >= maxUnknownRouteAccounts {
+		return
 	}
+	c.route.unknownAccounts[accName] = struct{}{}
 }
 
-// Applies the subscriptions held for accounts that have since been configured.
+// Closes the routes that dropped interest for an account that has since been
+// configured, so that they resend their subscriptions when they reconnect.
 // Called after a configuration reload.
-func (s *Server) applyPendingRouteSubs() {
-	type heldSubs struct {
-		route *client
-		subs  []*pendingRouteSub
-	}
-	var held []heldSubs
+func (s *Server) resyncRoutesForNewAccounts() {
+	var resync []*client
 
+	s.mu.Lock()
 	s.forEachRoute(func(r *client) {
 		r.mu.Lock()
 		defer r.mu.Unlock()
-		if r.route == nil || len(r.route.pendingSubs) == 0 {
+		if r.route == nil {
 			return
 		}
-		var subs []*pendingRouteSub
-		for accName, accSubs := range r.route.pendingSubs {
-			if _, err := s.LookupAccount(accName); err != nil {
+		for accName := range r.route.unknownAccounts {
+			// Not LookupAccount, which would take the server lock held here.
+			if _, ok := s.accounts.Load(accName); !ok {
 				continue
 			}
-			for _, sub := range accSubs {
-				subs = append(subs, sub)
-			}
-			delete(r.route.pendingSubs, accName)
-		}
-		if len(subs) > 0 {
-			held = append(held, heldSubs{r, subs})
+			r.route.unknownAccounts = nil
+			resync = append(resync, r)
+			return
 		}
 	})
+	s.mu.Unlock()
 
-	// Applied outside of the lock above, since this takes it again.
-	for _, h := range held {
-		for _, sub := range h.subs {
-			h.route.processRemoteSub(sub.arg, sub.leafSub, sub.hasOrigin)
-		}
+	// Outside of the lock above, closing takes it.
+	for _, r := range resync {
+		r.Debugf("Closing route to resend subscriptions for a newly configured account")
+		r.closeConnection(RouteRemoved)
 	}
 }
 
@@ -1541,7 +1491,7 @@ func (c *client) processRemoteUnsub(arg []byte, leafUnsub bool) (err error) {
 	c.mu.Unlock()
 
 	hasOrigin := leafUnsub && originSupport
-	origin, accNameFromProto, subject, queue, err := c.parseUnsubProto(arg, accInProto, hasOrigin)
+	origin, accNameFromProto, subject, _, err := c.parseUnsubProto(arg, accInProto, hasOrigin)
 	if err != nil {
 		return fmt.Errorf("processRemoteUnsub %s", err.Error())
 	}
@@ -1555,7 +1505,6 @@ func (c *client) processRemoteUnsub(arg []byte, leafUnsub bool) (err error) {
 		acc = v.(*Account)
 	} else {
 		c.Debugf("Unknown account %q for subject %q", accountName, subject)
-		c.removePendingSubForUnknownAccount(accountName, subject, queue)
 		return nil
 	}
 
@@ -1771,10 +1720,11 @@ func (c *client) processRemoteSub(argo []byte, leafSub, hasOrigin bool) (err err
 			// The account may simply not be configured here yet: a reload that
 			// introduces one reaches the servers of a cluster one at a time.
 			// Nothing sends this subscription again once the account appears,
-			// so hold it rather than drop it, otherwise the interest is lost
-			// for good and messages are discarded at the account boundary.
-			c.Debugf("Holding subscription on %q for unknown account %q", sub.subject, accountName)
-			c.holdSubForUnknownAccount(accountName, sub, argo, leafSub, hasOrigin)
+			// so remember the account and have the route resend everything
+			// after the reload that introduces it, otherwise the interest is
+			// lost for good and messages are discarded at the account boundary.
+			c.Errorf("Unknown account %q for remote subject %q", accountName, sub.subject)
+			c.noteUnknownAccount(accountName)
 			return
 		}
 		c.Debugf("Unknown account %q for remote subject %q", accountName, sub.subject)

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -5812,10 +5812,10 @@ func TestRouteReconnectAfterDuplicateRouteAdoptsConfiguredURL(t *testing.T) {
 
 // A configuration reload that introduces an account reaches the servers of a
 // cluster one at a time, so a server can receive interest for an account it
-// does not know yet. That interest has to be held rather than dropped: nothing
-// sends it again once the account appears, and the import is then left without
-// interest for good.
-func TestRouteSubForUnknownAccountHeldUntilConfigured(t *testing.T) {
+// does not know yet and has to drop it. Nothing sends that subscription again
+// once the account appears, so the route has to resend it, otherwise the
+// import is left without interest for good.
+func TestRouteSubForUnknownAccountResentOnceConfigured(t *testing.T) {
 	before := `
 		listen: 127.0.0.1:-1
 		cluster { name: C, listen: 127.0.0.1:%d, routes: [%s] }

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -5840,12 +5840,25 @@ func TestRouteSubForUnknownAccountHeldUntilConfigured(t *testing.T) {
 
 	// subFirst says whether the importing subscription exists before the second
 	// server learns about the exporting account.
+	// An unrelated reload can land on the peer while the account is still
+	// missing, which must not discard the interest held for it.
+	unrelated := `
+		listen: 127.0.0.1:-1
+		cluster { name: C, listen: 127.0.0.1:%d, routes: [%s] }
+		accounts {
+			IMP { users: [{user: imp, password: pwd}] }
+			OTHER { users: [{user: other, password: pwd}] }
+		}
+	`
+
 	for _, test := range []struct {
-		name     string
-		subFirst bool
+		name       string
+		subFirst   bool
+		interleave bool
 	}{
-		{"sub before the peer knows the account", true},
-		{"sub after both servers know the account", false},
+		{"sub before the peer knows the account", true, false},
+		{"sub after both servers know the account", false, false},
+		{"unrelated reload on the peer first", true, true},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			confA := createConfFile(t, []byte(fmt.Sprintf(before, -1, "")))
@@ -5880,6 +5893,10 @@ func TestRouteSubForUnknownAccountHeldUntilConfigured(t *testing.T) {
 				_, err := sa.LookupAccount("EXP")
 				return err
 			})
+			if test.interleave {
+				reloadUpdateConfig(t, sb, confB, fmt.Sprintf(unrelated, ob.Cluster.Port, routeToA))
+				checkClusterFormed(t, sa, sb)
+			}
 			reloadUpdateConfig(t, sb, confB, fmt.Sprintf(after, ob.Cluster.Port, routeToA))
 			checkClusterFormed(t, sa, sb)
 

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -5809,3 +5809,95 @@ func TestRouteReconnectAfterDuplicateRouteAdoptsConfiguredURL(t *testing.T) {
 	_, err = nca.Request("pinned.echo", []byte("ping"), time.Second)
 	require_NoError(t, err)
 }
+
+// A configuration reload that introduces an account reaches the servers of a
+// cluster one at a time, so a server can receive interest for an account it
+// does not know yet. That interest has to be held rather than dropped: nothing
+// sends it again once the account appears, and the import is then left without
+// interest for good.
+func TestRouteSubForUnknownAccountHeldUntilConfigured(t *testing.T) {
+	before := `
+		listen: 127.0.0.1:-1
+		cluster { name: C, listen: 127.0.0.1:%d, routes: [%s] }
+		accounts {
+			IMP { users: [{user: imp, password: pwd}] }
+		}
+	`
+	after := `
+		listen: 127.0.0.1:-1
+		cluster { name: C, listen: 127.0.0.1:%d, routes: [%s] }
+		accounts {
+			EXP {
+				users: [{user: exp, password: pwd}]
+				exports: [{stream: "app.>"}]
+			}
+			IMP {
+				users: [{user: imp, password: pwd}]
+				imports: [{stream: {account: EXP, subject: "app.>"}}]
+			}
+		}
+	`
+
+	// subFirst says whether the importing subscription exists before the second
+	// server learns about the exporting account.
+	for _, test := range []struct {
+		name     string
+		subFirst bool
+	}{
+		{"sub before the peer knows the account", true},
+		{"sub after both servers know the account", false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			confA := createConfFile(t, []byte(fmt.Sprintf(before, -1, "")))
+			sa, oa := RunServerWithConfig(confA)
+			defer sa.Shutdown()
+
+			routeToA := fmt.Sprintf("nats://127.0.0.1:%d", oa.Cluster.Port)
+			confB := createConfFile(t, []byte(fmt.Sprintf(before, -1, routeToA)))
+			sb, ob := RunServerWithConfig(confB)
+			defer sb.Shutdown()
+
+			checkClusterFormed(t, sa, sb)
+
+			nca := natsConnect(t, fmt.Sprintf("nats://imp:pwd@127.0.0.1:%d", oa.Port))
+			defer nca.Close()
+
+			subscribe := func() *nats.Subscription {
+				t.Helper()
+				sub := natsSubSync(t, nca, "app.foo")
+				natsFlush(t, nca)
+				return sub
+			}
+
+			var sub *nats.Subscription
+			if test.subFirst {
+				sub = subscribe()
+			}
+
+			// Only one server knows the new account to begin with.
+			reloadUpdateConfig(t, sa, confA, fmt.Sprintf(after, oa.Cluster.Port, ""))
+			checkFor(t, time.Second, 15*time.Millisecond, func() error {
+				_, err := sa.LookupAccount("EXP")
+				return err
+			})
+			reloadUpdateConfig(t, sb, confB, fmt.Sprintf(after, ob.Cluster.Port, routeToA))
+			checkClusterFormed(t, sa, sb)
+
+			if !test.subFirst {
+				sub = subscribe()
+				time.Sleep(100 * time.Millisecond)
+			}
+
+			// Publish on the server the subscriber is not connected to, so the
+			// message only arrives if the route carries the interest.
+			ncb := natsConnect(t, fmt.Sprintf("nats://exp:pwd@127.0.0.1:%d", ob.Port))
+			defer ncb.Close()
+			natsPub(t, ncb, "app.foo", []byte("hello"))
+			natsFlush(t, ncb)
+
+			if _, err := sub.NextMsg(2 * time.Second); err != nil {
+				t.Fatalf("Importing subscriber did not get the message: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #8560.

A config reload that introduces an account reaches the servers of a cluster one at a time. In that window a server receives interest for an account it does not know yet, and with configured accounts `processRemoteSub` logged and dropped it:

```go
if acc == nil {
    if staticResolver {
        c.Errorf("Unknown account %q for remote subject %q", accountName, sub.subject)
        return
    }
    // resolver path registers a placeholder instead
    if acc, isNew = srv.LookupOrRegisterAccount(accountName); isNew { ... }
}
```

Nothing sends that subscription again once the account appears — a later reload only updates accounts, and `accsAdded` in the reload path is about route pool accounts, not newly configured ones. The import is then left without interest on that server until the subscription is recreated by something else, which is why a stream step-down clears it in the report. Messages published there are dropped at the account boundary with no error to the publisher.

This holds the interest in a placeholder account, which is what the resolver path already does for the same situation. Reload updates accounts in place, so the interest carries into the configured account, and an account that never appears in the configuration is removed by the next reload as before.

## Testing

`TestRouteSubForUnknownAccountHeldUntilConfigured` covers both orderings on a two server cluster, with no JetStream involved:

- subscription created **before** the second server learns the account — fails on main, `Importing subscriber did not get the message: nats: timeout`
- subscription created **after** both servers know it — passes either way, so the failure above is the ordering and not the topology

`go test -race` on the new test, plus `TestRoute*`, `TestConfigReloadAccount*`, `TestConfigReloadCluster*`, `TestAccounts*`, `TestImport*` and `TestExport*` are green. One run of that group failed on an unrelated test that did not reproduce on a re-run or on an unmodified tree.