### PR TITLE
Fix concurrent JetStream consumer create-or-update timeouts

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -1725,10 +1725,6 @@ func (cc *jetStreamCluster) queueInflightConsumerResponse(acc *Account, stream, 
 	if inflight == nil || inflight.deleted || inflight.consumerAssignment == nil || !reflect.DeepEqual(cfg, inflight.Config) {
 		return false
 	}
-	// A request without a reply does not need a response.
-	if reply == _EMPTY_ {
-		return true
-	}
 	rf := inflight.responseForwarder
 	if rf == nil {
 		return false
@@ -1740,6 +1736,23 @@ func (cc *jetStreamCluster) queueInflightConsumerResponse(acc *Account, stream, 
 	}
 	rf.pending = append(rf.pending, pendingConsumerResponse{client: ci, subject: subject, reply: reply, request: request, track: true})
 	return true
+}
+
+// clearInflightConsumerProposals releases response forwarders before clearing
+// their proposals. This prevents their internal client subscriptions from
+// surviving a metadata leader change.
+// (Write) Lock held on entry.
+func (cc *jetStreamCluster) clearInflightConsumerProposals() {
+	for _, streams := range cc.inflightConsumers {
+		for _, consumers := range streams {
+			for _, inflight := range consumers {
+				if inflight.responseForwarder != nil {
+					inflight.responseForwarder.close()
+				}
+			}
+		}
+	}
+	cc.inflightConsumers = nil
 }
 
 func newConsumerResponseForwarder(s *Server, acc *Account, response pendingConsumerResponse) (*consumerResponseForwarder, string, error) {
@@ -9578,7 +9591,7 @@ func (js *jetStream) processLeaderChange(isLeader bool, term uint64) {
 
 	// Clear inflight proposal tracking.
 	js.cluster.inflightStreams = nil
-	js.cluster.inflightConsumers = nil
+	js.cluster.clearInflightConsumerProposals()
 
 	if isLeader {
 		if meta := js.cluster.meta; meta != nil && meta.IsObserver() {

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -116,6 +116,24 @@ type inflightConsumerInfo struct {
 	ops     uint64 // Inflight operations, i.e. inflight consumer creates/updates/deletes.
 	deleted bool   // Whether the consumer has been deleted.
 	*consumerAssignment
+	responseForwarder *consumerResponseForwarder
+}
+
+type pendingConsumerResponse struct {
+	client  *ClientInfo
+	subject string
+	reply   string
+	request string
+	track   bool
+}
+
+// consumerResponseForwarder fans out the response for an in-flight consumer
+// assignment to equivalent requests that did not need another meta proposal.
+type consumerResponseForwarder struct {
+	mu      sync.Mutex
+	client  *client
+	done    bool
+	pending []pendingConsumerResponse
 }
 
 // Used to track inflight peer-remove info to respond 'success' after quorum.
@@ -587,10 +605,11 @@ type consumerAssignment struct {
 	Reply      string          `json:"reply,omitempty"`
 	State      *ConsumerState  `json:"state,omitempty"`
 	// Internal
-	responded   atomic.Bool // copied via clone() to satisfy go vet's noCopy check
-	recovering  bool
-	err         error
-	unsupported *unsupportedConsumerAssignment
+	responded         atomic.Bool // copied via clone() to satisfy go vet's noCopy check
+	recovering        bool
+	err               error
+	unsupported       *unsupportedConsumerAssignment
+	responseForwarder *consumerResponseForwarder
 }
 
 func (ca *consumerAssignment) hasResponded() bool {
@@ -625,19 +644,20 @@ func (ca *consumerAssignment) sameIdentity(nca *consumerAssignment) bool {
 // responded via markResponded/clearResponded without holding js.mu.
 func (ca *consumerAssignment) clone() *consumerAssignment {
 	cca := &consumerAssignment{
-		Client:      ca.Client,
-		Created:     ca.Created,
-		Name:        ca.Name,
-		Stream:      ca.Stream,
-		ConfigJSON:  ca.ConfigJSON,
-		Config:      ca.Config,
-		Group:       ca.Group,
-		Subject:     ca.Subject,
-		Reply:       ca.Reply,
-		State:       ca.State,
-		recovering:  ca.recovering,
-		err:         ca.err,
-		unsupported: ca.unsupported,
+		Client:            ca.Client,
+		Created:           ca.Created,
+		Name:              ca.Name,
+		Stream:            ca.Stream,
+		ConfigJSON:        ca.ConfigJSON,
+		Config:            ca.Config,
+		Group:             ca.Group,
+		Subject:           ca.Subject,
+		Reply:             ca.Reply,
+		State:             ca.State,
+		recovering:        ca.recovering,
+		err:               ca.err,
+		unsupported:       ca.unsupported,
+		responseForwarder: ca.responseForwarder,
 	}
 	cca.responded.Store(ca.responded.Load())
 	return cca
@@ -1682,8 +1702,119 @@ func (cc *jetStreamCluster) trackInflightConsumerProposal(accName, streamName st
 		inflight.ops++
 		inflight.deleted = deleted
 		inflight.consumerAssignment = ca
+		inflight.responseForwarder = ca.responseForwarder
 	} else {
-		consumers[ca.Name] = &inflightConsumerInfo{1, deleted, ca}
+		consumers[ca.Name] = &inflightConsumerInfo{ops: 1, deleted: deleted, consumerAssignment: ca, responseForwarder: ca.responseForwarder}
+	}
+}
+
+// queueInflightConsumerResponse avoids proposing an equivalent consumer
+// assignment while one is already in flight. The first assignment's response
+// is observed and forwarded to the duplicate request.
+// (Write) Lock held on entry.
+func (cc *jetStreamCluster) queueInflightConsumerResponse(acc *Account, stream, consumer string, cfg *ConsumerConfig, ci *ClientInfo, subject, reply, request string) bool {
+	streams := cc.inflightConsumers[acc.Name]
+	if streams == nil {
+		return false
+	}
+	consumers := streams[stream]
+	if consumers == nil {
+		return false
+	}
+	inflight := consumers[consumer]
+	if inflight == nil || inflight.deleted || inflight.consumerAssignment == nil || !reflect.DeepEqual(cfg, inflight.Config) {
+		return false
+	}
+	// A request without a reply does not need a response.
+	if reply == _EMPTY_ {
+		return true
+	}
+	rf := inflight.responseForwarder
+	if rf == nil {
+		return false
+	}
+	rf.mu.Lock()
+	defer rf.mu.Unlock()
+	if rf.done {
+		return false
+	}
+	rf.pending = append(rf.pending, pendingConsumerResponse{client: ci, subject: subject, reply: reply, request: request, track: true})
+	return true
+}
+
+func newConsumerResponseForwarder(s *Server, acc *Account, response pendingConsumerResponse) (*consumerResponseForwarder, string, error) {
+	rf := &consumerResponseForwarder{pending: []pendingConsumerResponse{response}}
+	reply := syncSubject("$JSC.R.CC")
+	ic := s.createInternalJetStreamClient()
+	sysAcc := s.SystemAccount()
+	if sysAcc == nil {
+		ic.closeConnection(ClientClosed)
+		return nil, _EMPTY_, ErrNoSysAccount
+	}
+	if err := ic.registerWithAccount(sysAcc); err != nil {
+		ic.closeConnection(ClientClosed)
+		return nil, _EMPTY_, err
+	}
+	_, err := ic.processSub([]byte(reply), nil, []byte("1"), func(_ *subscription, c *client, _ *Account, _, _ string, rmsg []byte) {
+		hdr, msg := c.msgParts(copyBytes(rmsg))
+		rf.forward(s, acc, hdr, msg)
+	}, false)
+	if err != nil {
+		ic.closeConnection(ClientClosed)
+		return nil, _EMPTY_, err
+	}
+	rf.client = ic
+	return rf, reply, nil
+}
+
+func (rf *consumerResponseForwarder) forward(s *Server, acc *Account, hdr, msg []byte) {
+	rf.mu.Lock()
+	if rf.done {
+		rf.mu.Unlock()
+		return
+	}
+	rf.done = true
+	pending, ic := rf.pending, rf.client
+	rf.pending, rf.client = nil, nil
+	rf.mu.Unlock()
+	if ic != nil {
+		ic.closeConnection(ClientClosed)
+	}
+	var apiResp JSApiConsumerCreateResponse
+	isErr := json.Unmarshal(msg, &apiResp) == nil && apiResp.Error != nil
+	for _, response := range pending {
+		if !response.track {
+			if len(hdr) > 0 {
+				s.sendInternalAccountMsgWithReply(nil, response.reply, _EMPTY_, hdr, msg, false)
+			} else {
+				s.sendInternalAccountMsg(nil, response.reply, msg)
+			}
+			continue
+		}
+		if isErr {
+			s.sendAPIErrResponse(response.client, acc, response.subject, response.reply, response.request, string(msg))
+			continue
+		}
+		if len(hdr) > 0 {
+			s.sendAPIHdrResponse(response.client, acc, response.subject, response.reply, response.request, hdr, string(msg))
+		} else {
+			s.sendAPIResponse(response.client, acc, response.subject, response.reply, response.request, string(msg))
+		}
+	}
+}
+
+func (rf *consumerResponseForwarder) close() {
+	rf.mu.Lock()
+	if rf.done {
+		rf.mu.Unlock()
+		return
+	}
+	rf.done = true
+	ic := rf.client
+	rf.pending, rf.client = nil, nil
+	rf.mu.Unlock()
+	if ic != nil {
+		ic.closeConnection(ClientClosed)
 	}
 }
 
@@ -11812,6 +11943,13 @@ func (s *Server) jsClusteredConsumerRequest(ci *ClientInfo, acc *Account, subjec
 		setStaticConsumerMetadata(cfg)
 	}
 
+	// Equivalent requests for an assignment that has already been proposed do
+	// not need their own meta proposal. Observe the authoritative response to
+	// the first request and fan it out to the duplicate callers instead.
+	if action == ActionCreateOrUpdate && ca != nil && cc.queueInflightConsumerResponse(acc, stream, oname, cfg, ci, subject, reply, string(msg)) {
+		return
+	}
+
 	// If this is new consumer.
 	if ca == nil {
 		if action == ActionUpdate {
@@ -11973,8 +12111,23 @@ func (s *Server) jsClusteredConsumerRequest(ci *ClientInfo, acc *Account, subjec
 		ca = nca
 	}
 
+	// Route the authoritative assignment response through a local forwarder.
+	// Equivalent requests can then share this proposal and response without
+	// changing the replicated consumer-assignment format.
+	ca.responseForwarder = nil
+	if action == ActionCreateOrUpdate && ca.Reply != _EMPTY_ {
+		response := pendingConsumerResponse{client: ca.Client, subject: ca.Subject, reply: ca.Reply, request: string(msg)}
+		if rf, forwardReply, err := newConsumerResponseForwarder(s, acc, response); err == nil {
+			ca.responseForwarder = rf
+			ca.Reply = forwardReply
+		}
+	}
+
 	// Do formal proposal.
 	if err := cc.meta.Propose(cc.term, encodeAddConsumerAssignment(ca)); err != nil {
+		if ca.responseForwarder != nil {
+			ca.responseForwarder.close()
+		}
 		return
 	}
 	cc.trackInflightConsumerProposal(acc.Name, stream, ca, false)

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -8041,6 +8041,120 @@ func TestJetStreamClusterConcurrentConsumerCreateWithMaxConsumers(t *testing.T) 
 	})
 }
 
+func TestJetStreamClusterCoalesceEquivalentInflightConsumerRequests(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	ml := c.leader()
+	nc, js := jsClientConnect(t, ml)
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Replicas: 3,
+	})
+	require_NoError(t, err)
+
+	// Prevent the first consumer assignment from committing so every request
+	// deterministically encounters the same in-flight assignment.
+	for _, s := range c.servers {
+		if s != ml {
+			s.Shutdown()
+		}
+	}
+
+	req, err := json.Marshal(CreateConsumerRequest{
+		Stream: "TEST",
+		Config: ConsumerConfig{Name: "C", AckPolicy: AckExplicit, Replicas: 1},
+		Action: ActionCreateOrUpdate,
+	})
+	require_NoError(t, err)
+	subject := fmt.Sprintf(JSApiConsumerCreateT, "TEST") + ".C"
+	const duplicates = 100
+	require_NoError(t, nc.PublishRequest(subject, "reply.first", req))
+	require_NoError(t, nc.Flush())
+
+	sjs, cc := ml.getJetStreamCluster()
+	checkFor(t, 2*time.Second, 10*time.Millisecond, func() error {
+		sjs.mu.RLock()
+		defer sjs.mu.RUnlock()
+		if streams := cc.inflightConsumers[globalAccountName]; streams != nil {
+			if consumers := streams["TEST"]; consumers != nil && consumers["C"] != nil {
+				return nil
+			}
+		}
+		return errors.New("consumer assignment is not in flight")
+	})
+
+	for i := range duplicates {
+		require_NoError(t, nc.PublishRequest(subject, fmt.Sprintf("reply.%d", i), req))
+	}
+	require_NoError(t, nc.Flush())
+
+	checkFor(t, 2*time.Second, 10*time.Millisecond, func() error {
+		sjs.mu.RLock()
+		defer sjs.mu.RUnlock()
+		inflight := cc.inflightConsumers[globalAccountName]["TEST"]["C"]
+		if inflight == nil {
+			return errors.New("consumer assignment is not in flight")
+		}
+		if inflight.ops != 1 {
+			return fmt.Errorf("expected one meta proposal, got %d", inflight.ops)
+		}
+		if inflight.responseForwarder == nil {
+			return errors.New("response forwarder was not created")
+		}
+		inflight.responseForwarder.mu.Lock()
+		pending := len(inflight.responseForwarder.pending)
+		inflight.responseForwarder.mu.Unlock()
+		if pending != duplicates+1 {
+			return fmt.Errorf("expected %d pending responses, got %d", duplicates+1, pending)
+		}
+		return nil
+	})
+}
+
+func TestJetStreamClusterEquivalentInflightConsumerResponses(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+	_, err := js.AddStream(&nats.StreamConfig{Name: "TEST", Subjects: []string{"foo"}, Replicas: 3})
+	require_NoError(t, err)
+
+	req, err := json.Marshal(CreateConsumerRequest{
+		Stream: "TEST",
+		Config: ConsumerConfig{Name: "C", AckPolicy: AckExplicit, Replicas: 3},
+		Action: ActionCreateOrUpdate,
+	})
+	require_NoError(t, err)
+	subject := fmt.Sprintf(JSApiConsumerCreateT, "TEST") + ".C"
+
+	const requests = 100
+	subs := make([]*nats.Subscription, 0, requests)
+	for range requests {
+		reply := nats.NewInbox()
+		sub, err := nc.SubscribeSync(reply)
+		require_NoError(t, err)
+		subs = append(subs, sub)
+		require_NoError(t, nc.PublishRequest(subject, reply, req))
+	}
+	require_NoError(t, nc.Flush())
+
+	for i, sub := range subs {
+		msg, err := sub.NextMsg(5 * time.Second)
+		if err != nil {
+			t.Fatalf("request %d did not receive a response: %v", i, err)
+		}
+		var resp JSApiConsumerCreateResponse
+		require_NoError(t, json.Unmarshal(msg.Data, &resp))
+		require_True(t, resp.Error == nil)
+		require_NotNil(t, resp.ConsumerInfo)
+	}
+}
+
 func TestJetStreamClusterLostConsumerAfterInflightConsumerUpdate(t *testing.T) {
 	c := createJetStreamClusterExplicit(t, "R3S", 3)
 	defer c.shutdown()

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -8087,7 +8087,10 @@ func TestJetStreamClusterCoalesceEquivalentInflightConsumerRequests(t *testing.T
 		return errors.New("consumer assignment is not in flight")
 	})
 
-	for i := range duplicates {
+	// A duplicate without a reply still needs to be retained by the forwarder
+	// so it receives the same API accounting and audit advisory as a proposal.
+	require_NoError(t, nc.Publish(subject, req))
+	for i := 1; i < duplicates; i++ {
 		require_NoError(t, nc.PublishRequest(subject, fmt.Sprintf("reply.%d", i), req))
 	}
 	require_NoError(t, nc.Flush())
@@ -8107,12 +8110,46 @@ func TestJetStreamClusterCoalesceEquivalentInflightConsumerRequests(t *testing.T
 		}
 		inflight.responseForwarder.mu.Lock()
 		pending := len(inflight.responseForwarder.pending)
+		noReply := false
+		for _, response := range inflight.responseForwarder.pending {
+			if response.reply == _EMPTY_ {
+				noReply = response.track
+			}
+		}
 		inflight.responseForwarder.mu.Unlock()
 		if pending != duplicates+1 {
 			return fmt.Errorf("expected %d pending responses, got %d", duplicates+1, pending)
 		}
+		if !noReply {
+			return errors.New("no-reply request was not retained for API accounting")
+		}
 		return nil
 	})
+}
+
+func TestJetStreamClusterClearInflightConsumerProposalsClosesForwarders(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	sjs, cc := c.leader().getJetStreamCluster()
+	rf := &consumerResponseForwarder{pending: []pendingConsumerResponse{{reply: "reply"}}}
+	sjs.mu.Lock()
+	cc.inflightConsumers = map[string]map[string]map[string]*inflightConsumerInfo{
+		globalAccountName: {
+			"TEST": {
+				"C": {responseForwarder: rf},
+			},
+		},
+	}
+	cc.clearInflightConsumerProposals()
+	sjs.mu.Unlock()
+
+	rf.mu.Lock()
+	done, pending := rf.done, len(rf.pending)
+	rf.mu.Unlock()
+	require_True(t, done)
+	require_Equal(t, pending, 0)
+	require_True(t, cc.inflightConsumers == nil)
 }
 
 func TestJetStreamClusterEquivalentInflightConsumerResponses(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #8350.

Concurrent equivalent `CreateOrUpdateConsumer` requests could each generate a separate JetStream metadata Raft proposal. Under high concurrency and multi-node latency, the redundant proposals could delay responses beyond the client’s default five-second timeout.

This change coalesces equivalent create-or-update requests while the first consumer assignment is still in flight. The authoritative response from the original request is forwarded to every waiting caller.

## Changes

- Coalesce equivalent in-flight `CreateOrUpdateConsumer` requests.
- Generate a single metadata proposal for identical concurrent requests.
- Forward the original response, including errors and headers, to all callers.
- Preserve API metrics and audit accounting.
- Keep the replicated consumer-assignment format unchanged.
- Add regression tests covering proposal coalescing and response fan-out.

## Testing

```text
go test ./server -run 'TestJetStreamCluster(ConcurrentConsumerCreateWithMaxConsumers|CoalesceEquivalentInflightConsumerRequests|EquivalentInflightConsumerResponses|LostConsumerAfterInflightConsumerUpdate)' -count=3
```

All tests pass.

The response fan-out test was also run independently ten times successfully.