### PR TITLE
(2.15) [IMPROVED] Add backpressure to Raft proposal fast path

### DIFF
--- a/server/raft.go
+++ b/server/raft.go
@@ -275,6 +275,10 @@ type proposedEntry struct {
 	term  uint64 // Raft term in which it was accepted.
 }
 
+func (pe *proposedEntry) size() uint64 {
+	return uint64(len(pe.Data)) + 1
+}
+
 // catchupState structure that holds our subscription, and catchup term and index
 // as well as starting term and index and how many updates we have seen.
 type catchupState struct {
@@ -491,7 +495,7 @@ func (s *Server) initRaftNode(accName string, cfg *RaftConfig, labels pprofLabel
 		quit:     make(chan struct{}),
 		reqs:     newIPQueue[*voteRequest](s, qpfx+"vreq"),
 		votes:    newIPQueue[*voteResponse](s, qpfx+"vresp"),
-		prop:     newIPQueue[*proposedEntry](s, qpfx+"entry"),
+		prop:     newIPQueue[*proposedEntry](s, qpfx+"entry", ipqSizeCalculation((*proposedEntry).size)),
 		entry:    newIPQueue[*appendEntry](s, qpfx+"appendEntry"),
 		resp:     newIPQueue[*appendEntryResponse](s, qpfx+"appendEntryResponse"),
 		apply:    newIPQueue[*CommittedEntry](s, qpfx+"committedEntry"),
@@ -931,13 +935,30 @@ func (s *Server) transferRaftLeaders() bool {
 	return didTransfer
 }
 
+// checkFastPathLimits reports whether the proposal queue exceeds a fixed
+// entry count or byte limit. When the limit is exceeded, the proposal
+// fast path is closed for the given term so proposals fall back to the
+// locking path.
+func (n *raft) checkFastPathLimits(term uint64) bool {
+	const (
+		maxBatches = 8
+		maxBytes   = maxBatches * maxBatchBytes
+		maxEntries = maxBatches * maxBatchEntries
+	)
+	if n.prop.len() > maxEntries || n.prop.size() > maxBytes {
+		n.fastPathTerm.CompareAndSwap(term, 0)
+		return true
+	}
+	return false
+}
+
 // tryFastPathPropose enqueues the given data buffer to the
 // proposal queue, provided that the fast path is open, and that
 // the given term matches the current raft term.
 // Returns true if it was successfully enqueued. False if the
 // caller should fall back to the locking proposal path.
 func (n *raft) tryFastPathPropose(term uint64, data []byte) bool {
-	if term == 0 || term != n.fastPathTerm.Load() || n.State() != Leader {
+	if term == 0 || term != n.fastPathTerm.Load() || n.State() != Leader || n.checkFastPathLimits(term) {
 		return false
 	}
 	n.prop.push(newProposedEntry(newEntry(EntryNormal, data), _EMPTY_, term))
@@ -950,7 +971,7 @@ func (n *raft) tryFastPathPropose(term uint64, data []byte) bool {
 // Returns true if the entries were successfully enqueued. False if the
 // caller should fall back to the locking proposal path.
 func (n *raft) tryFastPathProposeMulti(term uint64, entries []*Entry) bool {
-	if term == 0 || term != n.fastPathTerm.Load() || n.State() != Leader {
+	if term == 0 || term != n.fastPathTerm.Load() || n.State() != Leader || n.checkFastPathLimits(term) {
 		return false
 	}
 	_, err := n.prop.pushMany(func(yield func(*proposedEntry) bool) {
@@ -3429,6 +3450,11 @@ func (n *raft) sendMembershipChange(e *Entry) bool {
 	return true
 }
 
+const (
+	maxBatchBytes   = 256 * 1024
+	maxBatchEntries = 4096 // larger batches showed no benefit
+)
+
 func (n *raft) runAsLeader() {
 	if n.State() == Closed {
 		return
@@ -3482,8 +3508,6 @@ func (n *raft) runAsLeader() {
 			}
 			n.resp.recycle(&ars)
 		case <-n.prop.ch:
-			const maxBatch = 256 * 1024
-			const maxEntries = 4096 // larger batches showed no benefit
 			var entries []*Entry
 
 			es, sz := n.prop.pop(), 0
@@ -3499,7 +3523,7 @@ func (n *raft) runAsLeader() {
 				// Increment size.
 				sz += len(b.Data) + 1
 				// If below thresholds go ahead and send.
-				if sz < maxBatch && len(entries) < maxEntries {
+				if sz < maxBatchBytes && len(entries) < maxBatchEntries {
 					continue
 				}
 				n.sendAppendEntry(entries)
@@ -5140,7 +5164,7 @@ func (n *raft) sendAppendEntryLocked(entries []*Entry, checkLeader bool) error {
 	// more proposals (no errors, not overrun), allow Propose
 	// and ProposeMulti to enqueue proposals for the current
 	// term without acquiring the raft mutex.
-	if checkLeader && n.werr == nil && !n.isLeaderOverrun() {
+	if checkLeader && n.werr == nil && !n.isLeaderOverrun() && !n.checkFastPathLimits(n.term) {
 		n.fastPathTerm.Store(n.term)
 		defer n.fastPathTerm.Store(0)
 	}

--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -504,7 +504,7 @@ func TestNRGProposalFastPath(t *testing.T) {
 	s := &Server{}
 
 	n := &raft{
-		prop: newIPQueue[*proposedEntry](s, "prop"),
+		prop: newIPQueue[*proposedEntry](s, "prop", ipqSizeCalculation((*proposedEntry).size)),
 		term: 1,
 	}
 
@@ -549,6 +549,43 @@ func TestNRGProposalFastPath(t *testing.T) {
 	n.fastPathTerm.Store(0)
 	require_Equal(t, n.fastPathTerm.Load(), uint64(0))
 	require_False(t, n.tryFastPathPropose(1, []byte("closed again")))
+}
+
+func TestNRGProposalFastPathLimits(t *testing.T) {
+	s := &Server{}
+	n := &raft{
+		prop: newIPQueue[*proposedEntry](s, "prop", ipqSizeCalculation((*proposedEntry).size)),
+		term: 1,
+	}
+	n.state.Store(int32(Leader))
+
+	for _, test := range []struct {
+		name          string
+		entries, size int
+	}{
+		{"limit entries", 8*maxBatchEntries + 1, 0},
+		{"limit bytes", 1, 8*maxBatchBytes + 1},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			n.fastPathTerm.Store(n.term)
+			data := make([]byte, test.size)
+			for range test.entries {
+				require_True(t, n.tryFastPathPropose(n.term, data))
+			}
+			// Adding more closes the fast path.
+			require_False(t, n.tryFastPathPropose(n.term, nil))
+			require_Equal(t, n.fastPathTerm.Load(), uint64(0))
+
+			// Reopen the fast path and try with propose multi
+			n.fastPathTerm.Store(n.term)
+			require_False(t, n.tryFastPathProposeMulti(n.term, []*Entry{newEntry(EntryNormal, nil)}))
+			require_Equal(t, n.fastPathTerm.Load(), uint64(0))
+			require_Equal(t, n.prop.len(), test.entries)
+
+			n.prop.drain()
+			require_False(t, n.checkFastPathLimits(n.term))
+		})
+	}
 }
 
 func TestNRGStepDownOnSameTermDoesntClearVote(t *testing.T) {


### PR DESCRIPTION
Make sure that the proposal queue does not grow too much if the proposal fast path remain open for a long time. For instance, if the leader goroutine is busy in appending an entry, and the IO operation is taking unexpectedly long.
When the proposal queue has 8 or more batches worth of entries, the proposal fast path gets closed, forcing proposals to fall back to the locking path.