### PR TITLE
[FIXED] Filestore compression header collisions

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -7991,29 +7991,19 @@ func (mb *msgBlock) recompressOnDiskIfNeeded() error {
 		return err
 	}
 
-	meta := &CompressionInfo{}
-	if _, err := meta.UnmarshalMetadata(origBuf); err != nil {
-		// An error is only returned here if there's a problem with parsing
-		// the metadata. If the file has no metadata at all, no error is
-		// returned and the algorithm defaults to no compression.
-		return fmt.Errorf("failed to read existing metadata header: %w", err)
+	decoded, diskAlg, err := mb.decode(origBuf)
+	if err != nil {
+		return fmt.Errorf("failed to decode original block: %w", err)
 	}
-	if meta.Algorithm == alg {
+	if diskAlg == alg {
 		// The block is already compressed with the chosen algorithm so there
 		// is nothing else to do. This is not a common case, it is here only
 		// to ensure we don't do unnecessary work in case something asked us
 		// to recompress an already compressed block with the same algorithm.
 		return nil
-	} else if alg != NoCompression {
-		// The block is already compressed using some algorithm, so we need
-		// to decompress the block using the existing algorithm before we can
-		// recompress it with the new one.
-		if origBuf, err = meta.Algorithm.Decompress(origBuf); err != nil {
-			return fmt.Errorf("failed to decompress original block: %w", err)
-		}
 	}
 
-	return mb.atomicOverwriteFile(origBuf, true)
+	return mb.atomicOverwriteFile(decoded, true)
 }
 
 // Lock should be held.
@@ -8101,24 +8091,43 @@ func (mb *msgBlock) atomicOverwriteFile(buf []byte, allowCompress bool) error {
 }
 
 // Lock should be held.
-func (mb *msgBlock) decompressIfNeeded(buf []byte) ([]byte, error) {
+func (mb *msgBlock) decode(buf []byte) ([]byte, StoreCompression, error) {
 	var meta CompressionInfo
 	if n, err := meta.UnmarshalMetadata(buf); err != nil {
 		// There was a problem parsing the metadata header of the block.
 		// If there's no metadata header, an error isn't returned here,
 		// we will instead just use default values of no compression.
-		return nil, err
+		return nil, meta.Algorithm, err
 	} else if n == 0 {
 		// There were no metadata bytes, so we assume the block is not
 		// compressed and return it as-is.
-		return buf, nil
+		return buf, NoCompression, nil
 	} else {
-		// Metadata was present so it's quite likely the block contents
-		// are compressed. If by any chance the metadata claims that the
-		// block is uncompressed, then the input slice is just returned
-		// unmodified.
-		return meta.Algorithm.Decompress(buf[n:])
+		// Metadata was present, so try to decompress the block.
+		decoded, err := meta.Algorithm.Decompress(buf[n:])
+		if err == nil {
+			return decoded, meta.Algorithm, nil
+		}
+		// Decompression failed. Before returning the error, check if the
+		// buffer happens to store a valid uncompressed record.
+		// A record with length 24145251 without headers happens to
+		// collide with a valid compression header "cmp" and
+		// compression algorithm 1 (S2).
+		if meta.Algorithm == S2Compression && len(buf) >= 24145251 {
+			var sm StoreMsg
+			if _, msgErr := mb.msgFromBufNoCopy(buf, &sm, mb.hh); msgErr == nil {
+				return buf, NoCompression, nil
+			}
+		}
+		// Return the original error
+		return nil, meta.Algorithm, err
 	}
+}
+
+// Lock should be held.
+func (mb *msgBlock) decompressIfNeeded(buf []byte) ([]byte, error) {
+	decoded, _, err := mb.decode(buf)
+	return decoded, err
 }
 
 // Lock should be held.
@@ -14498,7 +14507,9 @@ func (c *CompressionInfo) UnmarshalMetadata(b []byte) (int, error) {
 	if len(b) < 5 { // 4 + min 1 for uvarint uint64
 		return 0, nil
 	}
-	if b[0] != 'c' || b[1] != 'm' || b[2] != 'p' {
+	// An uncompressed record with length 7,368,035 starts with "cmp",
+	// so we also check algorithm byte.
+	if b[0] != 'c' || b[1] != 'm' || b[2] != 'p' || StoreCompression(b[3]) != S2Compression {
 		return 0, nil
 	}
 	var n int

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -10899,6 +10899,74 @@ func TestFileStoreAsyncFlushOnSkipMsgs(t *testing.T) {
 	}
 }
 
+func TestFileStoreCompressionHeaderCollision(t *testing.T) {
+	for _, size := range []int{7368035, 24145251} {
+		for _, hdr := range [][]byte{nil, []byte("NATS/1.0\r\nTest: value\r\n\r\n")} {
+			t.Run(fmt.Sprintf("Size=%d/Headers=%v", size, len(hdr) > 0), func(t *testing.T) {
+				testFileStoreAllPermutations(t, func(t *testing.T, fcfg FileStoreConfig) {
+					cfg := StreamConfig{Name: "TEST", Storage: FileStorage}
+					fs, err := newFileStoreWithCreated(fcfg, cfg, time.Now(), prf(&fcfg), nil)
+					require_NoError(t, err)
+					defer fs.Stop()
+
+					subj := "test"
+					msg := bytes.Repeat([]byte("a"), size-int(fileStoreMsgSize(subj, hdr, nil)))
+					_, _, err = fs.StoreMsg(subj, hdr, msg, 0)
+					require_NoError(t, err)
+					// Keep a following message to check after deletion.
+					_, _, err = fs.StoreMsg(subj, nil, []byte("next"), 0)
+					require_NoError(t, err)
+					require_NoError(t, fs.Stop())
+
+					// Reopen to force decoding from disk instead of reading cached messages.
+					fs, err = newFileStoreWithCreated(fcfg, cfg, time.Now(), prf(&fcfg), nil)
+					require_NoError(t, err)
+					defer fs.Stop()
+					sm, err := fs.LoadMsg(1, nil)
+					require_NoError(t, err)
+					require_Equal(t, sm.subj, subj)
+					require_True(t, bytes.Equal(sm.hdr, hdr))
+					require_True(t, bytes.Equal(sm.msg, msg))
+					removed, err := fs.RemoveMsg(1)
+					require_NoError(t, err)
+					require_True(t, removed)
+					sm, err = fs.LoadMsg(2, nil)
+					require_NoError(t, err)
+					require_Equal(t, string(sm.msg), "next")
+				})
+			})
+		}
+	}
+}
+
+func TestFileStoreDecodeCorruptBlock(t *testing.T) {
+	fs, err := newFileStore(FileStoreConfig{StoreDir: t.TempDir(), Compression: S2Compression}, StreamConfig{Name: "TEST", Storage: FileStorage})
+	require_NoError(t, err)
+	defer fs.Stop()
+
+	// Create a large valid S2 compressed block
+	msg := make([]byte, 25*1024*1024)
+	_, err = crand.Read(msg)
+	require_NoError(t, err)
+	_, _, err = fs.StoreMsg("test", nil, msg, 0)
+	require_NoError(t, err)
+	mb := fs.getFirstBlock()
+	require_NoError(t, mb.flushPendingMsgs())
+	mb.mu.Lock()
+	defer mb.mu.Unlock()
+	require_NoError(t, mb.recompressOnDiskIfNeeded())
+	compressed, err := mb.loadBlock(nil)
+	require_NoError(t, err)
+
+	// Corrupt a byte in the S2 data so decompression fails.
+	// mb.decode will try to interpret this block as uncompressed,
+	// but that will fail as well because of checksum mismatch.
+	compressed[len(compressed)/2] ^= 0xff
+	_, _, err = mb.decode(compressed)
+	require_Error(t, err)
+	require_True(t, errors.Is(err, s2.ErrCRC))
+}
+
 func TestFileStoreCompressionAfterTruncate(t *testing.T) {
 	tests := []struct {
 		title  string


### PR DESCRIPTION
When reading block files, the filestore checks for header "cmp" followed by byte 1 to distinguish S2 compressed blocks from uncompressed blocks. However, the "cmp" prefix is not distinguishable from uncompressed records of length 7,368,035 and 24,145,251.
If a valid compression header is found, assume that the data is compressed. Should decompression fail, we try to parse an uncompressed message. This will normally fail for corrupt data due to checksum mismatch, and will succeed if the message happened to be a collision.