### PR TITLE
[FIXED] Drop stale TTL entries from the THW when the message is already gone

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -7356,7 +7356,14 @@ func (fs *fileStore) expireMsgs() {
 	// Remove messages collected by THW.
 	if !sdmEnabled {
 		for _, rm := range rmSeqs {
-			fs.removeMsg(rm.Seq, false, false, false)
+			removed, err := fs.removeMsg(rm.Seq, false, false, false)
+			// The message may already be gone, removed out of band by a purge, a rollup
+			// or a compact, none of which consult the THW. Drop the entry in that case,
+			// otherwise it is collected again on every pass forever. A genuine removal
+			// failure (write error, closed store) keeps the entry so it is retried.
+			if !removed && (err == nil || err == ErrStoreMsgNotFound) {
+				fs.ttls.Remove(rm.Seq, rm.Expires)
+			}
 		}
 	} else {
 		// THW is unordered, so must sort by sequence and must not be holding the lock.

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -7357,12 +7357,15 @@ func (fs *fileStore) expireMsgs() {
 	if !sdmEnabled {
 		for _, rm := range rmSeqs {
 			removed, err := fs.removeMsg(rm.Seq, false, false, false)
-			// The message may already be gone, removed out of band by a purge, a rollup
-			// or a compact, none of which consult the THW. Drop the entry in that case,
-			// otherwise it is collected again on every pass forever. A genuine removal
-			// failure (write error, closed store) keeps the entry so it is retried.
-			if !removed && (err == nil || err == ErrStoreMsgNotFound) {
+			// The message may already be gone, removed out of band by a purge, a rollup,
+			// a compact or a truncate, none of which consult the THW. Drop the entry in
+			// that case, otherwise it is collected again on every pass forever. A genuine
+			// removal failure (write error, closed store) keeps the entry so it is retried.
+			if !removed && (err == nil || err == ErrStoreMsgNotFound || err == ErrStoreEOF) {
 				fs.ttls.Remove(rm.Seq, rm.Expires)
+				// The removal that orphaned the entry may already have been flushed, so
+				// mark the state dirty or the pruned wheel never reaches thw.db.
+				fs.dirty++
 			}
 		}
 	} else {
@@ -7386,6 +7389,7 @@ func (fs *fileStore) expireMsgs() {
 			sm, _ = fs.msgForSeqLocked(rm.Seq, &smv, false)
 			if sm == nil {
 				fs.ttls.Remove(rm.Seq, rm.Expires)
+				fs.dirty++
 				fs.mu.Unlock()
 				continue
 			}

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -9448,6 +9448,42 @@ func TestFileStoreMessageTTL(t *testing.T) {
 	require_Equal(t, ss.Msgs, 0)
 }
 
+func TestFileStoreMessageTTLRemovedOutOfBandDoesNotLeakTHW(t *testing.T) {
+	fs, err := newFileStore(
+		FileStoreConfig{StoreDir: t.TempDir()},
+		StreamConfig{Name: "zzz", Subjects: []string{"test.>"}, Storage: FileStorage, AllowMsgTTL: true, AllowRollup: true})
+	require_NoError(t, err)
+	defer fs.Stop()
+
+	ttl := int64(1) // 1 second
+
+	for i := 1; i <= 10; i++ {
+		_, _, err = fs.StoreMsg("test.a", nil, nil, ttl)
+		require_NoError(t, err)
+	}
+
+	fs.mu.RLock()
+	count := fs.ttls.Count()
+	fs.mu.RUnlock()
+	require_Equal(t, count, 10)
+
+	// Remove the messages out of band, the way a rollup or a subject purge does.
+	// This path does not consult the THW, so the entries stay behind.
+	purged, err := fs.PurgeEx("test.a", 0, 0)
+	require_NoError(t, err)
+	require_Equal(t, purged, 10)
+
+	// Once the TTLs are due, the expiry pass must notice the messages are already
+	// gone and drop the entries, instead of retrying them on every pass forever.
+	time.Sleep(time.Second * 2)
+	fs.expireMsgs()
+
+	fs.mu.RLock()
+	count = fs.ttls.Count()
+	fs.mu.RUnlock()
+	require_Equal(t, count, 0)
+}
+
 func TestFileStoreMessageTTLRestart(t *testing.T) {
 	dir := t.TempDir()
 

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -9484,6 +9484,78 @@ func TestFileStoreMessageTTLRemovedOutOfBandDoesNotLeakTHW(t *testing.T) {
 	require_Equal(t, count, 0)
 }
 
+func TestFileStoreMessageTTLTruncatedBelowDoesNotLeakTHW(t *testing.T) {
+	fs, err := newFileStore(
+		FileStoreConfig{StoreDir: t.TempDir()},
+		StreamConfig{Name: "zzz", Subjects: []string{"test.>"}, Storage: FileStorage, AllowMsgTTL: true})
+	require_NoError(t, err)
+	defer fs.Stop()
+
+	ttl := int64(1) // 1 second
+
+	for i := 1; i <= 10; i++ {
+		_, _, err = fs.StoreMsg("test.a", nil, nil, ttl)
+		require_NoError(t, err)
+	}
+
+	// Truncate below the last TTL message. LastSeq drops to 5 and the entries for
+	// 6..10 now point past the end of the stream, so removeMsg reports ErrStoreEOF.
+	require_NoError(t, fs.Truncate(5))
+
+	var ss StreamState
+	fs.FastState(&ss)
+	require_Equal(t, ss.LastSeq, 5)
+
+	time.Sleep(time.Second * 2)
+	fs.expireMsgs()
+
+	fs.mu.RLock()
+	count := fs.ttls.Count()
+	fs.mu.RUnlock()
+	require_Equal(t, count, 0)
+}
+
+func TestFileStoreMessageTTLRemovedOutOfBandPrunedTHWIsPersisted(t *testing.T) {
+	dir := t.TempDir()
+	cfg := StreamConfig{Name: "zzz", Subjects: []string{"test.>"}, Storage: FileStorage, AllowMsgTTL: true, AllowRollup: true}
+
+	fs, err := newFileStore(FileStoreConfig{StoreDir: dir}, cfg)
+	require_NoError(t, err)
+
+	ttl := int64(1) // 1 second
+
+	for i := 1; i <= 10; i++ {
+		_, _, err = fs.StoreMsg("test.a", nil, nil, ttl)
+		require_NoError(t, err)
+	}
+
+	// Remove out of band and flush, so thw.db on disk still carries the ten entries
+	// and nothing after this point dirties the state except the pruning itself.
+	purged, err := fs.PurgeEx("test.a", 0, 0)
+	require_NoError(t, err)
+	require_Equal(t, purged, 10)
+	require_NoError(t, fs.forceWriteFullState())
+
+	time.Sleep(time.Second * 2)
+	fs.expireMsgs()
+
+	fs.mu.RLock()
+	count := fs.ttls.Count()
+	fs.mu.RUnlock()
+	require_Equal(t, count, 0)
+
+	// A restart must not bring the stale entries back from thw.db.
+	fs.Stop()
+	fs, err = newFileStore(FileStoreConfig{StoreDir: dir}, cfg)
+	require_NoError(t, err)
+	defer fs.Stop()
+
+	fs.mu.RLock()
+	count = fs.ttls.Count()
+	fs.mu.RUnlock()
+	require_Equal(t, count, 0)
+}
+
 func TestFileStoreMessageTTLRestart(t *testing.T) {
 	dir := t.TempDir()
 

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -1439,7 +1439,12 @@ func (ms *memStore) expireMsgs() {
 	// Remove messages collected by THW.
 	if !sdmEnabled {
 		for _, rm := range rmSeqs {
-			ms.removeMsg(rm.Seq, false)
+			// The message may already be gone, removed out of band by a path that
+			// does not consult the THW. Drop the entry in that case, otherwise it is
+			// collected again on every pass forever.
+			if !ms.removeMsg(rm.Seq, false) {
+				ms.ttls.Remove(rm.Seq, rm.Expires)
+			}
 		}
 	} else {
 		// THW is unordered, so must sort by sequence and must not be holding the lock.

--- a/server/memstore_test.go
+++ b/server/memstore_test.go
@@ -1297,6 +1297,39 @@ func TestMemStoreAllLastSeqs(t *testing.T) {
 	require_True(t, reflect.DeepEqual(seqs, expected))
 }
 
+func TestMemStoreMessageTTLRemovedOutOfBandDoesNotLeakTHW(t *testing.T) {
+	ms, err := newMemStore(&StreamConfig{Name: "zzz", Subjects: []string{"test.>"}, Storage: MemoryStorage, AllowMsgTTL: true, AllowRollup: true})
+	require_NoError(t, err)
+	defer ms.Stop()
+
+	ttl := int64(1) // 1 second
+
+	for i := 1; i <= 10; i++ {
+		_, _, err = ms.StoreMsg("test.a", nil, nil, ttl)
+		require_NoError(t, err)
+	}
+
+	ms.mu.RLock()
+	count := ms.ttls.Count()
+	ms.mu.RUnlock()
+	require_Equal(t, count, 10)
+
+	// Remove the messages out of band, the way a rollup or a subject purge does.
+	purged, err := ms.PurgeEx("test.a", 0, 0)
+	require_NoError(t, err)
+	require_Equal(t, purged, 10)
+
+	// Once the TTLs are due, the expiry pass must drop the entries for messages
+	// that are already gone instead of retrying them on every pass forever.
+	time.Sleep(time.Second * 2)
+	ms.expireMsgs()
+
+	ms.mu.RLock()
+	count = ms.ttls.Count()
+	ms.mu.RUnlock()
+	require_Equal(t, count, 0)
+}
+
 func TestMemStoreUpdateConfigTTLState(t *testing.T) {
 	cfg := &StreamConfig{
 		Name:     "zzz",


### PR DESCRIPTION
A message with a per-message TTL that is removed before the TTL fires (subject purge, rollup) leaves its entry in the timed hash wheel. When the TTL comes due, `expireMsgs` finds the message already gone and leaves the entry in place, so it is collected again on every pass, persisted in `thw.db`, and recovered on restart. With every such entry in the past the expiry timer re-arms at its 250ms floor and each pass walks the whole wheel. Details and production numbers in #8594.

- `fileStore.expireMsgs` / `memStore.expireMsgs`: drop the entry when `removeMsg` reports the message is already gone, mirroring the subject-delete-marker branch. A genuine removal failure still keeps the entry so it is retried.
- Regression tests for both stores: store TTL messages, `PurgeEx` them by subject, run the expiry pass, assert the wheel is empty. Both fail on `main` without the change.
- Servers already carrying stale entries heal on the first expiry pass after upgrade.

Resolves #8594

Signed-off-by: Lubomír Cvrk <digitalstraw@gmail.com>