### PR TITLE
Add literal fast-path to isFilterSubsetOf

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -4943,6 +4943,11 @@ func (o *consumer) isFilterSubsetOf(subj string) bool {
 	if len(o.subjf) == 0 {
 		return false
 	}
+	// Fast-path a single literal filter, as isEqualOrSubsetMatch does. Only valid for
+	// one filter: all filters must be covered, so one match can not short-circuit.
+	if len(o.subjf) == 1 && !o.subjf[0].hasWildcard && subj == o.subjf[0].subject {
+		return true
+	}
 	tsa := [32]string{}
 	tts := tokenizeSubjectIntoSlice(tsa[:0], subj)
 	for _, filter := range o.subjf {

--- a/server/jetstream_consumer_test.go
+++ b/server/jetstream_consumer_test.go
@@ -959,6 +959,8 @@ func TestJetStreamConsumerIsFilterSubsetOf(t *testing.T) {
 		{"no filter", nil, ">", false},
 		{"single literal equal", []string{"foo.a"}, "foo.a", true},
 		{"single literal mismatch", []string{"foo.a"}, "foo.b", false},
+		{"single literal contained", []string{"foo.a"}, "foo.*", true},
+		{"one literal equal one outside", []string{"foo.a", "bar.a"}, "foo.a", false},
 		{"all literals contained", []string{"foo.a", "foo.b"}, "foo.>", true},
 		{"one literal outside", []string{"foo.a", "bar.a"}, "foo.>", false},
 		{"wildcards contained", []string{"foo.*", "foo.bar.>"}, "foo.>", true},
@@ -2924,6 +2926,28 @@ func Benchmark____JetStreamConsumerIsFilteredMatch(b *testing.B) {
 		c := consumerWithFilterSubjects(filterSubjects(int(n)))
 		b.Run(name, func(b *testing.B) {
 			c.isFilteredMatch(subject)
+		})
+	}
+}
+
+func Benchmark____JetStreamConsumerIsFilterSubsetOf(b *testing.B) {
+	for _, bm := range []struct {
+		name    string
+		filters []string
+		subject string
+	}{
+		// Takes the literal fast-path.
+		{"single literal filter", []string{"foo.bar.baz.qux"}, "foo.bar.baz.qux"},
+		// Skips it, the only filter has a wildcard.
+		{"single wildcard filter", []string{"foo.*.baz.qux"}, "foo.bar.baz.qux"},
+		// Skips it, more than one filter to cover.
+		{"multiple filters", []string{"foo.bar.baz.qux", "foo.bar.baz.quux"}, "foo.bar.baz.>"},
+	} {
+		c := consumerWithFilterSubjects(bm.filters)
+		b.Run(bm.name, func(b *testing.B) {
+			for b.Loop() {
+				c.isFilterSubsetOf(bm.subject)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Follow-up to #8572.

`isEqualOrSubsetMatch` short-circuits when a literal filter equals the candidate subject, while `isFilterSubsetOf` always tokenizes. This adds the same fast-path to `isFilterSubsetOf` so the two helpers handle that case consistently.

The fast-path is restricted to a single filter. `isEqualOrSubsetMatch` loops over all filters, which matches its ANY semantics, but `isFilterSubsetOf` requires every filter to be covered, so a match on one of several filters must not short-circuit. Removing that restriction would reintroduce the behaviour #8572 fixed.

The optimization is equivalent to the previous implementation for every reachable input. Filter subjects are validated with `IsValidSubject`, so `subj == filter.subject` implies both sides tokenize identically, and `isSubsetMatchTokenized(x, x)` holds for any valid subject.

Coverage added to `TestJetStreamConsumerIsFilterSubsetOf`:

- `single literal contained`, where a literal filter is covered by a wildcard purge subject and must not produce an early `false`;
- `one literal equal one outside`, where one filter equals the purge subject while another lies outside it, which must not short-circuit to `true`.

Both cases were confirmed to fail against deliberately broken variants of the fast-path.

## Benchmark

`Benchmark____JetStreamConsumerIsFilterSubsetOf` covers the three shapes. Measured against the previous implementation in the same binary, median of five runs:

```
single literal filter     43.40 ns/op  ->   3.23 ns/op   -92.5%
single wildcard filter    34.47 ns/op  ->  34.30 ns/op    -0.5%
multiple filters          59.03 ns/op  ->  58.65 ns/op    -0.6%
```

Only the first shape takes the new branch; the other two are unchanged within run-to-run noise. Neither implementation allocates.

The absolute saving is roughly 40ns per consumer per purge, which is negligible against the storage work a purge performs. The change is proposed for consistency between the two helpers rather than for throughput.

## Verification

```sh
go build ./...
go vet ./server
gofmt -l server/consumer.go server/jetstream_consumer_test.go

go test ./server \
  -run '^TestJetStreamConsumer(IsFilterSubsetOf|RollupMultiFilterDoesNotSkip|FilteredPurgeMultiFilterDoesNotSkip)$' \
  -count=20 -timeout=5m

CGO_ENABLED=1 go test -race ./server \
  -run '^TestJetStreamConsumer(RollupMultiFilterDoesNotSkip|FilteredPurgeMultiFilterDoesNotSkip)$' \
  -count=10 -timeout=10m
```

All pass.

Unrelated, noticed while adding the benchmark: `Benchmark____JetStreamConsumerIsFilteredMatch` calls `c.isFilteredMatch(subject)` outside any `b.N` or `b.Loop()` loop, so it does not measure anything. Left untouched here as out of scope; happy to send a separate fix if that's useful.