### PR TITLE
(2.15) Fix scoped JetStream source reply subjects

### DIFF
--- a/server/feature_flags.go
+++ b/server/feature_flags.go
@@ -20,9 +20,10 @@ import (
 )
 
 const (
-	FeatureFlagJsAckFormatV2     = "js_ack_fc_v2"
-	FeatureFlagJsRaftDeleteRange = "js_raft_delete_range"
-	FeatureFlagJsSnapshotSources = "js_snapshot_sources"
+	FeatureFlagJsAckFormatV2      = "js_ack_fc_v2"
+	FeatureFlagJsAPIReplyFormatV2 = "js_api_reply_v2"
+	FeatureFlagJsRaftDeleteRange  = "js_raft_delete_range"
+	FeatureFlagJsSnapshotSources  = "js_snapshot_sources"
 )
 
 var featureFlags = map[string]bool{
@@ -34,6 +35,18 @@ var featureFlags = map[string]bool{
 	// - v2: $JS.ACK.<domain>.<account hash>.<stream name>.<consumer name>.<num delivered>.<stream sequence>.<consumer sequence>.<timestamp>.<num pending>
 	// See also: https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-15.md#jsack
 	FeatureFlagJsAckFormatV2: false,
+
+	// Use a scoped v2 format for replies to internally-issued JetStream API
+	// requests. This permits a leafnode to authorize only the replies for a
+	// specific remote stream/consumer instead of every $JSC.R reply in an
+	// account.
+	//
+	// - v1: $JSC.R.<uid>
+	// - v2: $JSC.R.<domain>.<account hash>.<stream name>.<consumer name>.<uid>
+	//
+	// The reply subject is opaque to the remote API server, so this is safe to
+	// enable independently on the server issuing the request.
+	FeatureFlagJsAPIReplyFormatV2: false,
 
 	// Propose delete range gaps as a single `deleteRangeOp` Raft append entry
 	// instead of one entry per deleted sequence. Dramatically reduces Raft cost

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -13692,8 +13692,18 @@ func syncReplySubject() string {
 	return syncSubject("$JSC.R")
 }
 
-func infoReplySubject() string {
-	return syncSubject("$JSC.R")
+// infoReplySubject returns a reply subject for an internally-issued JetStream
+// API request. With js_api_reply_v2 enabled, it scopes the subject to the
+// requested API resource so leafnode permissions do not need to grant access
+// to every opaque $JSC.R reply.
+func (s *Server) infoReplySubject(domain, account, stream, consumer string) string {
+	if !s.getOpts().getFeatureFlag(FeatureFlagJsAPIReplyFormatV2) {
+		return syncSubject("$JSC.R")
+	}
+	if domain == _EMPTY_ {
+		domain = "_"
+	}
+	return syncSubject(fmt.Sprintf("$JSC.R.%s.%s.%s.%s", domain, getHash(account), stream, consumer))
 }
 
 func syncAckSubject() string {

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -25930,6 +25930,67 @@ func TestJetStreamSourceConsumerRetryUsesFreshReplySubject(t *testing.T) {
 	})
 }
 
+// https://github.com/nats-io/nats-server/issues/8558
+func TestJetStreamSourceConsumerUsesScopedAPIReplySubject(t *testing.T) {
+	for _, test := range []struct {
+		kind     string
+		name     string
+		durable  bool
+		consumer string
+	}{
+		{"source", "consumer create", false, ""},
+		{"source", "consumer reset", true, "SOURCE_CONSUMER"},
+		{"mirror", "consumer create", false, ""},
+		{"mirror", "consumer reset", true, "MIRROR_CONSUMER"},
+	} {
+		t.Run(test.kind+"/"+test.name, func(t *testing.T) {
+			s := RunBasicJetStreamServer(t)
+			defer s.Shutdown()
+
+			o := *s.getOpts()
+			o.FeatureFlags = map[string]bool{FeatureFlagJsAPIReplyFormatV2: true}
+			s.setOpts(&o)
+
+			nc, _ := jsClientConnect(t, s)
+			defer nc.Close()
+
+			const apiPrefix = "$JS.CLOUD.API"
+			reqCh := make(chan *nats.Msg, 1)
+			_, err := nc.Subscribe(apiPrefix+".CONSUMER.>", func(m *nats.Msg) { reqCh <- m })
+			require_NoError(t, err)
+			require_NoError(t, nc.Flush())
+
+			source := &StreamSource{
+				Name:     "ORIGIN",
+				External: &ExternalStream{ApiPrefix: apiPrefix},
+			}
+			if test.durable {
+				source.Consumer = &StreamConsumerSource{Name: test.consumer, DeliverSubject: "sync"}
+			}
+			cfg := &StreamConfig{Name: "SOURCE", Storage: MemoryStorage}
+			if test.kind == "mirror" {
+				cfg.Mirror = source
+			} else {
+				cfg.Sources = []*StreamSource{source}
+			}
+			addStream(t, nc, cfg)
+
+			req := require_ChanRead(t, reqCh, time.Second)
+			consumer := test.consumer
+			if !test.durable {
+				var ccr CreateConsumerRequest
+				require_NoError(t, json.Unmarshal(req.Data, &ccr))
+				consumer = ccr.Config.Name
+			}
+			prefix := fmt.Sprintf("$JSC.R.CLOUD.%s.ORIGIN.%s.", getHash(globalAccountName), consumer)
+			if !strings.HasPrefix(req.Reply, prefix) {
+				t.Fatalf("expected scoped reply prefix %q, got %q", prefix, req.Reply)
+			}
+			require_Equal(t, len(strings.Split(req.Reply, ".")), 7)
+		})
+	}
+}
+
 func TestJetStreamMirrorRetriesOnSeqAlreadySeenMismatch(t *testing.T) {
 	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()

--- a/server/stream.go
+++ b/server/stream.go
@@ -3052,7 +3052,7 @@ func (mset *stream) tryDeleteSourcingConsumer(kind string, source *StreamSource,
 		}
 
 		respCh := make(chan *JSApiConsumerDeleteResponse, 1)
-		reply := infoReplySubject()
+		reply := s.infoReplySubject(source.External.Domain(), acc.Name, sourceName, consumerName)
 		cdSub, err := acc.subscribeInternal(reply, func(sub *subscription, c *client, _ *Account, subject, reply string, rmsg []byte) {
 			_, msg := c.msgParts(rmsg)
 
@@ -3864,7 +3864,11 @@ func (mset *stream) setupMirrorConsumer() error {
 
 	newReplySubscription := func() (string, chan *JSApiConsumerCreateResponse, *subscription, error) {
 		respCh := make(chan *JSApiConsumerCreateResponse, 1)
-		reply := infoReplySubject()
+		consumer := req.Config.Name
+		if durableDeliverSubject != _EMPTY_ {
+			consumer = mirror.cname
+		}
+		reply := mset.srv.infoReplySubject(ext.Domain(), mset.acc.Name, mset.cfg.Mirror.Name, consumer)
 		crSub, err := mset.subscribeInternal(reply, func(sub *subscription, c *client, _ *Account, subject, reply string, rmsg []byte) {
 			_, msg := c.msgParts(rmsg)
 
@@ -4362,7 +4366,11 @@ func (mset *stream) trySetupSourceConsumer(iname string, seq uint64, startTime t
 	}
 	newReplySubscription := func() (string, chan *consumerCreateResp, *subscription, error) {
 		respCh := make(chan *consumerCreateResp, 1)
-		reply := infoReplySubject()
+		consumer := req.Config.Name
+		if durableDeliverSubject != _EMPTY_ {
+			consumer = si.cname
+		}
+		reply := mset.srv.infoReplySubject(ext.Domain(), mset.acc.Name, si.name, consumer)
 		crSub, err := mset.subscribeInternal(reply, func(sub *subscription, c *client, _ *Account, subject, reply string, rmsg []byte) {
 			hdr, msg := c.msgParts(rmsg)
 			var ccr JSApiConsumerCreateResponse


### PR DESCRIPTION
Fixes #8558.

When setting up a source or mirror, the server uses `$JSC.R.<uid>` as the reply subject for both consumer creation and durable consumer resets. In a leafnode deployment where multiple leaves share an account, that means each leaf needs access to `$JSC.R.*`, even if all of its other permissions are scoped to its own streams and consumers.

This adds an opt-in `js_api_reply_v2` feature flag. When enabled, source and mirror setup replies include the remote JetStream resource in the subject:

```text
$JSC.R.<domain>.<account-hash>.<stream>.<consumer>.<uid>
```

That lets a leafnode permission set allow only the replies associated with a specific source or mirror relationship, instead of all `$JSC.R` replies in the account.

The old reply format remains the default:

```text
$JSC.R.<uid>
```

The new format is used for both regular `CONSUMER.CREATE` requests and BYO/durable `CONSUMER.RESET` requests, for sources and mirrors.

Added coverage for:

- Source consumer creation
- Source durable consumer reset
- Mirror consumer creation
- Mirror durable consumer reset

Tests runFixes #8558.

This adds an opt-in reply subject format for JetStream source and mirror setup.

Today, source/mirror consumer setup uses reply subjects like:

```text
$JSC.R.<random id>
```

That means leafnodes sharing an account need permission for `$JSC.R.*` to receive replies for `CONSUMER.CREATE` or durable `CONSUMER.RESET`. In practice, that also lets one otherwise restricted leafnode see replies intended for another.

When `js_api_reply_v2` is enabled, source and mirror setup now uses a reply subject that includes the remote JetStream resource:

```text
$JSC.R.<domain>.<account-hash>.<stream>.<consumer>.<random id>
```

This makes it possible to grant a leafnode access only to replies for the stream and consumer it is allowed to source or mirror.

The old format remains the default, so there is no behavior change unless the feature flag is enabled.

Added coverage for:

- Source consumer create
- Source durable consumer reset
- Mirror consumer create
- Mirror durable consumer reset

Tests run:

```text
go test ./server -run '^(TestJetStreamSourceConsumerUsesScopedAPIReplySubject|TestJetStreamSourceConsumerRetryUsesFreshReplySubject|TestJetStreamLeafNodeAndMirrorResyncAfterConnectionDown|TestJetStreamConsumerResetResponseAcrossServiceImport)$' -count=1

go test ./server -count=1
```