### PR TITLE
CHANGED Replace Go 1.12 error shims with standard library errors.Is

### DIFF
--- a/server/errors.go
+++ b/server/errors.go
@@ -375,39 +375,8 @@ func UnpackIfErrorCtx(err error) string {
 	return err.Error()
 }
 
-// implements: go 1.13 errors.Unwrap(err error) error
-// TODO replace with native code once we no longer support go1.12
-func errorsUnwrap(err error) error {
-	u, ok := err.(interface {
-		Unwrap() error
-	})
-	if !ok {
-		return nil
-	}
-	return u.Unwrap()
-}
-
-// ErrorIs implements: go 1.13 errors.Is(err, target error) bool
-// TODO replace with native code once we no longer support go1.12
+// ErrorIs reports whether err or any error in its chain matches target.
+// Thin wrapper around the standard library errors.Is.
 func ErrorIs(err, target error) bool {
-	// this is an outright copy of go 1.13 errors.Is(err, target error) bool
-	// removed isComparable
-	if err == nil || target == nil {
-		return err == target
-	}
-
-	for {
-		if err == target {
-			return true
-		}
-		if x, ok := err.(interface{ Is(error) bool }); ok && x.Is(target) {
-			return true
-		}
-		// TODO: consider supporing target.Is(err). This would allow
-		// user-definable predicates, but also may allow for coping with sloppy
-		// APIs, thereby making it easier to get away with them.
-		if err = errorsUnwrap(err); err == nil {
-			return false
-		}
-	}
+	return errors.Is(err, target)
 }

--- a/server/errors_test.go
+++ b/server/errors_test.go
@@ -14,6 +14,7 @@
 package server
 
 import (
+	"errors"
 	"strings"
 	"testing"
 )
@@ -28,7 +29,7 @@ func TestErrCtx(t *testing.T) {
 	if e == ErrWrongGateway {
 		t.Fatalf("%v and %v can't be compared this way", e, ErrWrongGateway)
 	}
-	if !ErrorIs(e, ErrWrongGateway) {
+	if !errors.Is(e, ErrWrongGateway) {
 		t.Fatalf("%s and %s ", e, ErrWrongGateway)
 	}
 	if UnpackIfErrorCtx(ErrWrongGateway) != ErrWrongGateway.Error() {
@@ -55,7 +56,7 @@ func TestErrCtxWrapped(t *testing.T) {
 	if e == ErrWrongGateway {
 		t.Fatalf("%v and %v can't be compared this way", e, ErrWrongGateway)
 	}
-	if !ErrorIs(e, ErrWrongGateway) {
+	if !errors.Is(e, ErrWrongGateway) {
 		t.Fatalf("%s and %s ", e, ErrWrongGateway)
 	}
 	if UnpackIfErrorCtx(ErrWrongGateway) != ErrWrongGateway.Error() {

--- a/server/parser_test.go
+++ b/server/parser_test.go
@@ -15,6 +15,7 @@ package server
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -1013,7 +1014,7 @@ func TestMaxControlLine(t *testing.T) {
 			err := c.parse(pub[:14])
 			switch test.shouldFail {
 			case true:
-				if !ErrorIs(err, ErrMaxControlLine) {
+				if !errors.Is(err, ErrMaxControlLine) {
 					t.Fatalf("Expected an error parsing longer than expected control line")
 				}
 			case false:
@@ -1027,7 +1028,7 @@ func TestMaxControlLine(t *testing.T) {
 			err = c.parse(pub)
 			switch test.shouldFail {
 			case true:
-				if !ErrorIs(err, ErrMaxControlLine) {
+				if !errors.Is(err, ErrMaxControlLine) {
 					t.Fatalf("Expected an error parsing longer than expected control line")
 				}
 			case false:
@@ -1084,7 +1085,7 @@ func TestMaxControlLineNonClientUpperBound(t *testing.T) {
 					err := c.parse(chunk2)
 					if off <= 0 && err != nil {
 						t.Fatalf("unexpected error on second chunk: %v", err)
-					} else if off > 0 && !ErrorIs(err, ErrMaxControlLine) {
+					} else if off > 0 && !errors.Is(err, ErrMaxControlLine) {
 						t.Fatalf("expected ErrMaxControlLine after oversized accumulation, got: %v", err)
 					}
 				})


### PR DESCRIPTION
The Go 1.12 compatibility shims for errors.Is and errors.Unwrap are no longer needed now that the module requires Go 1.26.

This replaces the test call sites with the standard library errors.Is and removes both obsolete compatibility shims.

Tests:
go test ./server/ -run 'TestErrCtx|TestMaxControlLine'

