### PR TITLE
[FIXED] Remove stale JetStream account usage after peer removal

### DIFF
--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -2155,7 +2155,7 @@ func (jsa *jsAccount) remoteUpdateUsage(sub *subscription, c *client, _ *Account
 		// the membership check for new entries; steady-state updates avoid it.
 		if meta != nil {
 			var current bool
-			for _, peer := range meta.PeerNames() {
+			for _, peer := range meta.VotingPeerNames() {
 				if peer == rnode {
 					current = true
 					break

--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -2107,12 +2107,28 @@ func (a *Account) JetStreamEnabled() bool {
 	return enabled
 }
 
+func (jsa *jsAccount) removeRemoteUsage(rnode string) {
+	jsa.usageMu.Lock()
+	defer jsa.usageMu.Unlock()
+
+	rUsage := jsa.rusage[rnode]
+	if rUsage == nil {
+		return
+	}
+	for tierName, usage := range rUsage.tiers {
+		if total := jsa.usage[tierName]; total != nil {
+			total.total.mem -= usage.mem
+			total.total.store -= usage.store
+		}
+	}
+	jsa.apiTotal -= rUsage.api
+	jsa.apiErrors -= rUsage.err
+	delete(jsa.rusage, rnode)
+}
+
 func (jsa *jsAccount) remoteUpdateUsage(sub *subscription, c *client, _ *Account, subject, _ string, msg []byte) {
 	// jsa.js.srv is immutable and guaranteed to no be nil, so no lock needed.
 	s := jsa.js.srv
-
-	jsa.usageMu.Lock()
-	defer jsa.usageMu.Unlock()
 
 	if len(msg) < minUsageUpdateLen {
 		s.Warnf("Ignoring remote usage update with size too short")
@@ -2126,8 +2142,29 @@ func (jsa *jsAccount) remoteUpdateUsage(sub *subscription, c *client, _ *Account
 		s.Warnf("Received remote usage update with no remote node")
 		return
 	}
+
+	// Capture the meta group before the usage lock so we do not invert lock ordering.
+	meta := jsa.js.getMetaGroup()
+	jsa.usageMu.Lock()
+	defer jsa.usageMu.Unlock()
+
 	rUsage, ok := jsa.rusage[rnode]
 	if !ok {
+		// Once a server has been removed from the meta group, a usage update that
+		// was already in flight must not recreate its remote usage entry. Only do
+		// the membership check for new entries; steady-state updates avoid it.
+		if meta != nil {
+			var current bool
+			for _, peer := range meta.PeerNames() {
+				if peer == rnode {
+					current = true
+					break
+				}
+			}
+			if !current {
+				return
+			}
+		}
 		if jsa.rusage == nil {
 			jsa.rusage = make(map[string]*remoteUsage)
 		}

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -3055,6 +3055,19 @@ func (js *jetStream) processRemovePeer(peer string) {
 	delete(js.prNewPeers, peer)
 	js.prMu.Unlock()
 
+	// Account usage from remote servers is tracked by node ID. Once a server is
+	// removed from the meta group it will never update that entry again, so drop
+	// its last reported contribution from every account total.
+	js.mu.RLock()
+	accounts := make([]*jsAccount, 0, len(js.accounts))
+	for _, jsa := range js.accounts {
+		accounts = append(accounts, jsa)
+	}
+	js.mu.RUnlock()
+	for _, jsa := range accounts {
+		jsa.removeRemoteUsage(peer)
+	}
+
 	js.mu.Lock()
 	s, cc := js.srv, js.cluster
 	if cc == nil || cc.meta == nil {

--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -4584,6 +4584,106 @@ func TestJetStreamClusterPeerRemoveAndEvacuateMatrix(t *testing.T) {
 	}
 }
 
+func TestJetStreamClusterAccountUsageAfterServerRemove(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 4)
+	defer c.shutdown()
+
+	ml := c.leader()
+	require_NotNil(t, ml)
+
+	nc, js := jsClientConnect(t, ml)
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Replicas: 3,
+	})
+	require_NoError(t, err)
+
+	msg := bytes.Repeat([]byte("A"), 32*1024)
+	for range 128 {
+		_, err = js.Publish("foo", msg)
+		require_NoError(t, err)
+	}
+
+	si, err := js.StreamInfo("TEST")
+	require_NoError(t, err)
+	expectedStore := si.State.Bytes * 3
+
+	checkAccountStore := func(expected uint64) {
+		t.Helper()
+		checkFor(t, 10*time.Second, 100*time.Millisecond, func() error {
+			info, err := js.AccountInfo()
+			if err != nil {
+				return err
+			}
+			if info.Store != expected {
+				return fmt.Errorf("expected account store %d, got %d", expected, info.Store)
+			}
+			return nil
+		})
+	}
+	checkAccountStore(expectedStore)
+
+	// Remove a server that hosts a stream replica, but not the meta leader. The
+	// stream should move to the spare fourth server without changing the account's
+	// replicated storage total.
+	var removed *Server
+	for _, s := range c.servers {
+		if s != ml && s.JetStreamIsStreamAssigned(globalAccountName, "TEST") {
+			removed = s
+			break
+		}
+	}
+	require_NotNil(t, removed)
+	removedPeer := removed.Node()
+	removed.Shutdown()
+	removed.WaitForShutdown()
+
+	snc, _ := jsClientConnect(t, ml, nats.UserInfo("admin", "s3cr3t!"))
+	defer snc.Close()
+	b, err := json.Marshal(JSApiMetaServerRemoveRequest{Peer: removedPeer})
+	require_NoError(t, err)
+	rmsg, err := snc.Request(JSApiRemoveServer, b, 10*time.Second)
+	require_NoError(t, err)
+	var resp JSApiMetaServerRemoveResponse
+	require_NoError(t, json.Unmarshal(rmsg.Data, &resp))
+	require_True(t, resp.Success)
+
+	c.waitOnPeerCount(3)
+	checkFor(t, 10*time.Second, 100*time.Millisecond, func() error {
+		si, err := js.StreamInfo("TEST")
+		if err != nil {
+			return err
+		}
+		if si.Cluster == nil || len(si.Cluster.Replicas) != 2 {
+			return fmt.Errorf("stream has not returned to R3")
+		}
+		for _, peer := range si.Cluster.Replicas {
+			if !peer.Current {
+				return fmt.Errorf("stream replica %q is not current", peer.Name)
+			}
+		}
+		return nil
+	})
+
+	checkAccountStore(expectedStore)
+
+	// A usage update already in flight when the peer removal commits must not
+	// recreate the departed server's remote usage entry.
+	jsa := ml.getJetStream().lookupAccount(ml.globalAccount())
+	require_NotNil(t, jsa)
+	lateUpdate := make([]byte, minUsageUpdateLen)
+	binary.LittleEndian.PutUint64(lateUpdate[8:], si.State.Bytes)
+	jsa.remoteUpdateUsage(nil, nil, nil, fmt.Sprintf(jsaUpdatesPubT, globalAccountName, removedPeer), _EMPTY_, lateUpdate)
+	jsa.usageMu.RLock()
+	_, stale := jsa.rusage[removedPeer]
+	jsa.usageMu.RUnlock()
+	require_False(t, stale)
+	checkAccountStore(expectedStore)
+}
+
 func TestJetStreamClusterStreamPeerRemoveNoReplacementIsRejected(t *testing.T) {
 	for _, test := range []struct {
 		name     string

--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -4585,7 +4585,7 @@ func TestJetStreamClusterPeerRemoveAndEvacuateMatrix(t *testing.T) {
 }
 
 func TestJetStreamClusterAccountUsageAfterServerRemove(t *testing.T) {
-	c := createJetStreamClusterExplicit(t, "R3S", 4)
+	c := createJetStreamClusterExplicit(t, "R4S", 4)
 	defer c.shutdown()
 
 	ml := c.leader()


### PR DESCRIPTION
Fixes #8563.

When a JetStream server is permanently removed from the cluster, its last reported account usage can remain in `jsAccount.rusage`. Because that value is still included in the account totals, replacing a stream replica on another server can cause storage usage to be counted twice.

I reproduced this with a 4-node cluster and an R3 stream. After removing one of the replica-holding servers and letting the stream move to the spare node, the stream was still correctly running with 3 replicas, but the account storage usage increased as if there were 4 copies.

This change removes the departed server's usage when its meta peer removal is committed. It also ignores a late usage update from the removed node so that the stale entry cannot be added back after cleanup.

I added a regression test that:

* creates an R3 stream on a 4-node cluster,
* verifies the initial account usage,
* removes one of the servers hosting a replica,
* waits for the replica to move to the spare server,
* verifies the account usage stays unchanged,
* and checks that a late usage update from the removed peer does not recreate the stale entry.

Testing:

* new regression test passes repeatedly
* regression test passes with `-race`
* related peer-removal and account-usage tests pass
* `go vet ./server`
* `git diff --check`
