### PR TITLE
Stream snapshot v2 fixes

### DIFF
--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -3401,6 +3401,55 @@ func TestJetStreamSnapshots(t *testing.T) {
 	}
 }
 
+func TestJetStreamRestoreV2RejectsExistingStream(t *testing.T) {
+	for _, storage := range []StorageType{MemoryStorage, FileStorage} {
+		for _, restoring := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/restoring=%t", storage, restoring), func(t *testing.T) {
+				s := RunBasicJetStreamServer(t)
+				defer s.Shutdown()
+				acc := s.GlobalAccount()
+				cfg := StreamConfig{
+					Name:     "TEST",
+					Subjects: []string{"foo"},
+					Storage:  storage,
+				}
+				var mset *stream
+				var err error
+				if restoring {
+					mset, err = acc.addStreamForRestore(&cfg)
+				} else {
+					mset, err = acc.addStream(&cfg)
+				}
+				require_NoError(t, err)
+				require_NoError(t, mset.store.StoreRawMsg("foo", nil, []byte("original"), 1, time.Now().UnixNano(), 0, false))
+				state := mset.store.State()
+				usage := acc.JetStreamUsage()
+
+				// Exercise the creation check directly: another restore may have
+				// passed its initial existence check before this stream was created.
+				// Matching configurations must not allow it to reuse the stream,
+				// whether the first restore is still running or has already finished.
+				other, err := acc.addStreamForRestore(&cfg)
+				require_True(t, IsNatsErr(err, JSStreamNameExistRestoreFailedErr))
+				require_True(t, other == nil)
+
+				current, err := acc.lookupStream(cfg.Name)
+				require_NoError(t, err)
+				require_True(t, current == mset)
+				require_True(t, reflect.DeepEqual(mset.store.State(), state))
+				require_True(t, reflect.DeepEqual(acc.JetStreamUsage(), usage))
+				msg, err := mset.store.LoadMsg(1, nil)
+				require_NoError(t, err)
+				require_Equal(t, string(msg.msg), "original")
+				mset.mu.RLock()
+				stillRestoring := mset.restoring
+				mset.mu.RUnlock()
+				require_Equal(t, stillRestoring, restoring)
+			})
+		}
+	}
+}
+
 func TestJetStreamSnapshotV2ClampsConsumerStateToStream(t *testing.T) {
 	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()

--- a/server/stream.go
+++ b/server/stream.go
@@ -889,6 +889,11 @@ func (a *Account) addStreamWithAssignmentAndMode(config *StreamConfig, fsConfig 
 	jsa.mu.Lock()
 	if mset, ok := jsa.streams[cfg.Name]; ok {
 		jsa.mu.Unlock()
+		// A restore must create its own stream. Another restore or create may
+		// have claimed the name since the restore's initial existence check.
+		if restoring {
+			return nil, NewJSStreamNameExistRestoreFailedError()
+		}
 		// Check to see if configs are same.
 		ocfg := mset.config()
 

--- a/server/stream_backup.go
+++ b/server/stream_backup.go
@@ -229,6 +229,11 @@ func (js *jetStream) streamSnapshotV2(store StreamStore, state *StreamState, w i
 			errCh <- fmt.Errorf("couldn't load next message after seq %d: %s", seq+1, err)
 			return
 		}
+		// Concurrent deletions and publishes can move the next available
+		// message beyond the snapshot's original sequence range.
+		if seq > state.LastSeq {
+			break
+		}
 		if err = writeStoreMsg(&sm); err != nil {
 			errCh <- err
 			return


### PR DESCRIPTION
This includes a couple minor fixes, including ensuring that we can't overrun the `last_seq` with the next message call, and that we always strongly error when trying to restore over the top of an existing stream.