### PR TITLE
Fix filtered purge handling for multi-filter consumers

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -4929,6 +4929,22 @@ func (o *consumer) isEqualOrSubsetMatch(subj string) bool {
 	return false
 }
 
+// Check if all consumer filter subjects are subsets of the candidate subject.
+// Lock should be held.
+func (o *consumer) isFilterSubsetOf(subj string) bool {
+	if len(o.subjf) == 0 {
+		return false
+	}
+	tsa := [32]string{}
+	tts := tokenizeSubjectIntoSlice(tsa[:0], subj)
+	for _, filter := range o.subjf {
+		if !isSubsetMatchTokenized(filter.tokenizedSubject, tts) {
+			return false
+		}
+	}
+	return true
+}
+
 var (
 	errMaxAckPending = errors.New("max ack pending reached")
 	errBadConsumer   = errors.New("consumer not valid")

--- a/server/jetstream_consumer_test.go
+++ b/server/jetstream_consumer_test.go
@@ -949,6 +949,36 @@ func TestJetStreamConsumerIsEqualOrSubsetMatch(t *testing.T) {
 	}
 }
 
+func TestJetStreamConsumerIsFilterSubsetOf(t *testing.T) {
+	for _, test := range []struct {
+		name           string
+		filterSubjects []string
+		subject        string
+		result         bool
+	}{
+		{"no filter", nil, ">", false},
+		{"single literal equal", []string{"foo.a"}, "foo.a", true},
+		{"single literal mismatch", []string{"foo.a"}, "foo.b", false},
+		{"all literals contained", []string{"foo.a", "foo.b"}, "foo.>", true},
+		{"one literal outside", []string{"foo.a", "bar.a"}, "foo.>", false},
+		{"wildcards contained", []string{"foo.*", "foo.bar.>"}, "foo.>", true},
+		{"filter wider than subject", []string{"foo.>"}, "foo.bar", false},
+		{"rollup matches only one filter", []string{"events.host", "events.periodic"}, "events.periodic", false},
+		{"partial wildcard intersection", []string{"foo.*.bar"}, "foo.baz.>", false},
+		{"partial wildcard intersection short", []string{"*.bar"}, "foo.*", false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			c := consumerWithFilterSubjects(test.filterSubjects)
+			if res := c.isFilterSubsetOf(test.subject); res != test.result {
+				t.Fatalf("Filters %v subset of subject %q should be %v, got %v",
+					test.filterSubjects, test.subject, test.result, res)
+			}
+		})
+	}
+}
+
 func TestJetStreamConsumerBackOff(t *testing.T) {
 	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
@@ -7755,6 +7785,116 @@ func TestJetStreamConsumerPurge(t *testing.T) {
 	_, err = sub.Fetch(1)
 	require_Error(t, err)
 
+}
+
+func TestJetStreamConsumerRollupMultiFilterDoesNotSkip(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	nc, js := jsClientConnect(t, s)
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:        "TEST",
+		Subjects:    []string{"events.>"},
+		AllowRollup: true,
+	})
+	require_NoError(t, err)
+
+	deliver := nats.NewInbox()
+	sub, err := nc.SubscribeSync(deliver)
+	require_NoError(t, err)
+	defer sub.Unsubscribe()
+	require_NoError(t, nc.Flush())
+
+	_, err = js.AddConsumer("TEST", &nats.ConsumerConfig{
+		Durable:        "consumer",
+		DeliverSubject: deliver,
+		AckPolicy:      nats.AckExplicitPolicy,
+		MaxAckPending:  1,
+		FilterSubjects: []string{"events.host", "events.periodic"},
+	})
+	require_NoError(t, err)
+
+	_, err = js.Publish("events.host", []byte("A"))
+	require_NoError(t, err)
+	msgA, err := sub.NextMsg(time.Second)
+	require_NoError(t, err)
+
+	_, err = js.Publish("events.host", []byte("B"))
+	require_NoError(t, err)
+	rollup := nats.NewMsg("events.periodic")
+	rollup.Header.Set(JSMsgRollup, JSMsgRollupSubject)
+	rollup.Data = []byte("periodic")
+	_, err = js.PublishMsg(rollup)
+	require_NoError(t, err)
+	require_NoError(t, msgA.AckSync())
+
+	msgB, err := sub.NextMsg(time.Second)
+	require_NoError(t, err)
+	metadata, err := msgB.Metadata()
+	require_NoError(t, err)
+	require_Equal(t, metadata.Sequence.Stream, uint64(2))
+	require_Equal(t, string(msgB.Data), "B")
+	require_NoError(t, msgB.AckSync())
+
+	rollupMsg, err := sub.NextMsg(time.Second)
+	require_NoError(t, err)
+	metadata, err = rollupMsg.Metadata()
+	require_NoError(t, err)
+	require_Equal(t, metadata.Sequence.Stream, uint64(3))
+	require_Equal(t, string(rollupMsg.Data), "periodic")
+}
+
+func TestJetStreamConsumerFilteredPurgeMultiFilterDoesNotSkip(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	nc, js := jsClientConnect(t, s)
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"events.>"},
+	})
+	require_NoError(t, err)
+
+	deliver := nats.NewInbox()
+	sub, err := nc.SubscribeSync(deliver)
+	require_NoError(t, err)
+	defer sub.Unsubscribe()
+	require_NoError(t, nc.Flush())
+
+	_, err = js.AddConsumer("TEST", &nats.ConsumerConfig{
+		Durable:        "consumer",
+		DeliverSubject: deliver,
+		AckPolicy:      nats.AckExplicitPolicy,
+		MaxAckPending:  1,
+		FilterSubjects: []string{"events.host", "events.periodic"},
+	})
+	require_NoError(t, err)
+
+	_, err = js.Publish("events.host", []byte("A"))
+	require_NoError(t, err)
+	msgA, err := sub.NextMsg(time.Second)
+	require_NoError(t, err)
+
+	_, err = js.Publish("events.host", []byte("B"))
+	require_NoError(t, err)
+	_, err = js.Publish("events.periodic", []byte("P"))
+	require_NoError(t, err)
+
+	// Purge removes every message on one of the two filter subjects.
+	require_NoError(t, js.PurgeStream("TEST",
+		&nats.StreamPurgeRequest{Subject: "events.periodic"}))
+	require_NoError(t, msgA.AckSync())
+
+	msgB, err := sub.NextMsg(time.Second)
+	require_NoError(t, err)
+	metadata, err := msgB.Metadata()
+	require_NoError(t, err)
+	require_Equal(t, metadata.Sequence.Stream, uint64(2))
+	require_Equal(t, string(msgB.Data), "B")
 }
 
 func TestJetStreamConsumerFilterUpdate(t *testing.T) {

--- a/server/stream.go
+++ b/server/stream.go
@@ -3173,6 +3173,9 @@ func (mset *stream) purgeLocked(preq *JSApiStreamPurgeRequest, needLock bool) (p
 		if !doPurge && preq != nil && o.isFilteredMatch(preq.Subject) {
 			doPurge, isWider = true, true
 			start = state.FirstSeq
+		} else if doPurge && preq != nil && preq.Subject != _EMPTY_ && !o.isFilterSubsetOf(preq.Subject) {
+			isWider = true
+			start = state.FirstSeq
 		}
 		o.mu.RUnlock()
 		if doPurge {


### PR DESCRIPTION
Fixes #8571.

When a consumer has multiple filter subjects, purging or rolling up a subject that covers only one of those filters can incorrectly advance the consumer's stream cursor past messages that still exist under another filter.

For example, consider a consumer filtered on both `events.host` and `events.periodic`. If `events.periodic` is purged while an `events.host` message is waiting behind an unacknowledged message, the previous logic treats the purge as covering the consumer because one filter is a subset of the purge subject. This can cause the waiting `events.host` message to be skipped.

This change checks whether *every* consumer filter is covered by the purge subject. When the purge covers only part of the consumer's filter space, the consumer is handled through the existing wider-filter purge path. That path keeps the cursor anchored to the stream's first surviving sequence and removes only pending entries whose underlying messages were deleted.

Regression coverage is included for:

- subject rollup with `Nats-Rollup: sub`;
- a normal filtered `PurgeStream` request;
- single and multiple filter containment;
- literal and wildcard filter subjects;
- partial wildcard intersections.

## Verification

The focused helper and regression tests passed 20 consecutive runs:

```sh
go test ./server \
  -run '^TestJetStreamConsumer(IsFilterSubsetOf|RollupMultiFilterDoesNotSkip|FilteredPurgeMultiFilterDoesNotSkip)$' \
  -count=20 -timeout=5m
```

Both delivery regression tests passed 10 consecutive runs with the race detector:

```sh
CGO_ENABLED=1 go test -race ./server \
  -run '^TestJetStreamConsumer(RollupMultiFilterDoesNotSkip|FilteredPurgeMultiFilterDoesNotSkip)$' \
  -count=10 -timeout=10m
```

`go vet ./server`, `go build ./...` and `git diff --check` also pass.

The rollup scenario was additionally tested 20 consecutive times with a patched nats-server binary in an isolated OpenShift pod, without modifying the existing StatefulSet.
